### PR TITLE
Mine a block exactly at the given timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ There’s also special non-standard methods that aren’t included within the or
 * `evm_revert` : Revert the state of the blockchain to a previous snapshot. Takes a single parameter, which is the snapshot id to revert to. If no snapshot id is passed it will revert to the latest snapshot. Returns `true`.
 * `evm_increaseTime` : Jump forward in time. Takes one parameter, which is the amount of time to increase in seconds. Returns the total time adjustment, in seconds.
 * `evm_mine` : Force a block to be mined. Takes no parameters. Mines a block independent of whether or not mining is started or stopped.
+* `evm_mineAtTimestamp` : Force a block to be mined exactly at the given timestamp. Takes one parameter which is the expected timestamp of a new block in seconds.
 
 # Unsupported Methods
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ There’s also special non-standard methods that aren’t included within the or
 * `evm_snapshot` : Snapshot the state of the blockchain at the current block. Takes no parameters. Returns the integer id of the snapshot created.
 * `evm_revert` : Revert the state of the blockchain to a previous snapshot. Takes a single parameter, which is the snapshot id to revert to. If no snapshot id is passed it will revert to the latest snapshot. Returns `true`.
 * `evm_increaseTime` : Jump forward in time. Takes one parameter, which is the amount of time to increase in seconds. Returns the total time adjustment, in seconds.
-* `evm_mine` : Force a block to be mined. Takes no parameters. Mines a block independent of whether or not mining is started or stopped.
-* `evm_mineAtTimestamp` : Force a block to be mined exactly at the given timestamp. Takes one parameter which is the expected timestamp of a new block in seconds.
+* `evm_mine` : Force a block to be mined. Takes one optional parameter, which is the timestamp a block should setup as the mining time. Mines a block independent of whether or not mining is started or stopped.
 
 # Unsupported Methods
 

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -506,9 +506,10 @@ BlockchainDouble.prototype.processBlock = function(block, commit, callback) {
  * pending transactions.
  *
  * @param  {Function} callback Callback when transaction processing is finished.
+ * @param  {number} timestamp at which the block is mined
  * @return [type]              [description]
  */
-BlockchainDouble.prototype.processNextBlock = function(callback) {
+BlockchainDouble.prototype.processNextBlock = function(callback, timestamp) {
   var self = this;
 
   self.sortByPriceAndNonce();
@@ -546,6 +547,11 @@ BlockchainDouble.prototype.processNextBlock = function(callback) {
   this.createBlock(function(err, block) {
     if (err) return callback(err);
 
+    //Overwrite block timestamp
+    if (timestamp) {
+        block.header.timestamp = to.hex(timestamp);
+        self.setTime(new Date(timestamp * 1000));
+    }
     // Add transactions to the block.
     Array.prototype.push.apply(block.transactions, currentTransactions);
 

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -505,12 +505,17 @@ BlockchainDouble.prototype.processBlock = function(block, commit, callback) {
  * Process the next block like a normal blockchain, pulling from the list of
  * pending transactions.
  *
- * @param  {Function} callback Callback when transaction processing is finished.
  * @param  {number} timestamp at which the block is mined
+ * @param  {Function} callback Callback when transaction processing is finished.
  * @return [type]              [description]
  */
 BlockchainDouble.prototype.processNextBlock = function(timestamp, callback) {
   var self = this;
+
+  if (typeof timestamp === 'function') {
+    callback = timestamp;
+    timestamp = undefined;
+  }
 
   self.sortByPriceAndNonce();
 

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -509,7 +509,7 @@ BlockchainDouble.prototype.processBlock = function(block, commit, callback) {
  * @param  {number} timestamp at which the block is mined
  * @return [type]              [description]
  */
-BlockchainDouble.prototype.processNextBlock = function(callback, timestamp) {
+BlockchainDouble.prototype.processNextBlock = function(timestamp, callback) {
   var self = this;
 
   self.sortByPriceAndNonce();
@@ -550,7 +550,7 @@ BlockchainDouble.prototype.processNextBlock = function(callback, timestamp) {
     //Overwrite block timestamp
     if (timestamp) {
       self.data.blocks.last(function(err, last) {
-				if (last  && to.number(last.header.timestamp) > timestamp) {
+				if (last && to.number(last.header.timestamp) > timestamp) {
 					self.logger.log("Waring: Setting the block timestamp (" + timestamp + ") that is earlier than the parent block one.");
 				}
 			});

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -549,8 +549,13 @@ BlockchainDouble.prototype.processNextBlock = function(callback, timestamp) {
 
     //Overwrite block timestamp
     if (timestamp) {
-        block.header.timestamp = to.hex(timestamp);
-        self.setTime(new Date(timestamp * 1000));
+      self.data.blocks.last(function(err, last) {
+				if (last  && to.number(last.header.timestamp) > timestamp) {
+					self.logger.log("Waring: Setting the block timestamp (" + timestamp + ") that is earlier than the parent block one.");
+				}
+			});
+      block.header.timestamp = to.hex(timestamp);
+      self.setTime(new Date(timestamp * 1000));
     }
     // Add transactions to the block.
     Array.prototype.push.apply(block.transactions, currentTransactions);

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -429,6 +429,10 @@ GethApiDouble.prototype.evm_mine = function(callback) {
   this.state.blockchain.processNextBlock(callback);
 };
 
+GethApiDouble.prototype.evm_mineAtTimestamp = function(timestamp, callback) {
+    this.state.blockchain.processNextBlock(callback, timestamp);
+};
+
 GethApiDouble.prototype.debug_traceTransaction = function(tx_hash, params, callback) {
   if (typeof params == "function") {
     callback = params;

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -425,12 +425,12 @@ GethApiDouble.prototype.evm_increaseTime = function(seconds, callback) {
   callback(null, this.state.blockchain.increaseTime(seconds));
 };
 
-GethApiDouble.prototype.evm_mine = function(callback) {
-  this.state.blockchain.processNextBlock(callback);
-};
-
-GethApiDouble.prototype.evm_mineAtTimestamp = function(timestamp, callback) {
-    this.state.blockchain.processNextBlock(callback, timestamp);
+GethApiDouble.prototype.evm_mine = function(timestamp, callback) {
+  if (typeof timestamp == "function") {
+		callback = timestamp;
+		timestamp = NaN;
+  }
+  this.state.blockchain.processNextBlock(timestamp, callback);
 };
 
 GethApiDouble.prototype.debug_traceTransaction = function(tx_hash, params, callback) {

--- a/test/time_adjust.js
+++ b/test/time_adjust.js
@@ -68,7 +68,7 @@ describe('Time adjustment', function() {
   it('should mine a block at the given timestamp', function(done) {
       // Adjust time
       var expectedMinedTimestamp = 1000000;
-      send("evm_mineAtTimestamp", [expectedMinedTimestamp], function(err, result) {
+      send("evm_mine", [expectedMinedTimestamp], function(err, result) {
           if (err) return done(err);
 
           web3.eth.getBlock('latest', function(err, block){

--- a/test/time_adjust.js
+++ b/test/time_adjust.js
@@ -64,4 +64,21 @@ describe('Time adjustment', function() {
       })
     })
   })
+
+  it('should mine a block at the given timestamp', function(done) {
+      // Adjust time
+      var expectedMinedTimestamp = 1000000;
+      send("evm_mineAtTimestamp", [expectedMinedTimestamp], function(err, result) {
+          if (err) return done(err);
+
+          web3.eth.getBlock('latest', function(err, block){
+              if(err) return done(err)
+              assert(block.timestamp == expectedMinedTimestamp)
+              done()
+          })
+      })
+  })
+
+
+
 })


### PR DESCRIPTION
Following a problem with testing time-checking condition we experienced at [OpenZeppelin](https://github.com/OpenZeppelin/zeppelin-solidity/pull/353),
I'm posting a solution that should make blockchain time checking robust and consistent through tests. 

Currently, setting the blockchain internal time requires first precomputing time period (and rounding) that should be added to it's current clock and then calling two api functions: `evm_increaseTime` and `evm_mine`. This may cause an additional delay during execution which may risk in having a flaky and indeterministic tests or using weaker assertions (like `>=` instead of `==`). 

I'm proposing setting the blockchain time in a single api call `evm_mineAtTimestamp` that contains the expected final `block.timestamp` as a parameter. This should eliminate the errors caused by precomputing time difference with rounding and the delays caused by calling two separate api functions. 
