### PR TITLE
add Filecoin.Version method

### DIFF
--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -21,6 +21,7 @@ import { FileRef, SerializedFileRef } from "./things/file-ref";
 import { MinerPower, SerializedMinerPower } from "./things/miner-power";
 import { PowerClaim } from "./things/power-claim";
 import { MinerInfo, SerializedMinerInfo } from "./things/miner-info";
+import { SerializedVersion, Version } from "./things/version";
 
 export default class FilecoinApi implements types.Api {
   readonly [index: string]: (...args: any) => Promise<any>;
@@ -35,6 +36,12 @@ export default class FilecoinApi implements types.Api {
 
   async stop(): Promise<void> {
     return await this.#blockchain.stop();
+  }
+
+  async "Filecoin.Version"(): Promise<SerializedVersion> {
+    return new Version({
+      blockDelay: BigInt(this.#blockchain.options.miner.blockTime)
+    }).serialize();
   }
 
   async "Filecoin.ChainGetGenesis"(): Promise<SerializedTipset> {

--- a/src/chains/filecoin/filecoin/src/things/version.ts
+++ b/src/chains/filecoin/filecoin/src/things/version.ts
@@ -8,7 +8,7 @@ import { $INLINE_JSON } from "ts-transformer-inline-file";
 
 const { version: GanacheFilecoinVersion } = $INLINE_JSON("../../package.json");
 
-// https://pkg.go.dev/github.com/filecoin-project/lotus/api#Version
+// https://pkg.go.dev/github.com/filecoin-project/lotus@v1.4.0/api#Version
 
 function createBinarySemverVersion(version: string): number {
   const versionParts = version.split(".");

--- a/src/chains/filecoin/filecoin/src/things/version.ts
+++ b/src/chains/filecoin/filecoin/src/things/version.ts
@@ -1,0 +1,77 @@
+import {
+  SerializableObject,
+  DeserializedObject,
+  SerializedObject,
+  Definitions
+} from "./serializable-object";
+import { $INLINE_JSON } from "ts-transformer-inline-file";
+
+const { version: GanacheFilecoinVersion } = $INLINE_JSON("../../package.json");
+
+// https://pkg.go.dev/github.com/filecoin-project/lotus/api#Version
+
+function createBinarySemverVersion(version: string): number {
+  const versionParts = version.split(".");
+
+  const majorVersion =
+    versionParts.length > 0 ? parseInt(versionParts[0], 10) : 0;
+  const minorVersion =
+    versionParts.length > 1 ? parseInt(versionParts[1], 10) : 0;
+  const patchVersion =
+    versionParts.length > 2 ? parseInt(versionParts[2], 10) : 0;
+
+  const binaryVersion =
+    (majorVersion << 16) | (minorVersion << 8) | patchVersion;
+
+  return binaryVersion;
+}
+
+interface VersionConfig {
+  properties: {
+    version: {
+      type: string;
+      serializedType: string;
+      serializedName: "Version";
+    };
+    apiVersion: {
+      type: number;
+      serializedType: number;
+      serializedName: "APIVersion";
+    };
+    blockDelay: {
+      type: bigint;
+      serializedType: string;
+      serializedName: "BlockDelay";
+    };
+  };
+}
+
+class Version
+  extends SerializableObject<VersionConfig>
+  implements DeserializedObject<VersionConfig> {
+  get config(): Definitions<VersionConfig> {
+    return {
+      version: {
+        serializedName: "Version",
+        defaultValue: `@ganache/filecoin v${GanacheFilecoinVersion}`
+      },
+      apiVersion: {
+        serializedName: "APIVersion",
+        // Version determined by what we're using for at https://pkg.go.dev/github.com/filecoin-project/lotus/api
+        defaultValue: createBinarySemverVersion("1.4.0")
+      },
+      blockDelay: {
+        serializedName: "BlockDelay",
+        defaultValue: 0n
+      }
+    };
+  }
+
+  version: string;
+  apiVersion: number;
+  blockDelay: bigint;
+}
+
+type SerializedVersion = SerializedObject<VersionConfig>;
+
+export { Version, SerializedVersion };

--- a/src/chains/filecoin/filecoin/src/things/version.ts
+++ b/src/chains/filecoin/filecoin/src/things/version.ts
@@ -46,10 +46,10 @@ interface VersionConfig {
   };
 }
 
-type C = VersionConfig;
-
-class Version extends SerializableObject<C> implements DeserializedObject<C> {
-  get config(): Definitions<C> {
+class Version
+  extends SerializableObject<VersionConfig>
+  implements DeserializedObject<VersionConfig> {
+  get config(): Definitions<VersionConfig> {
     return {
       version: {
         deserializedName: "version",
@@ -71,7 +71,9 @@ class Version extends SerializableObject<C> implements DeserializedObject<C> {
   }
 
   constructor(
-    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+    options?:
+      | Partial<SerializedObject<VersionConfig>>
+      | Partial<DeserializedObject<VersionConfig>>
   ) {
     super();
 
@@ -85,6 +87,6 @@ class Version extends SerializableObject<C> implements DeserializedObject<C> {
   blockDelay: bigint;
 }
 
-type SerializedVersion = SerializedObject<C>;
+type SerializedVersion = SerializedObject<VersionConfig>;
 
 export { Version, SerializedVersion };

--- a/src/chains/filecoin/filecoin/src/things/version.ts
+++ b/src/chains/filecoin/filecoin/src/things/version.ts
@@ -46,25 +46,38 @@ interface VersionConfig {
   };
 }
 
-class Version
-  extends SerializableObject<VersionConfig>
-  implements DeserializedObject<VersionConfig> {
-  get config(): Definitions<VersionConfig> {
+type C = VersionConfig;
+
+class Version extends SerializableObject<C> implements DeserializedObject<C> {
+  get config(): Definitions<C> {
     return {
       version: {
+        deserializedName: "version",
         serializedName: "Version",
         defaultValue: `@ganache/filecoin v${GanacheFilecoinVersion}`
       },
       apiVersion: {
+        deserializedName: "apiVersion",
         serializedName: "APIVersion",
         // Version determined by what we're using for at https://pkg.go.dev/github.com/filecoin-project/lotus/api
         defaultValue: createBinarySemverVersion("1.4.0")
       },
       blockDelay: {
+        deserializedName: "blockDelay",
         serializedName: "BlockDelay",
         defaultValue: 0n
       }
     };
+  }
+
+  constructor(
+    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+  ) {
+    super();
+
+    this.version = super.initializeValue(this.config.version, options);
+    this.apiVersion = super.initializeValue(this.config.apiVersion, options);
+    this.blockDelay = super.initializeValue(this.config.blockDelay, options);
   }
 
   version: string;
@@ -72,6 +85,6 @@ class Version
   blockDelay: bigint;
 }
 
-type SerializedVersion = SerializedObject<VersionConfig>;
+type SerializedVersion = SerializedObject<C>;
 
 export { Version, SerializedVersion };

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/generic.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/generic.test.ts
@@ -97,6 +97,20 @@ describe("api", () => {
       });
     });
 
+    describe("Filecoin.Version", () => {
+      it("should return a value", async () => {
+        const versionInfo = await client.version();
+
+        assert(versionInfo.Version.includes("@ganache/filecoin v"));
+
+        assert.strictEqual(typeof versionInfo.APIVersion, "number");
+        assert(versionInfo.APIVersion > 0);
+
+        // should be 0 since we didn't specify in options
+        assert.strictEqual(versionInfo.BlockDelay, "0");
+      });
+    });
+
     describe("Filecoin.ChainGetGenesis", () => {
       it("should return a value", async () => {
         const genesis = await client.chainGetGenesis();

--- a/src/chains/filecoin/types/src/api.d.ts
+++ b/src/chains/filecoin/types/src/api.d.ts
@@ -11,11 +11,13 @@ import { SubscriptionMethod, SubscriptionId } from "./types/subscriptions";
 import { SerializedFileRef } from "./things/file-ref";
 import { SerializedMinerPower } from "./things/miner-power";
 import { SerializedMinerInfo } from "./things/miner-info";
+import { SerializedVersion } from "./things/version";
 export default class FilecoinApi implements types.Api {
   #private;
   readonly [index: string]: (...args: any) => Promise<any>;
   constructor(blockchain: Blockchain);
   stop(): Promise<void>;
+  "Filecoin.Version"(): Promise<SerializedVersion>;
   "Filecoin.ChainGetGenesis"(): Promise<SerializedTipset>;
   "Filecoin.ChainHead"(): Promise<SerializedTipset>;
   "Filecoin.ChainNotify"(rpcId?: string): PromiEvent<Subscription>;

--- a/src/chains/filecoin/types/src/things/version.d.ts
+++ b/src/chains/filecoin/types/src/things/version.d.ts
@@ -23,17 +23,18 @@ interface VersionConfig {
     };
   };
 }
-declare type C = VersionConfig;
 declare class Version
-  extends SerializableObject<C>
-  implements DeserializedObject<C> {
-  get config(): Definitions<C>;
+  extends SerializableObject<VersionConfig>
+  implements DeserializedObject<VersionConfig> {
+  get config(): Definitions<VersionConfig>;
   constructor(
-    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+    options?:
+      | Partial<SerializedObject<VersionConfig>>
+      | Partial<DeserializedObject<VersionConfig>>
   );
   version: string;
   apiVersion: number;
   blockDelay: bigint;
 }
-declare type SerializedVersion = SerializedObject<C>;
+declare type SerializedVersion = SerializedObject<VersionConfig>;
 export { Version, SerializedVersion };

--- a/src/chains/filecoin/types/src/things/version.d.ts
+++ b/src/chains/filecoin/types/src/things/version.d.ts
@@ -1,0 +1,39 @@
+import {
+  SerializableObject,
+  DeserializedObject,
+  SerializedObject,
+  Definitions
+} from "./serializable-object";
+interface VersionConfig {
+  properties: {
+    version: {
+      type: string;
+      serializedType: string;
+      serializedName: "Version";
+    };
+    apiVersion: {
+      type: number;
+      serializedType: number;
+      serializedName: "APIVersion";
+    };
+    blockDelay: {
+      type: bigint;
+      serializedType: string;
+      serializedName: "BlockDelay";
+    };
+  };
+}
+declare type C = VersionConfig;
+declare class Version
+  extends SerializableObject<C>
+  implements DeserializedObject<C> {
+  get config(): Definitions<C>;
+  constructor(
+    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+  );
+  version: string;
+  apiVersion: number;
+  blockDelay: bigint;
+}
+declare type SerializedVersion = SerializedObject<C>;
+export { Version, SerializedVersion };


### PR DESCRIPTION
This PR splits out some of the functionality from #718; specifically this PR adds the `Filecoin.Version` method, which is used in the `js-lotus-client-workshop` application.