### PR TITLE
fix: handle failure to retrieve `net_version` when forking

### DIFF
--- a/lib/forking/forked_blockchain.js
+++ b/lib/forking/forked_blockchain.js
@@ -171,9 +171,13 @@ ForkedBlockchain.prototype.initialize = async function(accounts, callback) {
     const forkVersion = await new Promise((resolve, reject) => {
       this.web3.eth.net.getId((err, version) => {
         if (err) {
-          Error.captureStackTrace(err);
-          err.message = `The fork provider errored when checking net_version: ${err.message}`;
-          reject(err);
+          if (this.options.network_id) {
+            resolve(this.options.network_id);
+          } else {
+            Error.captureStackTrace(err);
+            err.message = `The fork provider errored when checking net_version: ${err.message}`;
+            reject(err);
+          }
         } else {
           resolve(version);
         }


### PR DESCRIPTION
When forking against a local full node, some clients will reject `net_version` RPC requests, such as turbo-geth. In this case, if the `networkId` param was set - use it instead.