### PR TITLE
Add support for eth_signTypedData_v4

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -505,6 +505,10 @@ StateManager.prototype.sign = function(address, dataToSign) {
 };
 
 StateManager.prototype.signTypedData = function(address, typedDataToSign) {
+  if (typeof typedDataToSign === 'string') {
+    typedDataToSign = JSON.parse(typedDataToSign);
+  }
+
   var account = this.accounts[to.hex(address).toLowerCase()];
   if (!account) {
     throw new Error("cannot sign data; no private key");

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -320,6 +320,7 @@ GethApiDouble.prototype.eth_signTypedData = function(address, typedDataToSign, c
 
   callback(error, result);
 };
+GethApiDouble.prototype.eth_signTypedData_v4 = GethApiDouble.prototype.eth_signTypedData;
 
 GethApiDouble.prototype.eth_sendTransaction = function(txData, callback) {
   this.state.queueTransaction("eth_sendTransaction", txData, null, callback);


### PR DESCRIPTION
Add's support for the `eth_signTypedData_v4` RPC method. Also supports signing typed data where the payload is a string (which is how many nodes expect it).