### PR TITLE
fix: storage value encoding in forked trie.

### DIFF
--- a/lib/forking/forked_storage_trie.js
+++ b/lib/forking/forked_storage_trie.js
@@ -62,7 +62,7 @@ ForkedStorageBaseTrie.prototype.get = function(key, callback) {
                 return callback(err);
               }
 
-              value = utils.rlp.encode(value);
+              value = to.rpcQuantityBuffer(value);
 
               callback(null, value);
             }

--- a/lib/utils/to.js
+++ b/lib/utils/to.js
@@ -64,6 +64,16 @@ module.exports = {
     return val;
   },
 
+  rpcQuantityBuffer: function(val) {
+    val = this._rpcQuantityHexString(val);
+
+    if (val === "0x0") {
+      val = "0x";
+    }
+
+    return utils.rlp.encode(val);
+  },
+
   rpcDataHexString: function(val, length) {
     if (typeof length === "number") {
       val = this.hex(val).replace("0x", "");


### PR DESCRIPTION
This PR resolves https://github.com/trufflesuite/ganache-core/issues/625

It extends the ethereumjs-util rlp encoding by forcing the removal of any leading zeros.