### PR TITLE
feat: accept cli args over env vars

### DIFF
--- a/src/packages/cli/src/args.ts
+++ b/src/packages/cli/src/args.ts
@@ -151,6 +151,7 @@ export default function (version: string, isDocker: boolean) {
     TruffleColors.porsche
   }").bold ${center(version)}}`;
   let args = yargs
+    .env("GANACHE")
     // disable dot-notation because yargs just can't coerce args properly...
     // ...on purpose! https://github.com/yargs/yargs/issues/1021#issuecomment-352324693
     .parserConfiguration({ "dot-notation": false })


### PR DESCRIPTION
You can now do `$ GANACHE_wallet__totalAccounts=5 ganache` instead of `$ ganache --wallet.totalAccounts 5` -- a feature which was previously requested [here](https://github.com/trufflesuite/ganache-cli/pull/590).

I've found it is a nice feature to have when CLI tool is used in an npm package script, as I don't need to configure the script to accept the params (via `command -- args`).

Options are applied in the following order: ENV vars, config file, cli options. We don't yet support config-file parsing, but I'll add it in a future PR.