### PR TITLE
fix: change `Filecoin.WalletBalance` to have correct denominations

### DIFF
--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -233,9 +233,7 @@ export default class Blockchain extends Emittery.Typed<
     }
 
     // Subtract the cost from our current balance
-    let totalPrice = new BN(deal.pricePerEpoch)
-      .mul(new BN(deal.duration))
-      .toString(10);
+    let totalPrice = BigInt(deal.pricePerEpoch) * BigInt(deal.duration);
     this.#balance = this.#balance.sub(totalPrice);
 
     return deal.proposalCid;

--- a/src/chains/filecoin/filecoin/src/provider.ts
+++ b/src/chains/filecoin/filecoin/src/provider.ts
@@ -64,7 +64,7 @@ export default class FilecoinProvider
     accounts[this.blockchain.address.serialize()] = {
       unlocked: true,
       secretKey: this.blockchain.address.privateKey,
-      balance: BigInt(this.blockchain.balance.value)
+      balance: this.blockchain.balance.value
     };
     return accounts;
   }

--- a/src/chains/filecoin/filecoin/src/things/balance.ts
+++ b/src/chains/filecoin/filecoin/src/things/balance.ts
@@ -1,25 +1,28 @@
-import { SerializableLiteral } from "./serializable-literal";
 import BN from "bn.js";
+import { SerializableLiteral } from "./serializable-literal";
 
 interface BalanceConfig {
-  type: string;
+  type: bigint;
 }
 
+// The smallest denomination of FIL is an attoFIL (10^-18 FIL)
 class Balance extends SerializableLiteral<BalanceConfig> {
   get config() {
     return {
       defaultValue: literal => {
-        return literal || "500000000000000000000000";
+        return literal || 500n * 1000000000000000000n;
       }
     };
   }
 
-  sub(val: string | number): Balance {
-    return new Balance(new BN(this.value).sub(new BN(val)).toString(10));
+  sub(val: string | number | bigint): Balance {
+    return new Balance(this.value - BigInt(val));
   }
 
   toFIL(): number {
-    return new BN(this.value).div(new BN(10).pow(new BN(21))).toNumber();
+    return new BN(this.value.toString(10))
+      .div(new BN(10).pow(new BN(18)))
+      .toNumber();
   }
 }
 

--- a/src/chains/filecoin/filecoin/src/things/serializable-literal.ts
+++ b/src/chains/filecoin/filecoin/src/things/serializable-literal.ts
@@ -1,11 +1,14 @@
 import { Serializable } from "./serializable-object";
-import { config } from "yargs";
 
 type BaseConfig = {
   type: any;
 };
 
 type Literal<C extends BaseConfig> = C["type"];
+
+type SerializedLiteral<C extends BaseConfig> = C["type"] extends bigint
+  ? string
+  : Literal<C>;
 
 type DefaultValue<D> = D | ((options: D) => D);
 
@@ -15,7 +18,7 @@ type LiteralDefinition<C extends BaseConfig> = {
 };
 
 abstract class SerializableLiteral<C extends BaseConfig>
-  implements Serializable<Literal<C>> {
+  implements Serializable<SerializedLiteral<C>> {
   protected abstract get config(): LiteralDefinition<C>;
   value: Literal<C>;
 
@@ -41,8 +44,12 @@ abstract class SerializableLiteral<C extends BaseConfig>
     }
   }
 
-  serialize(): Literal<C> {
-    return this.value;
+  serialize(): SerializedLiteral<C> {
+    if (typeof this.value === "bigint") {
+      return this.value.toString(10) as SerializedLiteral<C>;
+    } else {
+      return this.value;
+    }
   }
 
   equals(obj: Serializable<Literal<C>>): boolean {


### PR DESCRIPTION
This PR is part of #694:
- Fixes the correct smallest denomination of FIL to be attoFIL instead of zeptoFIL
- I also went ahead and changed the base type of `Balance` to `bigint` instead of `string` and added serialization support

![image](https://user-images.githubusercontent.com/549323/104633502-16852c00-5654-11eb-84ec-b078420fa7fd.png)
