### PR TITLE
Include hex-encoded operands in the debug logging of opcodes.

### DIFF
--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -67,7 +67,10 @@ BlockchainDouble.prototype.initialize = function(accounts, callback) {
 
       if (options.debug == true) {
         self.vm.on('step', function(info){
-          self.logger.log(info.opcode.name)
+          var name = info.opcode.name;
+          var argsNum = info.opcode.in;
+          var args = argsNum ? info.stack.slice(-argsNum) : []
+          self.logger.log('' + name + ' ' + args.map((x) => x.toString("hex")).join(' '));
         });
       }
 


### PR DESCRIPTION
This allows deeper diagnosis of low-level EVM issues when using testrpc by displaying the operands for each opcode in debug mode.

How is `ganache-core` tested, and how can I add test coverage for my changes? Also, does this follow any coding conventions for this project?