### PR TITLE
Add `removed` field to Log JSON

### DIFF
--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -31,7 +31,8 @@ Log.prototype.toJSON = function() {
     address: to.rpcDataHexString(this.address),
     data: to.rpcDataHexString(this.data),
     topics: this.topics,
-    type: "mined"
+    type: "mined",
+    removed: (this.removed || false)
   };
 };
 

--- a/test/local/requests.js
+++ b/test/local/requests.js
@@ -1034,6 +1034,7 @@ const tests = function(web3) {
       const receipt = await web3.eth.sendTransaction(txData);
       assert.strictEqual(receipt.logs.length, 1, "Receipt had wrong amount of logs");
       assert.strictEqual(receipt.logs[0].blockHash, receipt.blockHash, "Logs blockhash doesn't match block blockhash");
+      assert.strictEqual(typeof receipt.logs[0].removed, "boolean", "Logs removed field missing or not a boolean");
 
       // Now double check the data was set properly.
       // NOTE: Because ethereumjs-testrpc processes transactions immediately,


### PR DESCRIPTION
Fixes #336

This is a fairly trivial change, especially considering Ganache will never reorg and thus the `removed` property is moot (which reasonably explains its omission in the first place).

However, for those of us who care whether or not a log was reorged as part of their application logic, and aren't using JavaScript (i.e., care about well-formed JSON-RPC responses and can't use the truthiness of `log.removed === undefined`), this lack of `removed` renders Ganache unusable as a Web3 provider.