### PR TITLE
add support for Filecoin.StateMinerPower method

### DIFF
--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -18,6 +18,8 @@ import Emittery from "emittery";
 import { HeadChange, HeadChangeType } from "./things/head-change";
 import { SubscriptionMethod, SubscriptionId } from "./types/subscriptions";
 import { FileRef, SerializedFileRef } from "./things/file-ref";
+import { MinerPower, SerializedMinerPower } from "./things/miner-power";
+import { PowerClaim } from "./things/power-claim";
 
 export default class FilecoinApi implements types.Api {
   readonly [index: string]: (...args: any) => Promise<any>;
@@ -128,6 +130,40 @@ export default class FilecoinApi implements types.Api {
 
   async "Filecoin.StateListMiners"(): Promise<Array<string>> {
     return [this.#blockchain.miner];
+  }
+
+  async "Filecoin.StateMinerPower"(
+    minerAddress: string
+  ): Promise<SerializedMinerPower> {
+    if (minerAddress === this.#blockchain.miner.value) {
+      const power = new MinerPower({
+        minerPower: new PowerClaim({
+          rawBytePower: 1n,
+          qualityAdjPower: 1n
+        }),
+        totalPower: new PowerClaim({
+          rawBytePower: 1n,
+          qualityAdjPower: 1n
+        }),
+        hasMinPower: false
+      });
+
+      return power.serialize();
+    } else {
+      const power = new MinerPower({
+        minerPower: new PowerClaim({
+          rawBytePower: 0n,
+          qualityAdjPower: 0n
+        }),
+        totalPower: new PowerClaim({
+          rawBytePower: 0n,
+          qualityAdjPower: 0n
+        }),
+        hasMinPower: false
+      });
+
+      return power.serialize();
+    }
   }
 
   async "Filecoin.WalletDefaultAddress"(): Promise<SerializedAddress> {

--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -132,21 +132,31 @@ export default class FilecoinApi implements types.Api {
     return [this.#blockchain.miner];
   }
 
+  // "A storage miner's storage power is a value roughly proportional
+  // to the amount of storage capacity they make available on behalf
+  // of the network via capacity commitments or storage deals."
+  // https://docs.filecoin.io/reference/glossary/#storage-power
+  // Since Ganache is currently only supporting 1 miner per Ganache
+  // instance, then it will have a raw byte power of 1n and everything else will
+  // have 0n. This indicates the supported miner contains all of the storage
+  // power for the entire network (which is true). Any number would do, so we'll
+  // stick with 1n. However quality adjusted power will be 0n always as relative
+  // power doesn't change:
+  // "The storage power a storage miner earns from a storage deal offered by a
+  // verified client will be augmented by a multiplier."
+  // https://docs.filecoin.io/reference/glossary/#quality-adjusted-storage-power
   async "Filecoin.StateMinerPower"(
     minerAddress: string
   ): Promise<SerializedMinerPower> {
-    // I don't fully understand what these values are supposed to be/mean
-    // but since we're the only miner on this "network", I figure they don't
-    // super matter. I'm putting in these placeholder values for now
-    if (minerAddress === this.#blockchain.miner.value) {
+    if (minerAddress === this.#blockchain.miner) {
       const power = new MinerPower({
         minerPower: new PowerClaim({
           rawBytePower: 1n,
-          qualityAdjPower: 1n
+          qualityAdjPower: 0n
         }),
         totalPower: new PowerClaim({
           rawBytePower: 1n,
-          qualityAdjPower: 1n
+          qualityAdjPower: 0n
         }),
         hasMinPower: false
       });

--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -135,6 +135,9 @@ export default class FilecoinApi implements types.Api {
   async "Filecoin.StateMinerPower"(
     minerAddress: string
   ): Promise<SerializedMinerPower> {
+    // I don't fully understand what these values are supposed to be/mean
+    // but since we're the only miner on this "network", I figure they don't
+    // super matter. I'm putting in these placeholder values for now
     if (minerAddress === this.#blockchain.miner.value) {
       const power = new MinerPower({
         minerPower: new PowerClaim({

--- a/src/chains/filecoin/filecoin/src/things/miner-power.ts
+++ b/src/chains/filecoin/filecoin/src/things/miner-power.ts
@@ -1,0 +1,57 @@
+import { SerializedRootCID } from "./root-cid";
+import {
+  SerializableObject,
+  SerializedObject,
+  DeserializedObject,
+  Definitions
+} from "./serializable-object";
+import { PowerClaim, SerializedPowerClaim } from "./power-claim";
+
+type MinerPowerConfig = {
+  properties: {
+    minerPower: {
+      type: PowerClaim;
+      serializedType: SerializedPowerClaim;
+      serializedName: "MinerPower";
+    };
+    totalPower: {
+      type: PowerClaim;
+      serializedType: SerializedPowerClaim;
+      serializedName: "TotalPower";
+    };
+    hasMinPower: {
+      type: boolean;
+      serializedType: SerializedRootCID;
+      serializedName: "HasMinPower";
+    };
+  };
+};
+
+class MinerPower
+  extends SerializableObject<MinerPowerConfig>
+  implements DeserializedObject<MinerPowerConfig> {
+  get config(): Definitions<MinerPowerConfig> {
+    return {
+      minerPower: {
+        serializedName: "MinerPower",
+        defaultValue: options => new PowerClaim(options)
+      },
+      totalPower: {
+        serializedName: "TotalPower",
+        defaultValue: options => new PowerClaim(options)
+      },
+      hasMinPower: {
+        serializedName: "HasMinPower",
+        defaultValue: false
+      }
+    };
+  }
+
+  minerPower: PowerClaim;
+  totalPower: PowerClaim;
+  hasMinPower: boolean;
+}
+
+type SerializedMinerPower = SerializedObject<MinerPowerConfig>;
+
+export { MinerPower, SerializedMinerPower };

--- a/src/chains/filecoin/filecoin/src/things/miner-power.ts
+++ b/src/chains/filecoin/filecoin/src/things/miner-power.ts
@@ -29,12 +29,10 @@ type MinerPowerConfig = {
   };
 };
 
-type C = MinerPowerConfig;
-
 class MinerPower
-  extends SerializableObject<C>
-  implements DeserializedObject<C> {
-  get config(): Definitions<C> {
+  extends SerializableObject<MinerPowerConfig>
+  implements DeserializedObject<MinerPowerConfig> {
+  get config(): Definitions<MinerPowerConfig> {
     return {
       minerPower: {
         deserializedName: "minerPower",
@@ -55,7 +53,9 @@ class MinerPower
   }
 
   constructor(
-    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+    options?:
+      | Partial<SerializedObject<MinerPowerConfig>>
+      | Partial<DeserializedObject<MinerPowerConfig>>
   ) {
     super();
 
@@ -69,6 +69,6 @@ class MinerPower
   hasMinPower: boolean;
 }
 
-type SerializedMinerPower = SerializedObject<C>;
+type SerializedMinerPower = SerializedObject<MinerPowerConfig>;
 
 export { MinerPower, SerializedMinerPower };

--- a/src/chains/filecoin/filecoin/src/things/miner-power.ts
+++ b/src/chains/filecoin/filecoin/src/things/miner-power.ts
@@ -29,24 +29,39 @@ type MinerPowerConfig = {
   };
 };
 
+type C = MinerPowerConfig;
+
 class MinerPower
-  extends SerializableObject<MinerPowerConfig>
-  implements DeserializedObject<MinerPowerConfig> {
-  get config(): Definitions<MinerPowerConfig> {
+  extends SerializableObject<C>
+  implements DeserializedObject<C> {
+  get config(): Definitions<C> {
     return {
       minerPower: {
+        deserializedName: "minerPower",
         serializedName: "MinerPower",
         defaultValue: options => new PowerClaim(options)
       },
       totalPower: {
+        deserializedName: "totalPower",
         serializedName: "TotalPower",
         defaultValue: options => new PowerClaim(options)
       },
       hasMinPower: {
+        deserializedName: "hasMinPower",
         serializedName: "HasMinPower",
         defaultValue: false
       }
     };
+  }
+
+  constructor(
+    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+  ) {
+    super();
+
+    this.minerPower = super.initializeValue(this.config.minerPower, options);
+    this.totalPower = super.initializeValue(this.config.totalPower, options);
+    this.hasMinPower = super.initializeValue(this.config.hasMinPower, options);
   }
 
   minerPower: PowerClaim;
@@ -54,6 +69,6 @@ class MinerPower
   hasMinPower: boolean;
 }
 
-type SerializedMinerPower = SerializedObject<MinerPowerConfig>;
+type SerializedMinerPower = SerializedObject<C>;
 
 export { MinerPower, SerializedMinerPower };

--- a/src/chains/filecoin/filecoin/src/things/miner-power.ts
+++ b/src/chains/filecoin/filecoin/src/things/miner-power.ts
@@ -7,6 +7,8 @@ import {
 } from "./serializable-object";
 import { PowerClaim, SerializedPowerClaim } from "./power-claim";
 
+// https://pkg.go.dev/github.com/filecoin-project/lotus@v1.4.0/api#MinerPower
+
 type MinerPowerConfig = {
   properties: {
     minerPower: {

--- a/src/chains/filecoin/filecoin/src/things/power-claim.ts
+++ b/src/chains/filecoin/filecoin/src/things/power-claim.ts
@@ -22,12 +22,10 @@ type PowerClaimConfig = {
   };
 };
 
-type C = PowerClaimConfig;
-
 class PowerClaim
-  extends SerializableObject<C>
-  implements DeserializedObject<C> {
-  get config(): Definitions<C> {
+  extends SerializableObject<PowerClaimConfig>
+  implements DeserializedObject<PowerClaimConfig> {
+  get config(): Definitions<PowerClaimConfig> {
     return {
       rawBytePower: {
         deserializedName: "rawBytePower",
@@ -43,7 +41,9 @@ class PowerClaim
   }
 
   constructor(
-    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+    options?:
+      | Partial<SerializedObject<PowerClaimConfig>>
+      | Partial<DeserializedObject<PowerClaimConfig>>
   ) {
     super();
 
@@ -61,6 +61,6 @@ class PowerClaim
   qualityAdjPower: bigint;
 }
 
-type SerializedPowerClaim = SerializedObject<C>;
+type SerializedPowerClaim = SerializedObject<PowerClaimConfig>;
 
 export { PowerClaim, SerializedPowerClaim };

--- a/src/chains/filecoin/filecoin/src/things/power-claim.ts
+++ b/src/chains/filecoin/filecoin/src/things/power-claim.ts
@@ -22,26 +22,45 @@ type PowerClaimConfig = {
   };
 };
 
+type C = PowerClaimConfig;
+
 class PowerClaim
-  extends SerializableObject<PowerClaimConfig>
-  implements DeserializedObject<PowerClaimConfig> {
-  get config(): Definitions<PowerClaimConfig> {
+  extends SerializableObject<C>
+  implements DeserializedObject<C> {
+  get config(): Definitions<C> {
     return {
       rawBytePower: {
+        deserializedName: "rawBytePower",
         serializedName: "RawBytePower",
         defaultValue: 1n
       },
       qualityAdjPower: {
+        deserializedName: "qualityAdjPower",
         serializedName: "QualityAdjPower",
         defaultValue: 1n
       }
     };
   }
 
+  constructor(
+    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+  ) {
+    super();
+
+    this.rawBytePower = super.initializeValue(
+      this.config.rawBytePower,
+      options
+    );
+    this.qualityAdjPower = super.initializeValue(
+      this.config.qualityAdjPower,
+      options
+    );
+  }
+
   rawBytePower: bigint;
   qualityAdjPower: bigint;
 }
 
-type SerializedPowerClaim = SerializedObject<PowerClaimConfig>;
+type SerializedPowerClaim = SerializedObject<C>;
 
 export { PowerClaim, SerializedPowerClaim };

--- a/src/chains/filecoin/filecoin/src/things/power-claim.ts
+++ b/src/chains/filecoin/filecoin/src/things/power-claim.ts
@@ -5,6 +5,8 @@ import {
   Definitions
 } from "./serializable-object";
 
+// https://pkg.go.dev/github.com/filecoin-project/lotus@v1.4.0/chain/actors/builtin/power#Claim
+
 type PowerClaimConfig = {
   properties: {
     rawBytePower: {

--- a/src/chains/filecoin/filecoin/src/things/power-claim.ts
+++ b/src/chains/filecoin/filecoin/src/things/power-claim.ts
@@ -1,0 +1,45 @@
+import {
+  SerializableObject,
+  SerializedObject,
+  DeserializedObject,
+  Definitions
+} from "./serializable-object";
+
+type PowerClaimConfig = {
+  properties: {
+    rawBytePower: {
+      type: bigint;
+      serializedType: string;
+      serializedName: "RawBytePower";
+    };
+    qualityAdjPower: {
+      type: bigint;
+      serializedType: string;
+      serializedName: "QualityAdjPower";
+    };
+  };
+};
+
+class PowerClaim
+  extends SerializableObject<PowerClaimConfig>
+  implements DeserializedObject<PowerClaimConfig> {
+  get config(): Definitions<PowerClaimConfig> {
+    return {
+      rawBytePower: {
+        serializedName: "RawBytePower",
+        defaultValue: 1n
+      },
+      qualityAdjPower: {
+        serializedName: "QualityAdjPower",
+        defaultValue: 1n
+      }
+    };
+  }
+
+  rawBytePower: bigint;
+  qualityAdjPower: bigint;
+}
+
+type SerializedPowerClaim = SerializedObject<PowerClaimConfig>;
+
+export { PowerClaim, SerializedPowerClaim };

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/miners.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/miners.test.ts
@@ -29,5 +29,27 @@ describe("api", () => {
         assert.strictEqual(miners[0], "t01000");
       });
     });
+
+    describe("Filecoin.StateMinerPower", () => {
+      it("should returns a nonzero power for the default miner", async () => {
+        const minerPower = await client.stateMinerPower("t01000");
+
+        // current implementation uses the default for both of these
+        assert.deepStrictEqual(minerPower.MinerPower, minerPower.TotalPower);
+        assert.strictEqual(minerPower.MinerPower.RawBytePower, "1");
+        assert.strictEqual(minerPower.MinerPower.QualityAdjPower, "0");
+        assert.strictEqual(minerPower.HasMinPower, false);
+      });
+
+      it("should returns a zero power for other miners", async () => {
+        const minerPower = await client.stateMinerPower("t01001");
+
+        // current implementation uses the default for both of these
+        assert.deepStrictEqual(minerPower.MinerPower, minerPower.TotalPower);
+        assert.strictEqual(minerPower.MinerPower.RawBytePower, "0");
+        assert.strictEqual(minerPower.MinerPower.QualityAdjPower, "0");
+        assert.strictEqual(minerPower.HasMinPower, false);
+      });
+    });
   });
 });

--- a/src/chains/filecoin/types/src/api.d.ts
+++ b/src/chains/filecoin/types/src/api.d.ts
@@ -9,6 +9,7 @@ import { SerializedRetrievalOrder } from "./things/retrieval-order";
 import { SerializedQueryOffer } from "./things/query-offer";
 import { SubscriptionMethod, SubscriptionId } from "./types/subscriptions";
 import { SerializedFileRef } from "./things/file-ref";
+import { SerializedMinerPower } from "./things/miner-power";
 export default class FilecoinApi implements types.Api {
   #private;
   readonly [index: string]: (...args: any) => Promise<any>;
@@ -21,6 +22,9 @@ export default class FilecoinApi implements types.Api {
     subscriptionId: SubscriptionId
   ): Promise<boolean>;
   "Filecoin.StateListMiners"(): Promise<Array<string>>;
+  "Filecoin.StateMinerPower"(
+    minerAddress: string
+  ): Promise<SerializedMinerPower>;
   "Filecoin.WalletDefaultAddress"(): Promise<SerializedAddress>;
   "Filecoin.WalletBalance"(address: string): Promise<string>;
   "Filecoin.ClientStartDeal"(

--- a/src/chains/filecoin/types/src/things/miner-power.d.ts
+++ b/src/chains/filecoin/types/src/things/miner-power.d.ts
@@ -25,17 +25,18 @@ declare type MinerPowerConfig = {
     };
   };
 };
-declare type C = MinerPowerConfig;
 declare class MinerPower
-  extends SerializableObject<C>
-  implements DeserializedObject<C> {
-  get config(): Definitions<C>;
+  extends SerializableObject<MinerPowerConfig>
+  implements DeserializedObject<MinerPowerConfig> {
+  get config(): Definitions<MinerPowerConfig>;
   constructor(
-    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+    options?:
+      | Partial<SerializedObject<MinerPowerConfig>>
+      | Partial<DeserializedObject<MinerPowerConfig>>
   );
   minerPower: PowerClaim;
   totalPower: PowerClaim;
   hasMinPower: boolean;
 }
-declare type SerializedMinerPower = SerializedObject<C>;
+declare type SerializedMinerPower = SerializedObject<MinerPowerConfig>;
 export { MinerPower, SerializedMinerPower };

--- a/src/chains/filecoin/types/src/things/miner-power.d.ts
+++ b/src/chains/filecoin/types/src/things/miner-power.d.ts
@@ -1,0 +1,41 @@
+import { SerializedRootCID } from "./root-cid";
+import {
+  SerializableObject,
+  SerializedObject,
+  DeserializedObject,
+  Definitions
+} from "./serializable-object";
+import { PowerClaim, SerializedPowerClaim } from "./power-claim";
+declare type MinerPowerConfig = {
+  properties: {
+    minerPower: {
+      type: PowerClaim;
+      serializedType: SerializedPowerClaim;
+      serializedName: "MinerPower";
+    };
+    totalPower: {
+      type: PowerClaim;
+      serializedType: SerializedPowerClaim;
+      serializedName: "TotalPower";
+    };
+    hasMinPower: {
+      type: boolean;
+      serializedType: SerializedRootCID;
+      serializedName: "HasMinPower";
+    };
+  };
+};
+declare type C = MinerPowerConfig;
+declare class MinerPower
+  extends SerializableObject<C>
+  implements DeserializedObject<C> {
+  get config(): Definitions<C>;
+  constructor(
+    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+  );
+  minerPower: PowerClaim;
+  totalPower: PowerClaim;
+  hasMinPower: boolean;
+}
+declare type SerializedMinerPower = SerializedObject<C>;
+export { MinerPower, SerializedMinerPower };

--- a/src/chains/filecoin/types/src/things/power-claim.d.ts
+++ b/src/chains/filecoin/types/src/things/power-claim.d.ts
@@ -18,16 +18,17 @@ declare type PowerClaimConfig = {
     };
   };
 };
-declare type C = PowerClaimConfig;
 declare class PowerClaim
-  extends SerializableObject<C>
-  implements DeserializedObject<C> {
-  get config(): Definitions<C>;
+  extends SerializableObject<PowerClaimConfig>
+  implements DeserializedObject<PowerClaimConfig> {
+  get config(): Definitions<PowerClaimConfig>;
   constructor(
-    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+    options?:
+      | Partial<SerializedObject<PowerClaimConfig>>
+      | Partial<DeserializedObject<PowerClaimConfig>>
   );
   rawBytePower: bigint;
   qualityAdjPower: bigint;
 }
-declare type SerializedPowerClaim = SerializedObject<C>;
+declare type SerializedPowerClaim = SerializedObject<PowerClaimConfig>;
 export { PowerClaim, SerializedPowerClaim };

--- a/src/chains/filecoin/types/src/things/power-claim.d.ts
+++ b/src/chains/filecoin/types/src/things/power-claim.d.ts
@@ -1,0 +1,33 @@
+import {
+  SerializableObject,
+  SerializedObject,
+  DeserializedObject,
+  Definitions
+} from "./serializable-object";
+declare type PowerClaimConfig = {
+  properties: {
+    rawBytePower: {
+      type: bigint;
+      serializedType: string;
+      serializedName: "RawBytePower";
+    };
+    qualityAdjPower: {
+      type: bigint;
+      serializedType: string;
+      serializedName: "QualityAdjPower";
+    };
+  };
+};
+declare type C = PowerClaimConfig;
+declare class PowerClaim
+  extends SerializableObject<C>
+  implements DeserializedObject<C> {
+  get config(): Definitions<C>;
+  constructor(
+    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+  );
+  rawBytePower: bigint;
+  qualityAdjPower: bigint;
+}
+declare type SerializedPowerClaim = SerializedObject<C>;
+export { PowerClaim, SerializedPowerClaim };


### PR DESCRIPTION
This PR is a continuation of #715, but there is added maturation and tests.

This PR adds the `Filecoin.StateMinerPower` method, which is necessary for the `/miners` page on the Filecoin Network Inspector app.