### PR TITLE
fix: set `difficulty` default to 1 and add `totalDifficulty`

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -765,7 +765,8 @@ export default class EthereumApi implements types.Api {
         parentHeader.miner,
         tx.gas,
         parentHeader.timestamp,
-        options.miner.difficulty
+        options.miner.difficulty,
+        parentHeader.totalDifficulty
       );
       const runArgs = {
         tx: tx,
@@ -1448,6 +1449,7 @@ export default class EthereumApi implements types.Api {
             logsBloom: header.logsBloom,
             miner: header.miner,
             difficulty: header.difficulty,
+            totalDifficulty: header.totalDifficulty,
             extraData: header.extraData,
             gasLimit: header.gasLimit,
             gasUsed: header.gasUsed,
@@ -1816,7 +1818,8 @@ export default class EthereumApi implements types.Api {
       blockchain.coinbase,
       gas.toBuffer(),
       parentHeader.timestamp,
-      options.miner.difficulty
+      options.miner.difficulty,
+      parentHeader.totalDifficulty
     );
 
     const simulatedTransaction = {

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -758,12 +758,14 @@ export default class EthereumApi implements types.Api {
           tx.gas = tx.gasLimit = options.miner.callGasLimit.toBuffer();
         }
       }
+
       const newBlock = new RuntimeBlock(
         Quantity.from((parentHeader.number.toBigInt() || 0n) + 1n),
         parentHeader.parentHash,
         parentHeader.miner,
         tx.gas,
-        parentHeader.timestamp
+        parentHeader.timestamp,
+        parentHeader.difficulty
       );
       const runArgs = {
         tx: tx,
@@ -1813,7 +1815,8 @@ export default class EthereumApi implements types.Api {
       parentHeader.parentHash,
       blockchain.coinbase,
       gas.toBuffer(),
-      parentHeader.timestamp
+      parentHeader.timestamp,
+      parentHeader.difficulty
     );
 
     const simulatedTransaction = {

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -765,7 +765,7 @@ export default class EthereumApi implements types.Api {
         parentHeader.miner,
         tx.gas,
         parentHeader.timestamp,
-        parentHeader.difficulty
+        options.miner.difficulty
       );
       const runArgs = {
         tx: tx,
@@ -1816,7 +1816,7 @@ export default class EthereumApi implements types.Api {
       blockchain.coinbase,
       gas.toBuffer(),
       parentHeader.timestamp,
-      parentHeader.difficulty
+      options.miner.difficulty
     );
 
     const simulatedTransaction = {

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -456,7 +456,8 @@ export default class Blockchain extends Emittery.Typed<
       previousBlock.hash(),
       this.coinbase,
       this.#options.miner.blockGasLimit.toBuffer(),
-      Quantity.from(timestamp == null ? this.#currentTime() : timestamp)
+      Quantity.from(timestamp == null ? this.#currentTime() : timestamp),
+      previousHeader.difficulty
     );
   };
 
@@ -555,7 +556,8 @@ export default class Blockchain extends Emittery.Typed<
       Quantity.from(BUFFER_32_ZERO),
       this.coinbase,
       blockGasLimit.toBuffer(),
-      Quantity.from(timestamp)
+      Quantity.from(timestamp),
+      this.#options.miner.difficulty
     );
 
     // store the genesis block in the database
@@ -897,7 +899,8 @@ export default class Blockchain extends Emittery.Typed<
       parentBlock.header.miner,
       parentBlock.header.gasLimit.toBuffer(),
       // make sure we use the same timestamp as the target block
-      targetBlock.header.timestamp
+      targetBlock.header.timestamp,
+      parentBlock.header.difficulty
     ) as RuntimeBlock & { uncleHeaders: []; transactions: Transaction[] };
     newBlock.transactions = [];
     newBlock.uncleHeaders = [];

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -457,7 +457,7 @@ export default class Blockchain extends Emittery.Typed<
       this.coinbase,
       this.#options.miner.blockGasLimit.toBuffer(),
       Quantity.from(timestamp == null ? this.#currentTime() : timestamp),
-      previousHeader.difficulty
+      this.#options.miner.difficulty
     );
   };
 
@@ -900,7 +900,7 @@ export default class Blockchain extends Emittery.Typed<
       parentBlock.header.gasLimit.toBuffer(),
       // make sure we use the same timestamp as the target block
       targetBlock.header.timestamp,
-      parentBlock.header.difficulty
+      this.#options.miner.difficulty
     ) as RuntimeBlock & { uncleHeaders: []; transactions: Transaction[] };
     newBlock.transactions = [];
     newBlock.uncleHeaders = [];

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -457,7 +457,8 @@ export default class Blockchain extends Emittery.Typed<
       this.coinbase,
       this.#options.miner.blockGasLimit.toBuffer(),
       Quantity.from(timestamp == null ? this.#currentTime() : timestamp),
-      this.#options.miner.difficulty
+      this.#options.miner.difficulty,
+      previousBlock.header.totalDifficulty
     );
   };
 
@@ -557,7 +558,8 @@ export default class Blockchain extends Emittery.Typed<
       this.coinbase,
       blockGasLimit.toBuffer(),
       Quantity.from(timestamp),
-      this.#options.miner.difficulty
+      this.#options.miner.difficulty,
+      Quantity.from(0) // we start the totalDifficulty at 0
     );
 
     // store the genesis block in the database
@@ -900,7 +902,8 @@ export default class Blockchain extends Emittery.Typed<
       parentBlock.header.gasLimit.toBuffer(),
       // make sure we use the same timestamp as the target block
       targetBlock.header.timestamp,
-      this.#options.miner.difficulty
+      this.#options.miner.difficulty,
+      parentBlock.header.totalDifficulty
     ) as RuntimeBlock & { uncleHeaders: []; transactions: Transaction[] };
     newBlock.transactions = [];
     newBlock.uncleHeaders = [];

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -559,7 +559,7 @@ export default class Blockchain extends Emittery.Typed<
       blockGasLimit.toBuffer(),
       Quantity.from(timestamp),
       this.#options.miner.difficulty,
-      Quantity.from(0) // we start the totalDifficulty at 0
+      RPCQUANTITY_ZERO // we start the totalDifficulty at 0
     );
 
     // store the genesis block in the database

--- a/src/chains/ethereum/ethereum/tests/api/eth/getBlockByNumber.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getBlockByNumber.test.ts
@@ -2,8 +2,7 @@ import assert from "assert";
 import EthereumProvider from "../../../src/provider";
 import getProvider from "../../helpers/getProvider";
 import compile from "../../helpers/compile";
-import { join } from "path";
-import { Quantity } from "@ganache/utils";
+const DEFAULT_DIFFICULTY = 1;
 
 describe("api", () => {
   describe("eth", () => {
@@ -19,16 +18,16 @@ describe("api", () => {
       });
 
       describe("difficulty", () => {
-        it("returns 1 for difficulty by default", async () => {
+        it("returns the block difficulty", async () => {
           const block = await provider.send("eth_getBlockByNumber", ["latest"]);
-          assert.strictEqual(block.difficulty, "0x1");
+          assert.strictEqual(block.difficulty, `0x${DEFAULT_DIFFICULTY}`);
         });
       });
 
       describe("totalDifficulty", () => {
-        it("returns 1 for genesis block totalDifficulty", async () => {
+        it("equals the block difficulty for the genesis block", async () => {
           const block = await provider.send("eth_getBlockByNumber", ["0x0"]);
-          assert.strictEqual(block.totalDifficulty, "0x1");
+          assert.strictEqual(block.totalDifficulty, `0x${DEFAULT_DIFFICULTY}`);
         });
       });
     });

--- a/src/chains/ethereum/ethereum/tests/api/eth/getBlockByNumber.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getBlockByNumber.test.ts
@@ -1,0 +1,36 @@
+import assert from "assert";
+import EthereumProvider from "../../../src/provider";
+import getProvider from "../../helpers/getProvider";
+import compile from "../../helpers/compile";
+import { join } from "path";
+import { Quantity } from "@ganache/utils";
+
+describe("api", () => {
+  describe("eth", () => {
+    describe("getBlockByNumber", () => {
+      let provider: EthereumProvider;
+
+      before(async () => {
+        provider = await getProvider();
+      });
+
+      after(async () => {
+        provider && (await provider.disconnect());
+      });
+
+      describe("difficulty", () => {
+        it("returns 1 for difficulty by default", async () => {
+          const block = await provider.send("eth_getBlockByNumber", ["latest"]);
+          assert.strictEqual(block.difficulty, "0x1");
+        });
+      });
+
+      describe("totalDifficulty", () => {
+        it("returns 1 for genesis block totalDifficulty", async () => {
+          const block = await provider.send("eth_getBlockByNumber", ["0x0"]);
+          assert.strictEqual(block.totalDifficulty, "0x1");
+        });
+      });
+    });
+  });
+});

--- a/src/chains/ethereum/ethereum/tests/api/eth/getBlockByNumber.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getBlockByNumber.test.ts
@@ -3,21 +3,31 @@ import EthereumProvider from "../../../src/provider";
 import getProvider from "../../helpers/getProvider";
 import compile from "../../helpers/compile";
 const DEFAULT_DIFFICULTY = 1;
+let provider: EthereumProvider;
+
+// helper to mine an arbitrary number of blocks using dummy transactions
+const mineBlocks = async (number: number, provider: EthereumProvider) => {
+  const [from] = await provider.send("eth_accounts");
+  for (let x = number; x > 0; x--) {
+    await provider.send("eth_subscribe", ["newHeads"]);
+
+    await provider.send("eth_sendTransaction", [{ from, to: from }]);
+
+    await provider.once("message");
+  }
+};
 
 describe("api", () => {
   describe("eth", () => {
     describe("getBlockByNumber", () => {
-      let provider: EthereumProvider;
-
-      before(async () => {
-        provider = await getProvider();
-      });
-
-      after(async () => {
-        provider && (await provider.disconnect());
-      });
-
       describe("difficulty", () => {
+        beforeEach(async () => {
+          provider = await getProvider();
+        });
+
+        afterEach(async () => {
+          provider && (await provider.disconnect());
+        });
         it("returns the block difficulty", async () => {
           const block = await provider.send("eth_getBlockByNumber", ["latest"]);
           assert.strictEqual(block.difficulty, `0x${DEFAULT_DIFFICULTY}`);
@@ -25,9 +35,63 @@ describe("api", () => {
       });
 
       describe("totalDifficulty", () => {
-        it("equals the block difficulty for the genesis block", async () => {
-          const block = await provider.send("eth_getBlockByNumber", ["0x0"]);
-          assert.strictEqual(block.totalDifficulty, `0x${DEFAULT_DIFFICULTY}`);
+        describe("when the default values are used", () => {
+          beforeEach(async () => {
+            provider = await getProvider();
+          });
+          afterEach(async () => {
+            provider && (await provider.disconnect());
+          });
+
+          it("equals the block difficulty for the genesis block", async () => {
+            const block = await provider.send("eth_getBlockByNumber", ["0x0"]);
+            assert.strictEqual(
+              block.totalDifficulty,
+              `0x${DEFAULT_DIFFICULTY}`
+            );
+          });
+          it("equals the sum of the difficulty of all blocks (hex)", async () => {
+            const numberOfBlocksToMine = Math.floor(Math.random() * 10 + 1);
+            await mineBlocks(numberOfBlocksToMine, provider);
+            const block = await provider.send("eth_getBlockByNumber", [
+              `0x${numberOfBlocksToMine}`
+            ]);
+            assert.strictEqual(
+              block.totalDifficulty,
+              `0x${((numberOfBlocksToMine + 1) * DEFAULT_DIFFICULTY).toString(
+                16
+              )}`
+            );
+          });
+        });
+
+        describe("when the difficulty is set manually", () => {
+          let difficulty;
+          beforeEach(async () => {
+            difficulty = Math.floor(Math.random() * 9 + 1);
+            provider = await getProvider({
+              miner: { difficulty }
+            });
+          });
+          afterEach(async () => {
+            provider && (await provider.disconnect());
+          });
+
+          it("equals the block difficulty for the genesis block", async () => {
+            const block = await provider.send("eth_getBlockByNumber", ["0x0"]);
+            assert.strictEqual(block.totalDifficulty, `0x${difficulty}`);
+          });
+          it("equals the sum of the difficulty of all blocks (hex)", async () => {
+            const numberOfBlocksToMine = Math.floor(Math.random() * 10 + 1);
+            await mineBlocks(numberOfBlocksToMine, provider);
+            const block = await provider.send("eth_getBlockByNumber", [
+              `0x${numberOfBlocksToMine}`
+            ]);
+            assert.strictEqual(
+              block.totalDifficulty,
+              `0x${((numberOfBlocksToMine + 1) * difficulty).toString(16)}`
+            );
+          });
         });
       });
     });

--- a/src/chains/ethereum/ethereum/tests/api/eth/getBlockByNumber.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getBlockByNumber.test.ts
@@ -5,18 +5,6 @@ import compile from "../../helpers/compile";
 const DEFAULT_DIFFICULTY = 1;
 let provider: EthereumProvider;
 
-// helper to mine an arbitrary number of blocks using dummy transactions
-const mineBlocks = async (number: number, provider: EthereumProvider) => {
-  const [from] = await provider.send("eth_accounts");
-  for (let x = number; x > 0; x--) {
-    await provider.send("eth_subscribe", ["newHeads"]);
-
-    await provider.send("eth_sendTransaction", [{ from, to: from }]);
-
-    await provider.once("message");
-  }
-};
-
 describe("api", () => {
   describe("eth", () => {
     describe("getBlockByNumber", () => {
@@ -24,10 +12,10 @@ describe("api", () => {
         beforeEach(async () => {
           provider = await getProvider();
         });
-
         afterEach(async () => {
           provider && (await provider.disconnect());
         });
+
         it("returns the block difficulty", async () => {
           const block = await provider.send("eth_getBlockByNumber", ["latest"]);
           assert.strictEqual(
@@ -55,7 +43,7 @@ describe("api", () => {
           });
           it("equals the sum of the difficulty of all blocks (hex)", async () => {
             const numberOfBlocksToMine = Math.floor(Math.random() * 10 + 1);
-            await mineBlocks(numberOfBlocksToMine, provider);
+            await provider.send("evm_mine", [{ blocks: numberOfBlocksToMine }]);
             const block = await provider.send("eth_getBlockByNumber", [
               `0x${numberOfBlocksToMine}`
             ]);
@@ -89,7 +77,7 @@ describe("api", () => {
           });
           it("equals the sum of the difficulty of all blocks (hex)", async () => {
             const numberOfBlocksToMine = Math.floor(Math.random() * 10 + 1);
-            await mineBlocks(numberOfBlocksToMine, provider);
+            await provider.send("evm_mine", [{ blocks: numberOfBlocksToMine }]);
             const block = await provider.send("eth_getBlockByNumber", [
               `0x${numberOfBlocksToMine}`
             ]);

--- a/src/chains/ethereum/ethereum/tests/api/eth/getBlockByNumber.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getBlockByNumber.test.ts
@@ -30,7 +30,10 @@ describe("api", () => {
         });
         it("returns the block difficulty", async () => {
           const block = await provider.send("eth_getBlockByNumber", ["latest"]);
-          assert.strictEqual(block.difficulty, `0x${DEFAULT_DIFFICULTY}`);
+          assert.strictEqual(
+            block.difficulty,
+            `0x${DEFAULT_DIFFICULTY.toString(16)}`
+          );
         });
       });
 
@@ -47,7 +50,7 @@ describe("api", () => {
             const block = await provider.send("eth_getBlockByNumber", ["0x0"]);
             assert.strictEqual(
               block.totalDifficulty,
-              `0x${DEFAULT_DIFFICULTY}`
+              `0x${DEFAULT_DIFFICULTY.toString(16)}`
             );
           });
           it("equals the sum of the difficulty of all blocks (hex)", async () => {
@@ -79,7 +82,10 @@ describe("api", () => {
 
           it("equals the block difficulty for the genesis block", async () => {
             const block = await provider.send("eth_getBlockByNumber", ["0x0"]);
-            assert.strictEqual(block.totalDifficulty, `0x${difficulty}`);
+            assert.strictEqual(
+              block.totalDifficulty,
+              `0x${difficulty.toString(16)}`
+            );
           });
           it("equals the sum of the difficulty of all blocks (hex)", async () => {
             const numberOfBlocksToMine = Math.floor(Math.random() * 10 + 1);

--- a/src/chains/ethereum/ethereum/tests/api/eth/getBlockByNumber.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getBlockByNumber.test.ts
@@ -45,7 +45,7 @@ describe("api", () => {
             const numberOfBlocksToMine = Math.floor(Math.random() * 10 + 1);
             await provider.send("evm_mine", [{ blocks: numberOfBlocksToMine }]);
             const block = await provider.send("eth_getBlockByNumber", [
-              `0x${numberOfBlocksToMine}`
+              `0x${numberOfBlocksToMine.toString(16)}`
             ]);
             assert.strictEqual(
               block.totalDifficulty,

--- a/src/chains/ethereum/ethereum/tests/api/eth/getBlockByNumber.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getBlockByNumber.test.ts
@@ -79,7 +79,7 @@ describe("api", () => {
             const numberOfBlocksToMine = Math.floor(Math.random() * 10 + 1);
             await provider.send("evm_mine", [{ blocks: numberOfBlocksToMine }]);
             const block = await provider.send("eth_getBlockByNumber", [
-              `0x${numberOfBlocksToMine}`
+              `0x${numberOfBlocksToMine.toString(16)}`
             ]);
             assert.strictEqual(
               block.totalDifficulty,

--- a/src/chains/ethereum/ethereum/tests/api/eth/subscribe.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/subscribe.test.ts
@@ -69,19 +69,20 @@ describe("api", () => {
             type: "eth_subscription",
             data: {
               result: {
-                difficulty: "0x0",
+                difficulty: "0x1",
+                totalDifficulty: "0x2",
                 extraData: "0x",
                 gasLimit: gasLimit,
                 gasUsed: "0x0",
                 hash:
-                  "0x7ffe37737a6a39477f0cd9eeb632a6b393c440ad17b6e82fcbe1ebf6556d768c",
+                  "0x8fe2cfd8278173d82040e23e2d593e82fa616170d5c37746c4ce6e0fc257a0af",
                 logsBloom: `0x${"0".repeat(512)}`,
                 miner: `0x${"0".repeat(40)}`,
                 mixHash: `0x${"0".repeat(64)}`,
                 nonce: "0x0000000000000000",
                 number: Quantity.from(startingBlockNumber + 1).toString(),
                 parentHash:
-                  "0x48ba6f672feca71b75568153ce81c75d0a8074c935d4ab2a23fc7dd64dd13fe2",
+                  "0x595a52280133ab1b357af73a10a8ac8a4f4283d24ae8766581e21e49c8292fab",
                 receiptsRoot:
                   "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
                 sha3Uncles:

--- a/src/chains/ethereum/ethereum/tests/api/eth/subscribe.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/subscribe.test.ts
@@ -75,14 +75,14 @@ describe("api", () => {
                 gasLimit: gasLimit,
                 gasUsed: "0x0",
                 hash:
-                  "0x8fe2cfd8278173d82040e23e2d593e82fa616170d5c37746c4ce6e0fc257a0af",
+                  "0x29ba0a09b00a67f86f6b3a82c77170c03f849eee3cd2188f21376099d65efa8f",
                 logsBloom: `0x${"0".repeat(512)}`,
                 miner: `0x${"0".repeat(40)}`,
                 mixHash: `0x${"0".repeat(64)}`,
                 nonce: "0x0000000000000000",
                 number: Quantity.from(startingBlockNumber + 1).toString(),
                 parentHash:
-                  "0x595a52280133ab1b357af73a10a8ac8a4f4283d24ae8766581e21e49c8292fab",
+                  "0x112ca33fb66d027956f21da2d1acededbc94b89b878ff886f7985df7d991012a",
                 receiptsRoot:
                   "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
                 sha3Uncles:

--- a/src/chains/ethereum/options/src/miner-options.ts
+++ b/src/chains/ethereum/options/src/miner-options.ts
@@ -44,6 +44,16 @@ export type MinerConfig = {
     };
 
     /**
+     * Sets the block difficulty
+     * @default 1
+     */
+    difficulty: {
+      type: Quantity;
+      rawType: string | number;
+      hasDefault: true;
+    };
+
+    /**
      * Sets the block gas limit in WEI.
      *
      * @default 12_000_000
@@ -171,6 +181,12 @@ export const MinerOptions: Definitions<MinerConfig> = {
     cliDescription:
       'Sets the default transaction gas limit in WEI. Set to "estimate" to use an estimate (slows down transaction execution by 40%+).',
     default: () => Quantity.from(90_000),
+    cliType: "string"
+  },
+  difficulty: {
+    normalize: Quantity.from,
+    cliDescription: "Sets the block difficulty for the network.",
+    default: () => Quantity.from(1),
     cliType: "string"
   },
   callGasLimit: {

--- a/src/chains/ethereum/options/src/miner-options.ts
+++ b/src/chains/ethereum/options/src/miner-options.ts
@@ -49,7 +49,7 @@ export type MinerConfig = {
      */
     difficulty: {
       type: Quantity;
-      rawType: string | number;
+      rawType: number;
       hasDefault: true;
     };
 
@@ -187,7 +187,7 @@ export const MinerOptions: Definitions<MinerConfig> = {
     normalize: Quantity.from,
     cliDescription: "Sets the block difficulty for the network.",
     default: () => Quantity.from(1),
-    cliType: "string"
+    cliType: "number"
   },
   callGasLimit: {
     normalize: Quantity.from,

--- a/src/chains/ethereum/options/src/miner-options.ts
+++ b/src/chains/ethereum/options/src/miner-options.ts
@@ -186,7 +186,7 @@ export const MinerOptions: Definitions<MinerConfig> = {
   },
   difficulty: {
     normalize: Quantity.from,
-    cliDescription: "Sets the block difficulty for the network.",
+    cliDescription: "Sets the block difficulty.",
     default: () => Quantity.from(1),
     cliType: "number"
   },

--- a/src/chains/ethereum/options/src/miner-options.ts
+++ b/src/chains/ethereum/options/src/miner-options.ts
@@ -45,7 +45,7 @@ export type MinerConfig = {
 
     /**
      * Sets the block difficulty
-
+     *
      * @default 1
      */
     difficulty: {

--- a/src/chains/ethereum/options/src/miner-options.ts
+++ b/src/chains/ethereum/options/src/miner-options.ts
@@ -187,7 +187,7 @@ export const MinerOptions: Definitions<MinerConfig> = {
   difficulty: {
     normalize: Quantity.from,
     cliDescription: "Sets the block difficulty.",
-    default: () => Quantity.from(1),
+    default: () => utils.RPCQUANTITY_ONE,
     cliType: "number"
   },
   callGasLimit: {

--- a/src/chains/ethereum/options/src/miner-options.ts
+++ b/src/chains/ethereum/options/src/miner-options.ts
@@ -45,6 +45,7 @@ export type MinerConfig = {
 
     /**
      * Sets the block difficulty
+
      * @default 1
      */
     difficulty: {

--- a/src/chains/ethereum/utils/src/things/runtime-block.ts
+++ b/src/chains/ethereum/utils/src/things/runtime-block.ts
@@ -144,6 +144,7 @@ export class Block {
 export class RuntimeBlock {
   public readonly header: {
     parentHash: Buffer;
+    difficulty: Buffer;
     coinbase: Buffer;
     number: Buffer;
     gasLimit: Buffer;
@@ -155,13 +156,15 @@ export class RuntimeBlock {
     parentHash: Data,
     coinbase: Address,
     gasLimit: Buffer,
-    timestamp: Quantity
+    timestamp: Quantity,
+    difficulty: Quantity
   ) {
     const ts = timestamp.toBuffer();
     this.header = {
       parentHash: parentHash.toBuffer(),
       coinbase: coinbase.toBuffer(),
       number: number.toBuffer(),
+      difficulty: difficulty.toBuffer(),
       gasLimit: gasLimit.length === 0 ? BUFFER_EMPTY : gasLimit,
       timestamp: ts.length === 0 ? BUFFER_EMPTY : ts
     };
@@ -197,7 +200,7 @@ export class RuntimeBlock {
       transactionsTrie,
       receiptTrie,
       bloom,
-      BUFFER_EMPTY, // difficulty
+      header.difficulty,
       header.number,
       header.gasLimit,
       gasUsed,


### PR DESCRIPTION
Currently Ganache sets all block headers to have `difficulty` and `totalDifficulty` hard-coded to 0. This PR causes Ganache to set the difficulty of each block (by default) to 1 (the user can specify their own block difficulty on the command line). The `totalDifficulty` is also now calculated based on the previous block's `totalDifficulty` and the block difficulty.