### PR TITLE
fix(tezos): frozen block time on flextesa instance

### DIFF
--- a/lib/tezos/flextesa.js
+++ b/lib/tezos/flextesa.js
@@ -90,7 +90,7 @@ const bake = (flextesa) => {
         resolve();
       }
     });
-    flextesa.stdin.write("client-0 bake for ganache --minimal-timestamp\n");
+    flextesa.stdin.write("client-0 bake for ganache\n");
   });
 };
 


### PR DESCRIPTION
Currently, all blocks in flextesa seem to have the same timestamp. It is the time flextesa/ganache was started. Which, as can be imagined, makes testing timestamp-based checks difficult or near impossible.
This small fix fixes that.

From the flextesa docs:
https://tezos.gitlab.io/008/cli-commands.html
```
--minimal-timestamp: Use the minimal timestamp instead of the current date as timestamp of the baked block
```