### PR TITLE
add ActorAddress method

### DIFF
--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -129,6 +129,14 @@ export default class FilecoinApi implements types.Api {
     }
   }
 
+  // This method is part of the StorageMiner API,
+  // so it's supposed to return the actor address
+  // for the mining side of things (since Ganache
+  // represents multiple actors in this simulator)
+  async "Filecoin.ActorAddress"(): Promise<string> {
+    return this.#blockchain.miner;
+  }
+
   async "Filecoin.StateListMiners"(): Promise<Array<string>> {
     return [this.#blockchain.miner];
   }

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/miners.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/miners.test.ts
@@ -81,17 +81,6 @@ describe("api", () => {
 
         assert.strictEqual(minerActorAddress, "t01000");
       });
-
-      it("should fail to retrieve miner info for other miners", async () => {
-        try {
-          const minerInfo = await client.stateMinerInfo("t01001");
-          assert.fail(
-            `Should not have retrieved a miner info for miner t01001, but receive: ${minerInfo}`
-          );
-        } catch (e) {
-          return;
-        }
-      });
     });
   });
 });

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/miners.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/miners.test.ts
@@ -74,5 +74,24 @@ describe("api", () => {
         }
       });
     });
+
+    describe("Filecoin.ActorAddress", () => {
+      it("should return the miner info for the default miner", async () => {
+        const minerActorAddress = await client.actorAddress();
+
+        assert.strictEqual(minerActorAddress, "t01000");
+      });
+
+      it("should fail to retrieve miner info for other miners", async () => {
+        try {
+          const minerInfo = await client.stateMinerInfo("t01001");
+          assert.fail(
+            `Should not have retrieved a miner info for miner t01001, but receive: ${minerInfo}`
+          );
+        } catch (e) {
+          return;
+        }
+      });
+    });
   });
 });

--- a/src/chains/filecoin/types/src/api.d.ts
+++ b/src/chains/filecoin/types/src/api.d.ts
@@ -22,6 +22,7 @@ export default class FilecoinApi implements types.Api {
   [SubscriptionMethod.ChannelClosed](
     subscriptionId: SubscriptionId
   ): Promise<boolean>;
+  "Filecoin.ActorAddress"(): Promise<string>;
   "Filecoin.StateListMiners"(): Promise<Array<string>>;
   "Filecoin.StateMinerPower"(
     minerAddress: string


### PR DESCRIPTION
This PR splits out some of the functionality from #718; specifically this PR adds the `Filecoin.ActorAddress` method, which is used in the `js-lotus-client-workshop` application.