### PR TITLE
fix(docs): update contributing url in readme to full path

### DIFF
--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -198,7 +198,7 @@ New RPC documentation coming soon! See https://github.com/trufflesuite/ganache-c
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for our guide to contributing to Ganache.
+See [CONTRIBUTING.md](https://github.com/trufflesuite/ganache-core/blob/develop/CONTRIBUTING.md) for our guide to contributing to Ganache.
 
 ## Related
 


### PR DESCRIPTION
Updating the contributing link to include the full path so it's not broken when published to npm, docker hub, etc