### PR TITLE
fix: update storage DealState enum from filecoin source

### DIFF
--- a/src/chains/filecoin/filecoin/src/deal-state.ts
+++ b/src/chains/filecoin/filecoin/src/deal-state.ts
@@ -1,46 +1,127 @@
 // Note that the runtime number values of these enums match
-// *exactly* the number values of the same states on the Lotus server.
+// *exactly* the number values of the same states found at
+// go-fil-markets/storagemarket/dealstatus.go (https://git.io/JtJAS)
+// **DO NOT TRUST** other sources (i.e. lotus/lotuspond/front/src/Client.js
+// or js-lotus-client-workshop/src/08-deals/deal-list.js)
 // Don't reorganize unless you know what you're doing.
 
+// Updated to v1.1.1 (https://github.com/filecoin-project/go-fil-markets/blob/v1.1.1/storagemarket/dealstatus.go)
 export enum DealState {
+  // Unknown means the current status of a deal is undefined
   Unknown,
+
+  // ProposalNotFound is a status returned in responses when the deal itself cannot
+  // be located
   ProposalNotFound,
+
+  // ProposalRejected is returned by a StorageProvider when it chooses not to accept
+  // a DealProposal
   ProposalRejected,
+
+  // ProposalAccepted indicates an intent to accept a storage deal proposal
   ProposalAccepted,
+
+  // Staged means a deal has been published and data is ready to be put into a sector
   Staged,
+
+  // Sealing means a deal is in a sector that is being sealed
   Sealing,
+
+  // Finalizing means a deal is in a sealed sector and we're doing final
+  // housekeeping before marking it active
+  Finalizing,
+
+  // Active means a deal is in a sealed sector and the miner is proving the data
+  // for the deal
   Active,
+
+  // Expired means a deal has passed its final epoch and is expired
+  Expired,
+
+  // Slashed means the deal was in a sector that got slashed from failing to prove
+  Slashed,
+
+  // Rejecting means the Provider has rejected the deal, and will send a rejection response
+  Rejecting,
+
+  // Failing means something has gone wrong in a deal. Once data is cleaned up the deal will finalize on
+  // Error
   Failing,
-  NotFound,
-  FundsEnsured, // Deposited funds as neccesary to create a deal, ready to move forward
-  Validating, // Verifying that deal parameters are good
-  Transferring, // Moving data
-  WaitingForData, // Manual transfer
-  VerifyData, // Verify transferred data - generate CAR / piece data
-  EnsureProviderFunds, // Ensuring that provider collateral is sufficient
-  EnsureClientFunds, // Ensuring that client funds are sufficient
-  ProviderFunding, // Waiting for funds to appear in Provider balance
-  ClientFunding, // Waiting for funds to appear in Client balance
-  Publish, // Publishing deal to chain
-  Publishing, // Waiting for deal to appear on chain
-  Error, // deal failed with an unexpected error
-  Completed // on provider side, indicates deal is active and info for retrieval is recorded
+
+  // FundsReserved means we've deposited funds as necessary to create a deal, ready to move forward
+  FundsReserved,
+
+  // CheckForAcceptance means the client is waiting for a provider to seal and publish a deal
+  CheckForAcceptance,
+
+  // Validating means the provider is validating that deal parameters are good for a proposal
+  Validating,
+
+  // AcceptWait means the provider is running any custom decision logic to decide whether or not to accept the deal
+  AcceptWait,
+
+  // StartDataTransfer means data transfer is beginning
+  StartDataTransfer,
+
+  // Transferring means data is being sent from the client to the provider via the data transfer module
+  Transferring,
+
+  // WaitingForData indicates either a manual transfer
+  // or that the provider has not received a data transfer request from the client
+  WaitingForData,
+
+  // VerifyData means data has been transferred and we are attempting to verify it against the PieceCID
+  VerifyData,
+
+  // ReserveProviderFunds means that provider is making sure it has adequate funds for the deal in the StorageMarketActor
+  ReserveProviderFunds,
+
+  // ReserveClientFunds means that client is making sure it has adequate funds for the deal in the StorageMarketActor
+  ReserveClientFunds,
+
+  // ProviderFunding means that the provider has deposited funds in the StorageMarketActor and it is waiting
+  // to see the funds appear in its balance
+  ProviderFunding,
+
+  // ClientFunding means that the client has deposited funds in the StorageMarketActor and it is waiting
+  // to see the funds appear in its balance
+  ClientFunding,
+
+  // Publish means the deal is ready to be published on chain
+  Publish,
+
+  // Publishing means the deal has been published but we are waiting for it to appear on chain
+  Publishing,
+
+  // Error means the deal has failed due to an error, and no further updates will occur
+  Error,
+
+  // ProviderTransferAwaitRestart means the provider has restarted while data
+  // was being transferred from client to provider, and will wait for the client to
+  // resume the transfer
+  ProviderTransferAwaitRestart,
+
+  // ClientTransferRestart means a storage deal data transfer from client to provider will be restarted
+  // by the client
+  ClientTransferRestart,
+
+  // AwaitingPreCommit means a deal is ready and must be pre-committed
+  AwaitingPreCommit
 }
 
 export let terminalStates: Array<DealState> = [
-  // go-fil-markets/storagemarket/types.go
   DealState.ProposalNotFound,
   DealState.ProposalRejected,
   DealState.Error,
-  DealState.Completed
+  DealState.Expired
 ];
 
 export let nextSuccessfulState: Record<DealState, DealState> = [
   DealState.Validating,
   DealState.Staged,
-  DealState.EnsureProviderFunds,
-  DealState.EnsureClientFunds,
-  DealState.FundsEnsured,
+  DealState.ReserveProviderFunds,
+  DealState.ReserveClientFunds,
+  DealState.FundsReserved,
   DealState.ProviderFunding,
   DealState.ClientFunding,
   DealState.Publish,


### PR DESCRIPTION
This PR is part of #693. It updates the `DealState` enum for storage deals and adds more comments/context about how/where to update the enum in the future