### PR TITLE
refactor: replace seedCounter w/ an instance prng

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -1910,9 +1910,7 @@ export default class EthereumApi implements types.Api {
     }
 
     const wallet = this.#wallet;
-    const newAccount = wallet.createRandomAccount(
-      this.#options.wallet.mnemonic
-    );
+    const newAccount = wallet.createRandomAccount();
     const address = newAccount.address;
     const strAddress = address.toString();
     const encryptedKeyFile = await wallet.encrypt(

--- a/src/chains/ethereum/ethereum/src/wallet.ts
+++ b/src/chains/ethereum/ethereum/src/wallet.ts
@@ -188,14 +188,13 @@ export default class Wallet {
     //#endregion
   }
 
-  #seedCounter = 0n;
+  #randomRng = rng("ganache");
 
   #randomBytes = (length: number) => {
     // Since this is a mock RPC library, the rng doesn't need to be
     // cryptographically secure, and determinism is desired.
     const buf = Buffer.allocUnsafe(length);
-    const seed = (this.#seedCounter += 1n);
-    const rand = rng(seed.toString());
+    const rand = this.#randomRng;
     for (let i = 0; i < length; i++) {
       buf[i] = (rand() * 256) | 0; // generates a random number from 0 to 255
     }


### PR DESCRIPTION
I'm unsure why I implemented the wallet rng with it's own internal RNG state, but it doesn't seem neccessary.

In fact, the prng we use (alea) has a period of ~2^116 , whereas we'd start seeing weirdness at Number.MAX_SAFE_INTEGER (because `Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2`