### PR TITLE
fix: handle exiting better for CLI

### DIFF
--- a/src/packages/cli/src/cli.ts
+++ b/src/packages/cli/src/cli.ts
@@ -48,6 +48,7 @@ const server = Ganache.server(argv);
 console.log(detailedVersion);
 
 let started = false;
+let shuttingDown = false;
 process.on("uncaughtException", function (e) {
   if (started) {
     logAndForceExit([e], 1);
@@ -69,12 +70,20 @@ if (process.platform === "win32") {
 }
 
 const closeHandler = async function () {
+  if (shuttingDown) {
+    logAndForceExit(["User requested to force quit."], 1);
+    return; // should not get here because of process.exit() but just in case
+  }
+
   try {
     // graceful shutdown
     if (server.status === 1) {
+      console.log(
+        "Attempting to gracefully shut down Ganache. Press Ctrl+C again to force quit."
+      );
       await server.close();
     }
-    process.exitCode = 0;
+    process.exit(0);
   } catch (err) {
     logAndForceExit(
       [


### PR DESCRIPTION
This PR fixes #773. I'm not sure what's different about windows here, but a couple of things that ensures things close (and reasonably gracefully):
1. Changing `process.exitCode = 0` to `process.exit(0)`. The [former](https://nodejs.org/dist/latest-v14.x/docs/api/process.html#process_process_exitcode) does not exit; it just sets the code for whenever the process does exit. However, the process would only exit if the server's `listen` (or some other dangling open function handle) all close out. We shouldn't wait for this, and apparently on Windows it does not close. This fixes the issue.
1. I also added a force quit option here if for some reason `await server.close()` takes a really long time. This was my original though of the bug, so I implemented this, only to find out that `await server.close()` was not the issue. I left it in for good measure. Do note I verified that [node uses 'Ctrl+C' terminology on Mac as well](https://github.com/nodejs/node/blob/master/lib/repl.js#L778)