### PR TITLE
evm_setTime

### DIFF
--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -478,6 +478,11 @@ GethApiDouble.prototype.evm_increaseTime = function(seconds, callback) {
   callback(null, this.state.blockchain.increaseTime(seconds));
 };
 
+
+GethApiDouble.prototype.evm_setTime = function(date, callback) {
+  callback(null, this.state.blockchain.setTime(date))
+};
+
 GethApiDouble.prototype.evm_mine = function(callback) {
   this.state.processBlocks(1, function(err) {
     callback(err, '0x0');

--- a/test/time_adjust.js
+++ b/test/time_adjust.js
@@ -118,11 +118,6 @@ describe('Time adjustment', function() {
 
           web3.eth.getBlock('latest', function(err, block){
             if(err) return done(err)
-
-            // Somehow it jumps an extra 18 seconds, ish, when run inside the whole
-            // test suite. It might have something to do with when the before block
-            // runs and when the test runs. Likely the last block didn't occur for
-            // awhile.
             assert(previousTime > block.timestamp);
             done()
             })

--- a/test/time_adjust.js
+++ b/test/time_adjust.js
@@ -102,4 +102,32 @@ describe('Time adjustment', function() {
       })
     })
   })
+
+  it('should allow setting of time', function(done) {
+    web3.eth.getBlock('latest', function(err, block) {
+      if (err) return done(err)
+
+      var previousTime = block.timestamp
+
+      send("evm_setTime", [new Date(startTime.getTime() - (secondsToJump * 2))], function(err, result) {
+        if (err) return done(err);
+
+        // Mine a block so new time is recorded.
+        send("evm_mine", function(err, result) {
+          if (err) return done(err);
+
+          web3.eth.getBlock('latest', function(err, block){
+            if(err) return done(err)
+
+            // Somehow it jumps an extra 18 seconds, ish, when run inside the whole
+            // test suite. It might have something to do with when the before block
+            // runs and when the test runs. Likely the last block didn't occur for
+            // awhile.
+            assert(previousTime > block.timestamp);
+            done()
+            })
+          })
+        })
+      })
+  });
 })

--- a/test/time_adjust.js
+++ b/test/time_adjust.js
@@ -109,7 +109,7 @@ describe('Time adjustment', function() {
 
       var previousTime = block.timestamp
 
-      send("evm_setTime", [new Date(startTime.getTime() - (secondsToJump * 2))], function(err, result) {
+      send("evm_setTime", [new Date(previousTime - secondsToJump)], function(err, result) {
         if (err) return done(err);
 
         // Mine a block so new time is recorded.


### PR DESCRIPTION
This would be useful for setting the time in a truffle test, I am not aware of any other method of doing this, and we've had several issues due to needing a historical timestamp for ENS related tests.