### PR TITLE
feat: add server options to cli and default logging

### DIFF
--- a/src/chains/ethereum/options/src/logging-options.ts
+++ b/src/chains/ethereum/options/src/logging-options.ts
@@ -77,7 +77,7 @@ export type LoggingConfig = {
   };
 };
 
-const logger: Logger = { log: () => {} };
+const logger: Logger = { log: console.log };
 
 export const LoggingOptions: Definitions<LoggingConfig> = {
   debug: {

--- a/src/packages/cli/src/args.ts
+++ b/src/packages/cli/src/args.ts
@@ -6,6 +6,7 @@ import {
   Definitions,
   YargsPrimitiveCliTypeStrings
 } from "@ganache/options";
+import { serverDefaults } from "@ganache/core";
 import { Command, Argv } from "./types";
 import chalk from "chalk";
 import { EOL } from "os";
@@ -40,6 +41,70 @@ const addAliases = (args: yargs.Argv<{}>, aliases: string[], key: string) => {
   const options = { hidden: true, alias: key };
   return aliases.reduce((args, a) => args.option(a, options), args);
 };
+
+function processOption(
+  state: any,
+  category: string,
+  group: string,
+  option: string,
+  optionObj: Definitions<Base.Config>[string | number],
+  argv: yargs.Argv
+) {
+  if (optionObj.disableInCLI !== true) {
+    const shortHand = [];
+    const legacyAliases = [];
+
+    let description = highlight(optionObj.cliDescription || "");
+    if (optionObj.cliAliases) {
+      optionObj.cliAliases.forEach(alias => {
+        if (alias.length === 1) shortHand.push(alias);
+        else legacyAliases.push(alias);
+      });
+      description = chalk`${description}${EOL}{dim deprecated aliases: ${legacyAliases
+        .map(a => `--${a}`)
+        .join(", ")}}`;
+    }
+
+    const generateDefaultDescription = () => {
+      // default sometimes requires a config, so we supply one
+      return (state[option] = optionObj.default
+        ? optionObj.default(state).toString()
+        : undefined);
+    };
+    const defaultDescription =
+      optionObj.defaultDescription || generateDefaultDescription();
+
+    // we need to specify the type of each array so yargs properly casts
+    // the types held within each array
+    const { cliType } = optionObj;
+    const array = cliType && cliType.startsWith("array:"); // e.g. array:string or array:number
+    const type = (array
+      ? cliType.slice(6) // remove the "array:" part
+      : cliType) as YargsPrimitiveCliTypeStrings;
+
+    const options: Options = {
+      group,
+      description,
+      alias: shortHand,
+      defaultDescription,
+      array,
+      type,
+      choices: optionObj.cliChoices,
+      coerce: optionObj.cliCoerce
+    };
+
+    const key = `${category}.${option}`;
+
+    // First, create *hidden* deprecated aliases...
+    argv = addAliases(argv, legacyAliases, key);
+
+    // and *then* create the main option, as options added later take precedence
+    // example: `-d --wallet.seed 123` is invalid (mutally exclusive). If aliases are defined _after_
+    // the main option definition the error message will be `Arguments deterministic and wallet.seed are mutually exclusive`
+    // when it should be `Arguments wallet.deterministic and wallet.seed are mutually exclusive`
+    argv = argv.option(key, options);
+  }
+}
 
 export default function (version: string, isDocker: boolean) {
   let args = yargs
@@ -86,64 +151,20 @@ export default function (version: string, isDocker: boolean) {
           const state = {};
           for (const option in categoryObj) {
             const optionObj = categoryObj[option];
-            if (optionObj.disableInCLI !== true) {
-              const shortHand = [];
-              const legacyAliases = [];
-
-              let description = highlight(optionObj.cliDescription || "");
-              if (optionObj.cliAliases) {
-                optionObj.cliAliases.forEach(alias => {
-                  if (alias.length === 1) shortHand.push(alias);
-                  else legacyAliases.push(alias);
-                });
-                description = chalk`${description}${EOL}{dim deprecated aliases: ${legacyAliases
-                  .map(a => `--${a}`)
-                  .join(", ")}}`;
-              }
-
-              const generateDefaultDescription = () => {
-                // default sometimes requires a config, so we supply one
-                return (state[option] = optionObj.default
-                  ? optionObj.default(state).toString()
-                  : undefined);
-              };
-              const defaultDescription =
-                optionObj.defaultDescription || generateDefaultDescription();
-
-              // we need to specify the type of each array so yargs properly casts
-              // the types held within each array
-              const { cliType } = optionObj;
-              const array = cliType && cliType.startsWith("array:"); // e.g. array:string or array:number
-              const type = (array
-                ? cliType.slice(6) // remove the "array:" part
-                : cliType) as YargsPrimitiveCliTypeStrings;
-
-              const options: Options = {
-                group,
-                description,
-                alias: shortHand,
-                defaultDescription,
-                array,
-                type,
-                choices: optionObj.cliChoices,
-                coerce: optionObj.cliCoerce
-              };
-
-              const key = `${category}.${option}`;
-
-              // First, create *hidden* deprecated aliases...
-              flavorArgs = addAliases(flavorArgs, legacyAliases, key);
-
-              // and *then* create the main option, as options added later take precedence
-              // example: `-d --wallet.seed 123` is invalid (mutally exclusive). If aliases are defined _after_
-              // the main option definition the error message will be `Arguments deterministic and wallet.seed are mutually exclusive`
-              // when it should be `Arguments wallet.deterministic and wallet.seed are mutually exclusive`
-              flavorArgs = flavorArgs.option(key, options);
-            }
+            processOption(state, category, group, option, optionObj, flavorArgs);
           }
         }
 
-        // TODO: combine these cli options with core's `ServerOptions`
+        const state = {};
+        const categoryObj = serverDefaults.server;
+        const options = Object.keys(categoryObj);
+        const group = "Server:";
+        for (const option of options) {
+          const optionObj = categoryObj[option];
+
+          processOption(state, "server", group, option, optionObj, flavorArgs);
+        }
+
         flavorArgs = flavorArgs
           .option("server.host", {
             group: "Server:",

--- a/src/packages/cli/src/args.ts
+++ b/src/packages/cli/src/args.ts
@@ -151,15 +151,21 @@ export default function (version: string, isDocker: boolean) {
           const state = {};
           for (const option in categoryObj) {
             const optionObj = categoryObj[option];
-            processOption(state, category, group, option, optionObj, flavorArgs);
+            processOption(
+              state,
+              category,
+              group,
+              option,
+              optionObj,
+              flavorArgs
+            );
           }
         }
 
         const state = {};
         const categoryObj = serverDefaults.server;
-        const options = Object.keys(categoryObj);
         const group = "Server:";
-        for (const option of options) {
+        for (const option in categoryObj) {
           const optionObj = categoryObj[option];
 
           processOption(state, "server", group, option, optionObj, flavorArgs);

--- a/src/packages/core/index.ts
+++ b/src/packages/core/index.ts
@@ -2,7 +2,7 @@ import ConnectorLoader from "./src/connector-loader";
 import { ProviderOptions, ServerOptions } from "./src/options";
 import Server from "./src/server";
 
-export { ProviderOptions, ServerOptions } from "./src/options";
+export { ProviderOptions, ServerOptions, serverDefaults } from "./src/options";
 
 export default {
   server: (options?: ServerOptions) => new Server(options),

--- a/src/packages/core/src/options/server-options.ts
+++ b/src/packages/core/src/options/server-options.ts
@@ -40,12 +40,14 @@ export const ServerOptions: Definitions<ServerConfig> = {
     normalize,
     cliDescription: "Enable a websocket server.",
     default: () => true,
-    legacyName: "ws"
+    legacyName: "ws",
+    cliType: "boolean"
   },
   wsBinary: {
     normalize,
     cliDescription:
       "Whether or not websockets should response with binary data (ArrayBuffers) or strings.",
-    default: () => "auto"
+    default: () => "auto",
+    cliChoices: [true, false, "auto"]
   }
 };

--- a/src/packages/core/src/options/server-options.ts
+++ b/src/packages/core/src/options/server-options.ts
@@ -48,6 +48,6 @@ export const ServerOptions: Definitions<ServerConfig> = {
     cliDescription:
       "Whether or not websockets should response with binary data (ArrayBuffers) or strings.",
     default: () => "auto",
-    cliChoices: [true, false, "auto"]
+    cliChoices: [true, false, "auto"] as any[]
   }
 };


### PR DESCRIPTION
This PR adds the `@ganache/core` `server` options to the CLI. It also changes the default logger to be stdout as stated in the JSDoc