### PR TITLE
fix: ignore folders that are packages from another branch

### DIFF
--- a/scripts/link-ts-references.ts
+++ b/scripts/link-ts-references.ts
@@ -5,7 +5,7 @@
 
 import { resolve, join, relative } from "path";
 import glob from "glob";
-import { writeFileSync } from "fs-extra";
+import { writeFileSync, existsSync } from "fs-extra";
 
 type Mapping = { [key: string]: string };
 
@@ -142,7 +142,7 @@ const packageDirectories = flat(
   packages.map(pkg => {
     return glob.sync(pkg + "/", options);
   })
-);
+).filter(dir => existsSync(join(dir, "package.json")));
 
 function keys(object: {}) {
   return object ? Object.keys(object) : [];


### PR DESCRIPTION
If you checkout a branch that doesn't include a newly introduced package from your last branch (which you had ran `npm run tsc`), the `link-ts-references.ts` script erroneously picks it up as a folder without the necessary package files. This PR ignores folders that don't have a `package.json`