### PR TITLE
feat: accept cli args via json and package.json

### DIFF
--- a/src/packages/cli/src/args.ts
+++ b/src/packages/cli/src/args.ts
@@ -108,6 +108,8 @@ function processOption(
 
 export default function (version: string, isDocker: boolean) {
   let args = yargs
+    .config()
+    .pkgConf("ganache")
     // disable dot-notation because yargs just can't coerce args properly...
     // ...on purpose! https://github.com/yargs/yargs/issues/1021#issuecomment-352324693
     .parserConfiguration({ "dot-notation": false })


### PR DESCRIPTION
This enables doing `ganache --config my-config.json` where `my-config.json` is

```json
{
  "wallet.totalAccounts": 5
}
```

This _also_ enables setting the same config object in the project's `package.json` under the "ganache" field. e.g., 

```json5
{
  // ... rest of package.json
  "ganache": {
    "wallet.totalAccounts": 5
  }
}
```

We probably want to kick this one down the road, as the preferred way of specifying options is to set `"wallet": {"totalAccounts": 5}}`. We disabled yargs' dot-notation feature because of the way yargs parses dot-notation arguments didn't work well for us (I can't remember exactly what the problem was right now); and now the side effect is that it doesn't parse these config files the way we want.