### PR TITLE
chore: update ipfs server to have a more generic options setup

### DIFF
--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -77,7 +77,7 @@ export default class Blockchain extends Emittery.Typed<
 
     setTimeout(async () => {
       // Create the IPFS server
-      this.ipfsServer = new IPFSServer(this.options.chain.ipfsPort);
+      this.ipfsServer = new IPFSServer(this.options.chain);
 
       await this.ipfsServer.start();
 


### PR DESCRIPTION
This PR updates `IPFSServer` to properly consume options and use the host option. It also renames the directory used for IPFS files to not have the word `foo`.