### PR TITLE
feat: add support for `Filecoin.StateMinerPower` method

### DIFF
--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -99,6 +99,9 @@ export default class FilecoinApi implements types.Api {
   async "Filecoin.StateMinerPower"(
     minerAddress: string
   ): Promise<SerializedMinerPower> {
+    // I don't fully understand what these values are supposed to be/mean
+    // but since we're the only miner on this "network", I figure they don't
+    // super matter. I'm putting in these placeholder values for now
     if (minerAddress === this.#blockchain.miner.value) {
       const power = new MinerPower({
         minerPower: new PowerClaim({

--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -18,6 +18,8 @@ import Emittery from "emittery";
 import { HeadChange, HeadChangeType } from "./things/head-change";
 import { SubscriptionMethod, SubscriptionId } from "./types/subscriptions";
 import { FileRef, SerializedFileRef } from "./things/file-ref";
+import { MinerPower, SerializedMinerPower } from "./things/miner-power";
+import { PowerClaim } from "./things/power-claim";
 
 export default class FilecoinApi implements types.Api {
   readonly [index: string]: (...args: any) => Promise<any>;
@@ -92,6 +94,40 @@ export default class FilecoinApi implements types.Api {
 
   async "Filecoin.StateListMiners"(): Promise<Array<SerializedMiner>> {
     return [this.#blockchain.miner.serialize()];
+  }
+
+  async "Filecoin.StateMinerPower"(
+    minerAddress: string
+  ): Promise<SerializedMinerPower> {
+    if (minerAddress === this.#blockchain.miner.value) {
+      const power = new MinerPower({
+        minerPower: new PowerClaim({
+          rawBytePower: 1n,
+          qualityAdjPower: 1n
+        }),
+        totalPower: new PowerClaim({
+          rawBytePower: 1n,
+          qualityAdjPower: 1n
+        }),
+        hasMinPower: false
+      });
+
+      return power.serialize();
+    } else {
+      const power = new MinerPower({
+        minerPower: new PowerClaim({
+          rawBytePower: 0n,
+          qualityAdjPower: 0n
+        }),
+        totalPower: new PowerClaim({
+          rawBytePower: 0n,
+          qualityAdjPower: 0n
+        }),
+        hasMinPower: false
+      });
+
+      return power.serialize();
+    }
   }
 
   async "Filecoin.WalletDefaultAddress"(): Promise<SerializedAddress> {

--- a/src/chains/filecoin/filecoin/src/things/miner-power.ts
+++ b/src/chains/filecoin/filecoin/src/things/miner-power.ts
@@ -1,0 +1,57 @@
+import { SerializedRootCID } from "./root-cid";
+import {
+  SerializableObject,
+  SerializedObject,
+  DeserializedObject,
+  Definitions
+} from "./serializable-object";
+import { PowerClaim, SerializedPowerClaim } from "./power-claim";
+
+type MinerPowerConfig = {
+  properties: {
+    minerPower: {
+      type: PowerClaim;
+      serializedType: SerializedPowerClaim;
+      serializedName: "MinerPower";
+    };
+    totalPower: {
+      type: PowerClaim;
+      serializedType: SerializedPowerClaim;
+      serializedName: "TotalPower";
+    };
+    hasMinPower: {
+      type: boolean;
+      serializedType: SerializedRootCID;
+      serializedName: "HasMinPower";
+    };
+  };
+};
+
+class MinerPower
+  extends SerializableObject<MinerPowerConfig>
+  implements DeserializedObject<MinerPowerConfig> {
+  get config(): Definitions<MinerPowerConfig> {
+    return {
+      minerPower: {
+        serializedName: "MinerPower",
+        defaultValue: options => new PowerClaim(options)
+      },
+      totalPower: {
+        serializedName: "TotalPower",
+        defaultValue: options => new PowerClaim(options)
+      },
+      hasMinPower: {
+        serializedName: "HasMinPower",
+        defaultValue: false
+      }
+    };
+  }
+
+  minerPower: PowerClaim;
+  totalPower: PowerClaim;
+  hasMinPower: boolean;
+}
+
+type SerializedMinerPower = SerializedObject<MinerPowerConfig>;
+
+export { MinerPower, SerializedMinerPower };

--- a/src/chains/filecoin/filecoin/src/things/power-claim.ts
+++ b/src/chains/filecoin/filecoin/src/things/power-claim.ts
@@ -1,0 +1,45 @@
+import {
+  SerializableObject,
+  SerializedObject,
+  DeserializedObject,
+  Definitions
+} from "./serializable-object";
+
+type PowerClaimConfig = {
+  properties: {
+    rawBytePower: {
+      type: bigint;
+      serializedType: string;
+      serializedName: "RawBytePower";
+    };
+    qualityAdjPower: {
+      type: bigint;
+      serializedType: string;
+      serializedName: "QualityAdjPower";
+    };
+  };
+};
+
+class PowerClaim
+  extends SerializableObject<PowerClaimConfig>
+  implements DeserializedObject<PowerClaimConfig> {
+  get config(): Definitions<PowerClaimConfig> {
+    return {
+      rawBytePower: {
+        serializedName: "RawBytePower",
+        defaultValue: 1n
+      },
+      qualityAdjPower: {
+        serializedName: "QualityAdjPower",
+        defaultValue: 1n
+      }
+    };
+  }
+
+  rawBytePower: bigint;
+  qualityAdjPower: bigint;
+}
+
+type SerializedPowerClaim = SerializedObject<PowerClaimConfig>;
+
+export { PowerClaim, SerializedPowerClaim };

--- a/src/chains/filecoin/filecoin/src/things/serializable-object.ts
+++ b/src/chains/filecoin/filecoin/src/things/serializable-object.ts
@@ -159,7 +159,9 @@ abstract class SerializableObject<C extends BaseConfig>
 
   private serializeValue(value: any) {
     let returnVal: any = value;
-    if (
+    if (typeof value === "bigint") {
+      returnVal = value.toString(10);
+    } else if (
       value instanceof SerializableObject ||
       value instanceof SerializableLiteral
     ) {


### PR DESCRIPTION
This PR is part of #694. It makes the necessary changes to support the `/miners` page on the network inspector example

![image](https://user-images.githubusercontent.com/549323/104635959-7e894180-5657-11eb-958f-09fd04289ef9.png)
