### PR TITLE
fix estimateGas bug when basefee > defaultTransactionGasLimit

### DIFF
--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -277,12 +277,13 @@ GethApiDouble.prototype.eth_call = function(tx_data, block_number, callback) {
 };
 
 GethApiDouble.prototype.eth_estimateGas = function(tx_data, block_number, callback) {
+  tx_data.gas = this.state.blockchain.blockGasLimit;
   this.state.queueTransaction("eth_estimateGas", tx_data, callback);
 };
 
 GethApiDouble.prototype.eth_getStorageAt = function(address, position, block_number, callback) {
   this.state.queueStorage(address, position, block_number, callback);
-}
+};
 
 GethApiDouble.prototype.eth_newBlockFilter = function(callback) {
   var filter_id = utils.addHexPrefix(utils.intToHex(this.state.latest_filter_id));

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -277,7 +277,9 @@ GethApiDouble.prototype.eth_call = function(tx_data, block_number, callback) {
 };
 
 GethApiDouble.prototype.eth_estimateGas = function(tx_data, block_number, callback) {
-  tx_data.gas = this.state.blockchain.blockGasLimit;
+  if (!tx_data.gas) {
+    tx_data.gas = this.state.blockchain.blockGasLimit;
+  }
   this.state.queueTransaction("eth_estimateGas", tx_data, callback);
 };
 

--- a/test/gas.js
+++ b/test/gas.js
@@ -43,6 +43,19 @@ describe("Gas Estimation", function() {
     });
   });
 
+  function verifyGas(txHash, gasEstimate, done) {
+    // Get the gas usage.
+    web3.eth.getTransactionReceipt(txHash, function(err, receipt) {
+      if (err) return done(err);
+
+      // When instamining, gasUsed and cumulativeGasUsed should be the same.
+      assert.equal(receipt.gasUsed, gasEstimate);
+      assert.equal(receipt.cumulativeGasUsed, gasEstimate);
+
+      done();
+    });
+  }
+
   function testTransactionEstimate(contractFn, args, done) {
     var estimate = contractFn.estimateGas.bind.apply(contractFn.estimateGas, [contractFn].concat(args));
     var transaction = contractFn.bind.apply(contractFn, [contractFn].concat(args));
@@ -54,23 +67,18 @@ describe("Gas Estimation", function() {
       transaction(function(err, tx) {
         if (err) return done(err);
 
-        // Get the gas usage.
-        web3.eth.getTransactionReceipt(tx, function(err, receipt) {
-          if (err) return done(err);
-
-          // When instamining, gasUsed and cumulativeGasUsed should be the same.
-          assert.equal(receipt.gasUsed, estimate);
-          assert.equal(receipt.cumulativeGasUsed, estimate);
-
-          done();
-        })
+        verifyGas(tx, estimate, done);
       })
     })
   }
 
-  // it("matches estimate for deployment", function(done) {
-  //   testTransactionEstimate(EstimateGasContract.new, [{data: EstimateGasContract._code, from: accounts[0]}], done);
-  // });
+  it("matches estimate for deployment", function(done) {
+    web3.eth.estimateGas({ data: EstimateGasContract._code, from: accounts[0]}, function(err, gasEstimate) {
+      if (err) assert.fail(err);
+
+      verifyGas(EstimateGas.transactionHash, gasEstimate, done);
+    });
+  });
 
   it("matches usage for complex function call (add)", function(done) {
     testTransactionEstimate(EstimateGas.add, ["Tim", "A great guy", 5, {from: accounts[0], gas: 3141592}], done);
@@ -80,4 +88,4 @@ describe("Gas Estimation", function() {
     testTransactionEstimate(EstimateGas.transfer, ["0x0123456789012345678901234567890123456789", 5, "Tim", {from: accounts[0], gas: 3141592}], done);
   });
 
-})
+});


### PR DESCRIPTION
The gasLimit for an estimateGas call was set to the
defaultTransactionGasLimit of 90000 gas. This would cause
ethereumjs-vm runCall to throw the error 'base fee exceeds
gas limit'.

By setting the gasLimit to the block gas limit, this allows use to
correctly estimate gas for tx's where the basefee > gasLimit, such as
when deploying a contract.

This is how geth does it. https://github.com/ethereum/wiki/wiki/JSON-RPC#parameters-25