### PR TITLE
feat: add `Filecoin.ChainNotify` method and Filecoin support websockets and subscriptions

### DIFF
--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -1,5 +1,5 @@
 //#region Imports
-import { types } from "@ganache/utils";
+import { types, Quantity, PromiEvent } from "@ganache/utils";
 import Blockchain from "./blockchain";
 import {
   StorageProposal,
@@ -7,19 +7,23 @@ import {
 } from "./things/storage-proposal";
 import { SerializedRootCID, RootCID } from "./things/root-cid";
 import { SerializedDeal } from "./things/deal";
-import { SerializedTipset } from "./things/tipset";
+import { SerializedTipset, Tipset } from "./things/tipset";
 import { SerializedAddress } from "./things/address";
 import { SerializedMiner } from "./things/miner";
 import {
   SerializedRetrievalOffer,
   RetrievalOffer
 } from "./things/retrieval-offer";
+import Emittery from "emittery";
+import { HeadChange, HeadChangeType } from "./things/head-change";
 
 const _blockchain = Symbol("blockchain");
 
 export default class FilecoinApi implements types.Api {
   readonly [index: string]: (...args: any) => Promise<any>;
 
+  readonly #getId = (id => () => Quantity.from(++id))(0);
+  readonly #subscriptions = new Map<string, Emittery.UnsubscribeFn>();
   private readonly [_blockchain]: Blockchain;
 
   constructor(blockchain: Blockchain) {
@@ -36,6 +40,39 @@ export default class FilecoinApi implements types.Api {
 
   async "Filecoin.ChainHead"(): Promise<SerializedTipset> {
     return this[_blockchain].latestTipset().serialize();
+  }
+
+  "Filecoin.ChainNotify"(): PromiEvent<Quantity> {
+    const subscription = this.#getId();
+    const promiEvent = PromiEvent.resolve(subscription);
+
+    // There currently isn't an unsubscribe method,
+    // but it would go here
+    this.#subscriptions.set(subscription.toString(), () => {});
+
+    const currentHead = new HeadChange({
+      type: HeadChangeType.HCCurrent,
+      val: this[_blockchain].latestTipset()
+    });
+
+    this[_blockchain].on("tipset", (tipset: Tipset) => {
+      const newHead = new HeadChange({
+        type: HeadChangeType.HCApply,
+        val: tipset
+      });
+
+      promiEvent.emit("message", {
+        type: "xrpc.ch.val",
+        data: [subscription.toString(), [newHead.serialize()]]
+      });
+    });
+
+    promiEvent.emit("message", {
+      type: "xrpc.ch.val",
+      data: [subscription.toString(), [currentHead.serialize()]]
+    });
+
+    return promiEvent;
   }
 
   async "Filecoin.StateListMiners"(): Promise<Array<SerializedMiner>> {

--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -17,29 +17,27 @@ import {
 import Emittery from "emittery";
 import { HeadChange, HeadChangeType } from "./things/head-change";
 
-const _blockchain = Symbol("blockchain");
-
 export default class FilecoinApi implements types.Api {
   readonly [index: string]: (...args: any) => Promise<any>;
 
   readonly #getId = (id => () => Quantity.from(++id))(0);
   readonly #subscriptions = new Map<string, Emittery.UnsubscribeFn>();
-  private readonly [_blockchain]: Blockchain;
+  readonly #blockchain: Blockchain;
 
   constructor(blockchain: Blockchain) {
-    this[_blockchain] = blockchain;
+    this.#blockchain = blockchain;
   }
 
   async stop(): Promise<void> {
-    return await this[_blockchain].stop();
+    return await this.#blockchain.stop();
   }
 
   async "Filecoin.ChainGetGenesis"(): Promise<SerializedTipset> {
-    return this[_blockchain].latestTipset().serialize();
+    return this.#blockchain.latestTipset().serialize();
   }
 
   async "Filecoin.ChainHead"(): Promise<SerializedTipset> {
-    return this[_blockchain].latestTipset().serialize();
+    return this.#blockchain.latestTipset().serialize();
   }
 
   "Filecoin.ChainNotify"(): PromiEvent<Quantity> {
@@ -52,10 +50,10 @@ export default class FilecoinApi implements types.Api {
 
     const currentHead = new HeadChange({
       type: HeadChangeType.HCCurrent,
-      val: this[_blockchain].latestTipset()
+      val: this.#blockchain.latestTipset()
     });
 
-    this[_blockchain].on("tipset", (tipset: Tipset) => {
+    this.#blockchain.on("tipset", (tipset: Tipset) => {
       const newHead = new HeadChange({
         type: HeadChangeType.HCApply,
         val: tipset
@@ -76,19 +74,19 @@ export default class FilecoinApi implements types.Api {
   }
 
   async "Filecoin.StateListMiners"(): Promise<Array<SerializedMiner>> {
-    return [this[_blockchain].miner.serialize()];
+    return [this.#blockchain.miner.serialize()];
   }
 
   async "Filecoin.WalletDefaultAddress"(): Promise<SerializedAddress> {
-    return this[_blockchain].address.serialize();
+    return this.#blockchain.address.serialize();
   }
 
   async "Filecoin.WalletBalance"(address: string): Promise<string> {
-    let managedAddress = this[_blockchain].address;
+    let managedAddress = this.#blockchain.address;
 
     // For now, anything but our default address will have no balance
     if (managedAddress.value == address) {
-      return this[_blockchain].balance.serialize();
+      return this.#blockchain.balance.serialize();
     } else {
       return "0";
     }
@@ -98,19 +96,19 @@ export default class FilecoinApi implements types.Api {
     serializedProposal: SerializedStorageProposal
   ): Promise<SerializedRootCID> {
     let proposal = new StorageProposal(serializedProposal);
-    let proposalRootCid = await this[_blockchain].startDeal(proposal);
+    let proposalRootCid = await this.#blockchain.startDeal(proposal);
 
     return proposalRootCid.serialize();
   }
 
   async "Filecoin.ClientListDeals"(): Promise<Array<SerializedDeal>> {
-    return this[_blockchain].deals.map(deal => deal.serialize());
+    return this.#blockchain.deals.map(deal => deal.serialize());
   }
 
   async "Filecoin.ClientFindData"(
     rootCid: SerializedRootCID
   ): Promise<Array<SerializedRetrievalOffer>> {
-    let remoteOffer = await this[_blockchain].createRetrievalOffer(
+    let remoteOffer = await this.#blockchain.createRetrievalOffer(
       new RootCID(rootCid)
     );
     return [remoteOffer.serialize()];
@@ -119,13 +117,13 @@ export default class FilecoinApi implements types.Api {
   async "Filecoin.ClientHasLocal"(
     rootCid: SerializedRootCID
   ): Promise<boolean> {
-    return await this[_blockchain].hasLocal(rootCid["/"]);
+    return await this.#blockchain.hasLocal(rootCid["/"]);
   }
 
   async "Filecoin.ClientRetrieve"(
     retrievalOffer: SerializedRetrievalOffer
   ): Promise<object> {
-    await this[_blockchain].retrieve(new RetrievalOffer(retrievalOffer));
+    await this.#blockchain.retrieve(new RetrievalOffer(retrievalOffer));
 
     // Return value is a placeholder.
     //
@@ -137,7 +135,7 @@ export default class FilecoinApi implements types.Api {
   }
 
   async "Filecoin.GanacheMineTipset"(): Promise<SerializedTipset> {
-    await this[_blockchain].mineTipset();
-    return this[_blockchain].latestTipset().serialize();
+    await this.#blockchain.mineTipset();
+    return this.#blockchain.latestTipset().serialize();
   }
 }

--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -85,7 +85,7 @@ export default class Blockchain extends Emittery.Typed<
 
         this.miningTimeout = setInterval(
           intervalMine,
-          this.options.miner.blockTime
+          this.options.miner.blockTime * 1000
         );
 
         utils.unref(this.miningTimeout);

--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -134,6 +134,7 @@ export default class Blockchain extends Emittery.Typed<
   // previous tipset is the parent of the new blocks.
   async mineTipset(numNewBlocks: number = 1): Promise<void> {
     let previousTipset: Tipset = this.latestTipset();
+    const newTipsetHeight = previousTipset.height + 1;
 
     let newBlocks: Array<Block> = [];
 
@@ -141,14 +142,15 @@ export default class Blockchain extends Emittery.Typed<
       newBlocks.push(
         new Block({
           miner: this.miner,
-          parents: [previousTipset.cids[0]]
+          parents: [previousTipset.cids[0]],
+          height: newTipsetHeight
         })
       );
     }
 
     let newTipset = new Tipset({
       blocks: newBlocks,
-      height: previousTipset.height + 1
+      height: newTipsetHeight
     });
 
     this.tipsets.push(newTipset);

--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -19,6 +19,7 @@ import { FilecoinInternalOptions } from "@ganache/filecoin-options";
 
 export type BlockchainEvents = {
   ready(): void;
+  tipset: Tipset;
 };
 
 export default class Blockchain extends Emittery.Typed<
@@ -166,6 +167,8 @@ export default class Blockchain extends Emittery.Typed<
     }
 
     this.logLatestTipset();
+
+    this.emit("tipset", newTipset);
   }
 
   async hasLocal(cid: string): Promise<boolean> {

--- a/src/chains/filecoin/filecoin/src/connector.ts
+++ b/src/chains/filecoin/filecoin/src/connector.ts
@@ -1,8 +1,8 @@
 import Emittery from "emittery";
 import FilecoinApi from "./api";
-import { JsonRpcTypes, types, utils, PromiEvent } from "@ganache/utils";
+import { JsonRpcTypes, types, utils } from "@ganache/utils";
 import FilecoinProvider from "./provider";
-import { RecognizedString, HttpRequest } from "uWebSockets.js";
+import { RecognizedString, HttpRequest, WebSocket } from "uWebSockets.js";
 import { FilecoinProviderOptions } from "@ganache/filecoin-options";
 
 export type ProviderOptions = FilecoinProviderOptions;
@@ -44,15 +44,11 @@ export class Connector
     return JSON.parse(message) as JsonRpcTypes.Request<FilecoinApi>;
   }
 
-  // Note that if we allow Filecoin to support Websockets, ws-server.ts blows up.
-  // TODO: Look into this.
   handle(
     payload: JsonRpcTypes.Request<FilecoinApi>,
-    _connection: HttpRequest /*| WebSocket*/
-  ): PromiEvent<any> {
-    return new PromiEvent(resolve => {
-      return this.#provider.send(payload).then(resolve);
-    });
+    _connection: HttpRequest | WebSocket
+  ): Promise<any> {
+    return this.#provider.send(payload);
   }
 
   format(

--- a/src/chains/filecoin/filecoin/src/things/head-change.ts
+++ b/src/chains/filecoin/filecoin/src/things/head-change.ts
@@ -1,0 +1,61 @@
+import {
+  SerializableObject,
+  DeserializedObject,
+  Definitions,
+  SerializedObject
+} from "./serializable-object";
+import { Tipset, SerializedTipset } from "./tipset";
+
+interface HeadChangeConfig {
+  properties: {
+    type: {
+      type: string;
+      serializedType: string;
+      serializedName: "Type";
+    };
+    val: {
+      type: Tipset;
+      serializedType: SerializedTipset;
+      serializedName: "Val";
+    };
+  };
+}
+
+class HeadChange
+  extends SerializableObject<HeadChangeConfig>
+  implements DeserializedObject<HeadChangeConfig> {
+  get config(): Definitions<HeadChangeConfig> {
+    return {
+      type: {
+        serializedName: "Type",
+        defaultValue: (options = HeadChangeType.HCCurrent) => options
+      },
+      val: {
+        serializedName: "Val",
+        defaultValue: options => new Tipset(options)
+      }
+    };
+  }
+
+  constructor(
+    options?:
+      | Partial<SerializedObject<HeadChangeConfig>>
+      | Partial<DeserializedObject<HeadChangeConfig>>
+  ) {
+    super(options);
+  }
+
+  type: string;
+  val: Tipset;
+}
+
+type SerializedHeadChange = SerializedObject<HeadChangeConfig>;
+
+// Retrieved these from https://git.io/Jtvke
+export enum HeadChangeType {
+  HCRevert = "revert",
+  HCApply = "apply",
+  HCCurrent = "current"
+}
+
+export { HeadChange, SerializedHeadChange };

--- a/src/chains/filecoin/filecoin/src/types/subscriptions.ts
+++ b/src/chains/filecoin/filecoin/src/types/subscriptions.ts
@@ -1,0 +1,7 @@
+export enum SubscriptionMethod {
+  ChannelUpdated = "xrpc.ch.val",
+  ChannelClosed = "xrpc.ch.close",
+  SubscriptionCanceled = "xrpc.cancel"
+}
+
+export type SubscriptionId = string;

--- a/src/packages/core/src/servers/ws-server.ts
+++ b/src/packages/core/src/servers/ws-server.ts
@@ -52,7 +52,10 @@ export default class WebsocketServer {
         message: ArrayBuffer,
         isBinary: boolean
       ) => {
-        let payload: ReturnType<typeof connector.parse>;
+        // We have to use type any instead of ReturnType<typeof connector.parse>
+        // on `payload` because Typescript isn't smart enough to understand the
+        // ambiguity doesn't actually exist
+        let payload: any;
         const useBinary = autoBinary ? isBinary : (wsBinary as boolean);
         try {
           payload = connector.parse(Buffer.from(message));


### PR DESCRIPTION
This PR is part of #694 (although most Lotus applications want to use WebSockets)

This supports the Chain Explorer feature in the https://github.com/filecoin-shipyard/filecoin-network-inspector example

![image](https://user-images.githubusercontent.com/549323/104633129-8d6df500-5653-11eb-9456-f0057bc8faec.png)

---

This PR also resolves #692:

![image.png](https://images.zenhubusercontent.com/5b2bf0d96fa6f07063196b99/cccadd51-e8ef-4964-91ba-0c70603395f2)