### PR TITLE
chore: add "push" action to "build all" on `develop`

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -35,7 +35,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    if: github.ref == 'refs/heads/chore/develop-build-all'
+    if: github.ref == 'refs/heads/develop'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,3 +25,47 @@ jobs:
       - run: npm test
         env:
           FORCE_COLOR: 1
+
+  build-all:
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [10.7.0, 10.x, 11.x, 12.x, 13.x, 14.x]
+        os: [windows-2019, ubuntu-16.04, ubuntu-18.04, macos-11.0]
+
+    runs-on: ${{ matrix.os }}
+
+    if: github.ref == 'refs/heads/chore/develop-build-all'
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      # we need build tools for the `bigint-buffer` module
+      - name: Add msbuild to PATH
+        if: startsWith(matrix.os, 'windows-')
+        uses: microsoft/setup-msbuild@v1.0.2
+      - name: Update npm for node 10.7.0
+        # lerna bootstrap was failing on node 10.7.0 with npm 6.1.0, updating
+        # to npm 6.4.1 seems to fix the problem
+        if: ${{ startsWith(matrix.os, 'windows-') && matrix.node == '10.7.0' }}
+        run: npm install npm@6.4.1 --global
+      - name: install node tools
+        if: startsWith(matrix.os, 'windows-')
+        # windows-build-tools@5.2.2 failed to install, so we use 4.0.0
+        run: npm install --global --production windows-build-tools@4.0.0
+      - name: install node-gyp
+        if: startsWith(matrix.os, 'windows-')
+        run: npm install --global node-gyp@latest
+      - name: Set node config to use python2.7
+        if: startsWith(matrix.os, 'windows-')
+        run: npm config set python python2.7
+      - name: Set node config to set msvs_version to 2015
+        if: startsWith(matrix.os, 'windows-')
+        run: npm config set msvs_version 2015
+      - run: npm ci
+      - run: npm test
+        env:
+          FORCE_COLOR: 1


### PR DESCRIPTION
This PR adds build jobs for the remaining parts of the build matrix for `push` events to `develop`

Here is an example of what it would look like: https://github.com/trufflesuite/ganache-core/actions/runs/497178739