### PR TITLE
feat: log warning on legacy-style eth_getTransactionReceipt calls

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -1201,16 +1201,19 @@ export default class EthereumApi implements types.Api {
     ]);
     if (transaction) {
       return receipt.toJSON(block, transaction);
-    } else if (
-      this.#options.miner.blockTime <= 0 &&
-      this.#options.miner.legacyInstamine !== true &&
+    }
+
+    const options = this.#options;
+    if (
+      options.miner.blockTime <= 0 &&
+      options.miner.legacyInstamine !== true &&
       this.#blockchain.isStarted()
     ) {
       // if we are performing non-legacy instamining, then check to see if the
       // transaction is pending so as to warn about the v7 breaking change
       const tx = this.#blockchain.transactions.transactionPool.find(txHash);
       if (tx != null) {
-        this.#options.logging.logger.log(
+        options.logging.logger.log(
           " > Ganache `eth_getTransactionReceipt` notice: the transaction with hash\n" +
             ` > \`${txHash.toString()}\` has not\n` +
             " > yet been mined. See https://trfl.co/v7-instamine for additional information."

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -1202,6 +1202,17 @@ export default class EthereumApi implements types.Api {
     if (transaction) {
       return receipt.toJSON(block, transaction);
     } else {
+      // check to see if the transaction is pending
+      const tx = this.#blockchain.transactions.transactionPool.find(txHash);
+      if (tx != null) {
+        this.#options.logging.logger.log(
+          " > Ganache `eth_getTransactionReceipt` warning: the requested transaction has not yet been mined."
+        );
+        this.#options.logging.logger.log(
+          " > After it has been mined you will be able to obtain the receipt. See https://trfl.co/v7-instamine for more details."
+        );
+      }
+
       return null;
     }
   }

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -1203,14 +1203,14 @@ export default class EthereumApi implements types.Api {
       return receipt.toJSON(block, transaction);
     }
 
+    // if we are performing non-legacy instamining, then check to see if the
+    // transaction is pending so as to warn about the v7 breaking change
     const options = this.#options;
     if (
       options.miner.blockTime <= 0 &&
       options.miner.legacyInstamine !== true &&
       this.#blockchain.isStarted()
     ) {
-      // if we are performing non-legacy instamining, then check to see if the
-      // transaction is pending so as to warn about the v7 breaking change
       const tx = this.#blockchain.transactions.transactionPool.find(txHash);
       if (tx != null) {
         options.logging.logger.log(

--- a/src/chains/ethereum/ethereum/src/provider.ts
+++ b/src/chains/ethereum/ethereum/src/provider.ts
@@ -266,6 +266,8 @@ export default class EthereumProvider
             : JSON.stringify(params, null, 2).split("\n").join("\n   > ")
         }`
       );
+    } else {
+      options.logging.logger.log(method);
     }
   };
 

--- a/src/chains/ethereum/ethereum/tests/api/eth/getTransactionReceipt.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getTransactionReceipt.test.ts
@@ -17,7 +17,7 @@ describe("api", () => {
           loggedStuff: "",
           log: function (message) {
             if (message) {
-              this.loggedStuff = this.loggedStuff.concat(message);
+              this.loggedStuff += message;
             }
           }
         };

--- a/src/chains/ethereum/ethereum/tests/api/eth/getTransactionReceipt.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getTransactionReceipt.test.ts
@@ -103,7 +103,7 @@ describe("api", () => {
           );
         });
 
-        it("doesn't log the notice when the chain is stopped", async () => {
+        it("doesn't log when the chain is stopped", async () => {
           await provider.send("miner_stop", []);
           const hash = await provider.send("eth_sendTransaction", [
             { from, to: from }

--- a/src/chains/ethereum/ethereum/tests/api/eth/getTransactionReceipt.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getTransactionReceipt.test.ts
@@ -1,0 +1,74 @@
+import getProvider from "../../helpers/getProvider";
+import assert from "assert";
+import EthereumProvider from "../../../src/provider";
+
+describe("api", () => {
+  describe("eth", () => {
+    describe("getTransactionReceipt", () => {
+      let provider: EthereumProvider;
+      let logger;
+
+      beforeEach(async () => {
+        // create a logger to test output
+        logger = {
+          clearLoggedStuff: function () {
+            this.loggedStuff = "";
+          },
+          loggedStuff: "",
+          log: function (message) {
+            if (message) {
+              this.loggedStuff = this.loggedStuff.concat(message);
+            }
+          }
+        };
+        provider = await getProvider({ logging: { logger } });
+      });
+
+      it("returns the receipt for the transaction", async () => {
+        const [from] = await provider.send("eth_accounts");
+        await provider.send("eth_subscribe", ["newHeads"]);
+
+        const hash = await provider.send("eth_sendTransaction", [
+          {
+            from,
+            to: from
+          }
+        ]);
+
+        // wait for the tx to be mined
+        await provider.once("message");
+        const receipt = await provider.send("eth_getTransactionReceipt", [
+          hash
+        ]);
+        assert(receipt);
+      });
+
+      it("returns null if the transaction does not exist", async () => {
+        const result = await provider.send("eth_getTransactionReceipt", [
+          "0x0"
+        ]);
+        assert.strictEqual(result, null);
+      });
+
+      it("logs a warning if the transaction hasn't been mined yet", async () => {
+        logger.clearLoggedStuff();
+        const [from] = await provider.send("eth_accounts");
+
+        const hash = await provider.send("eth_sendTransaction", [
+          {
+            from,
+            to: from
+          }
+        ]);
+
+        // do not wait for the tx to be mined which will create a warning
+        await provider.send("eth_getTransactionReceipt", [hash]);
+        assert(
+          logger.loggedStuff.includes(
+            "Ganache `eth_getTransactionReceipt` warning"
+          )
+        );
+      });
+    });
+  });
+});

--- a/src/chains/ethereum/ethereum/tests/api/eth/getTransactionReceipt.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getTransactionReceipt.test.ts
@@ -47,7 +47,7 @@ describe("api", () => {
         assert(receipt);
         assert(
           !logger.loggedStuff.includes(
-            "Ganache `eth_getTransactionReceipt` warning"
+            "Ganache `eth_getTransactionReceipt` notice"
           )
         );
       });
@@ -59,12 +59,12 @@ describe("api", () => {
         assert.strictEqual(result, null);
         assert(
           !logger.loggedStuff.includes(
-            "Ganache `eth_getTransactionReceipt` warning"
+            "Ganache `eth_getTransactionReceipt` notice"
           )
         );
       });
 
-      describe("legacy instamine detection and warning", () => {
+      describe("legacy instamine detection and notice", () => {
         it("logs a warning if the transaction hasn't been mined yet", async () => {
           const [from] = await provider.send("eth_accounts");
 
@@ -83,7 +83,36 @@ describe("api", () => {
           assert.strictEqual(result, null);
           assert(
             logger.loggedStuff.includes(
-              "Ganache `eth_getTransactionReceipt` warning"
+              "Ganache `eth_getTransactionReceipt` notice"
+            )
+          );
+        });
+
+        it("doesn't log when instamine is not enabled", async () => {
+          const nonInstamineProvider = await getProvider({
+            logging: { logger },
+            miner: { blockTime: 1 }
+          });
+
+          const [from] = await nonInstamineProvider.send("eth_accounts");
+
+          const hash = await nonInstamineProvider.send("eth_sendTransaction", [
+            {
+              from,
+              to: from
+            }
+          ]);
+
+          // do not wait for the tx to be mined which will create a warning
+          const result = await nonInstamineProvider.send(
+            "eth_getTransactionReceipt",
+            [hash]
+          );
+
+          assert.strictEqual(result, null);
+          assert(
+            !logger.loggedStuff.includes(
+              "Ganache `eth_getTransactionReceipt` notice"
             )
           );
         });

--- a/src/chains/ethereum/ethereum/tests/api/eth/getTransactionReceipt.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getTransactionReceipt.test.ts
@@ -24,6 +24,10 @@ describe("api", () => {
         provider = await getProvider({ logging: { logger } });
       });
 
+      afterEach(() => {
+        logger.clearLoggedStuff();
+      });
+
       it("returns the receipt for the transaction", async () => {
         const [from] = await provider.send("eth_accounts");
         await provider.send("eth_subscribe", ["newHeads"]);
@@ -51,7 +55,6 @@ describe("api", () => {
       });
 
       it("logs a warning if the transaction hasn't been mined yet", async () => {
-        logger.clearLoggedStuff();
         const [from] = await provider.send("eth_accounts");
 
         const hash = await provider.send("eth_sendTransaction", [

--- a/src/chains/ethereum/ethereum/tests/api/eth/getTransactionReceipt.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getTransactionReceipt.test.ts
@@ -45,6 +45,11 @@ describe("api", () => {
           hash
         ]);
         assert(receipt);
+        assert(
+          !logger.loggedStuff.includes(
+            "Ganache `eth_getTransactionReceipt` warning"
+          )
+        );
       });
 
       it("returns null if the transaction does not exist", async () => {
@@ -52,6 +57,11 @@ describe("api", () => {
           "0x0"
         ]);
         assert.strictEqual(result, null);
+        assert(
+          !logger.loggedStuff.includes(
+            "Ganache `eth_getTransactionReceipt` warning"
+          )
+        );
       });
 
       describe("legacy instamine detection and warning", () => {

--- a/src/chains/ethereum/ethereum/tests/api/eth/getTransactionReceipt.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getTransactionReceipt.test.ts
@@ -54,23 +54,29 @@ describe("api", () => {
         assert.strictEqual(result, null);
       });
 
-      it("logs a warning if the transaction hasn't been mined yet", async () => {
-        const [from] = await provider.send("eth_accounts");
+      describe("legacy instamine detection and warning", () => {
+        it("logs a warning if the transaction hasn't been mined yet", async () => {
+          const [from] = await provider.send("eth_accounts");
 
-        const hash = await provider.send("eth_sendTransaction", [
-          {
-            from,
-            to: from
-          }
-        ]);
+          const hash = await provider.send("eth_sendTransaction", [
+            {
+              from,
+              to: from
+            }
+          ]);
 
-        // do not wait for the tx to be mined which will create a warning
-        await provider.send("eth_getTransactionReceipt", [hash]);
-        assert(
-          logger.loggedStuff.includes(
-            "Ganache `eth_getTransactionReceipt` warning"
-          )
-        );
+          // do not wait for the tx to be mined which will create a warning
+          const result = await provider.send("eth_getTransactionReceipt", [
+            hash
+          ]);
+
+          assert.strictEqual(result, null);
+          assert(
+            logger.loggedStuff.includes(
+              "Ganache `eth_getTransactionReceipt` warning"
+            )
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
In Ganache v7, instamining will be enabled by default but implemented in a different way than v6.

In v6, a transaction is sent, Ganache mines the transaction, and then returns the transaction hash. This enables the user to immediately request the transaction receipt via `eth_getTransactionReceipt`. This is, however, not how nodes in the wild behave. In the wild, the transaction hash is returned to the user and then the user will need to wait until the transaction is mined before requesting the receipt. If they request the receipt before it is mined, they will receive a `null` response.

For v7, this behavior is modified to more accurately reflect what a user will experience from a node in the wild. This may be problematic for some folks upgrading as tests will probably break etc. In order to help them upgrade with more ease, a warning message is implemented here to help them understand the situation.