### PR TITLE
implement multiple accounts through the db

### DIFF
--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -45,11 +45,13 @@ export default class FilecoinApi implements types.Api {
   }
 
   async "Filecoin.ChainGetGenesis"(): Promise<SerializedTipset> {
-    return this.#blockchain.latestTipset().serialize();
+    const tipset = this.#blockchain.latestTipset();
+    return tipset.serialize();
   }
 
   async "Filecoin.ChainHead"(): Promise<SerializedTipset> {
-    return this.#blockchain.latestTipset().serialize();
+    const tipset = this.#blockchain.latestTipset();
+    return tipset.serialize();
   }
 
   // Reference implementation entry point: https://git.io/JtO3a
@@ -211,18 +213,16 @@ export default class FilecoinApi implements types.Api {
   }
 
   async "Filecoin.WalletDefaultAddress"(): Promise<SerializedAddress> {
-    return this.#blockchain.address.serialize();
+    await this.#blockchain.waitForReady();
+    const accounts = await this.#blockchain.accountManager!.getControllableAccounts();
+    return accounts[0].address.serialize();
   }
 
   async "Filecoin.WalletBalance"(address: string): Promise<string> {
-    let managedAddress = this.#blockchain.address;
+    await this.#blockchain.waitForReady();
 
-    // For now, anything but our default address will have no balance
-    if (managedAddress.value == address) {
-      return this.#blockchain.balance.serialize();
-    } else {
-      return "0";
-    }
+    const account = await this.#blockchain.accountManager!.getAccount(address);
+    return account.balance.serialize();
   }
 
   async "Filecoin.ClientStartDeal"(
@@ -273,6 +273,7 @@ export default class FilecoinApi implements types.Api {
 
   async "Ganache.MineTipset"(): Promise<SerializedTipset> {
     await this.#blockchain.mineTipset();
-    return this.#blockchain.latestTipset().serialize();
+    const tipset = this.#blockchain.latestTipset();
+    return tipset.serialize();
   }
 }

--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -91,7 +91,8 @@ export default class Blockchain extends Emittery.Typed<
       );
       this.accountManager = await AccountManager.initialize(
         this.#database.accounts!,
-        this.privateKeyManager
+        this.privateKeyManager,
+        this.#database
       );
 
       const controllableAccounts = await this.accountManager.getControllableAccounts();

--- a/src/chains/filecoin/filecoin/src/data-managers/account-manager.ts
+++ b/src/chains/filecoin/filecoin/src/data-managers/account-manager.ts
@@ -2,6 +2,7 @@ import Manager from "./manager";
 import { LevelUp } from "levelup";
 import { Account, AccountConfig } from "../things/account";
 import PrivateKeyManager from "./private-key-manager";
+import { Address } from "../things/address";
 
 export default class AccountManager extends Manager<Account, AccountConfig> {
   #privateKeyManager: PrivateKeyManager;

--- a/src/chains/filecoin/filecoin/src/data-managers/account-manager.ts
+++ b/src/chains/filecoin/filecoin/src/data-managers/account-manager.ts
@@ -33,7 +33,9 @@ export default class AccountManager extends Manager<Account, AccountConfig> {
   async getAccount(address: string): Promise<Account> {
     let account = await super.get(address);
     if (!account) {
-      account = new Account();
+      account = new Account({
+        address: new Address(address)
+      });
       await this.putAccount(account);
     }
 

--- a/src/chains/filecoin/filecoin/src/data-managers/account-manager.ts
+++ b/src/chains/filecoin/filecoin/src/data-managers/account-manager.ts
@@ -1,0 +1,93 @@
+import Manager from "./manager";
+import { LevelUp } from "levelup";
+import { Account, AccountConfig } from "../things/account";
+import PrivateKeyManager from "./private-key-manager";
+
+export default class AccountManager extends Manager<Account, AccountConfig> {
+  #privateKeyManager: PrivateKeyManager;
+
+  static async initialize(base: LevelUp, privateKeyManager: PrivateKeyManager) {
+    const manager = new AccountManager(base, privateKeyManager);
+    return manager;
+  }
+
+  constructor(base: LevelUp, privateKeyManager: PrivateKeyManager) {
+    super(base, Account);
+
+    // the account manager doesn't handle private keys directly
+    // we need to use the private key manager for that
+    this.#privateKeyManager = privateKeyManager;
+  }
+
+  async putAccount(account: Account) {
+    await super.set(account.address.value, account);
+
+    if (account.address.privateKey) {
+      await this.#privateKeyManager.putPrivateKey(
+        account.address.value,
+        account.address.privateKey
+      );
+    }
+  }
+
+  async getAccount(address: string): Promise<Account> {
+    let account = await super.get(address);
+    if (!account) {
+      account = new Account();
+      await this.putAccount(account);
+    }
+
+    const privateKey = await this.#privateKeyManager.getPrivateKey(
+      account.address.value
+    );
+    if (privateKey) {
+      account.address.setPrivateKey(privateKey);
+    }
+
+    return account;
+  }
+
+  /**
+   * Returns an array of accounts which we have private keys
+   * for. The order is the order in which they were stored.
+   * To add a controllable account, use `AccountManager.putAccount(account)`
+   * where `account.address.privateKey` is set.
+   */
+  async getControllableAccounts(): Promise<Array<Account>> {
+    const addresses = await this.#privateKeyManager.getAddressesWithPrivateKeys();
+    const accounts = await Promise.all(
+      addresses.map(async address => await this.getAccount(address))
+    );
+    return accounts;
+  }
+
+  async mintFunds(address: string, amount: bigint) {
+    const account = await this.getAccount(address);
+    account.addBalance(amount);
+    await this.putAccount(account);
+  }
+
+  async transferFunds(
+    from: string,
+    to: string,
+    amount: bigint
+  ): Promise<boolean> {
+    const fromAccount = await this.getAccount(from);
+    const toAccount = await this.getAccount(to);
+    if (fromAccount.balance.value >= amount) {
+      fromAccount.subtractBalance(amount);
+      toAccount.addBalance(amount);
+      await this.putAccount(fromAccount);
+      await this.putAccount(toAccount);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  async incrementNonce(address: string) {
+    const account = await this.getAccount(address);
+    account.nonce++;
+    await this.putAccount(account);
+  }
+}

--- a/src/chains/filecoin/filecoin/src/data-managers/private-key-manager.ts
+++ b/src/chains/filecoin/filecoin/src/data-managers/private-key-manager.ts
@@ -1,0 +1,59 @@
+import { LevelUp } from "levelup";
+
+const NOTFOUND = 404;
+
+export default class PrivateKeyManager {
+  static AccountsWithPrivateKeysKey = Buffer.from("accounts-with-private-keys");
+  private base: LevelUp;
+
+  static async initialize(base: LevelUp) {
+    const manager = new PrivateKeyManager(base);
+    return manager;
+  }
+
+  constructor(base: LevelUp) {
+    this.base = base;
+  }
+
+  async getPrivateKey(address: string): Promise<string | null> {
+    try {
+      const privateKey: Buffer = await this.base.get(Buffer.from(address));
+      return privateKey.toString();
+    } catch (e) {
+      if (e.status === NOTFOUND) {
+        return null;
+      }
+      throw e;
+    }
+  }
+
+  async putPrivateKey(address: string, privateKey: string) {
+    await this.base.put(Buffer.from(address), Buffer.from(privateKey));
+    const addresses = await this.getAddressesWithPrivateKeys();
+    if (!addresses.includes(address)) {
+      addresses.push(address);
+      await this.base.put(
+        PrivateKeyManager.AccountsWithPrivateKeysKey,
+        Buffer.from(JSON.stringify(addresses))
+      );
+    }
+  }
+
+  async getAddressesWithPrivateKeys(): Promise<Array<string>> {
+    try {
+      const result: Buffer = await this.base.get(
+        PrivateKeyManager.AccountsWithPrivateKeysKey
+      );
+      return JSON.parse(result.toString());
+    } catch (e) {
+      if (e.status === NOTFOUND) {
+        await this.base.put(
+          PrivateKeyManager.AccountsWithPrivateKeysKey,
+          Buffer.from(JSON.stringify([]))
+        );
+        return [];
+      }
+      throw e;
+    }
+  }
+}

--- a/src/chains/filecoin/filecoin/src/data-managers/private-key-manager.ts
+++ b/src/chains/filecoin/filecoin/src/data-managers/private-key-manager.ts
@@ -5,14 +5,40 @@ const NOTFOUND = 404;
 export default class PrivateKeyManager {
   static AccountsWithPrivateKeysKey = Buffer.from("accounts-with-private-keys");
   private base: LevelUp;
+  #addressesWithPrivateKeys: string[];
+
+  get addressesWithPrivateKeys() {
+    return this.#addressesWithPrivateKeys;
+  }
 
   static async initialize(base: LevelUp) {
-    const manager = new PrivateKeyManager(base);
+    let addressesWithPrivateKeys: string[];
+    try {
+      const result: Buffer = await base.get(
+        PrivateKeyManager.AccountsWithPrivateKeysKey
+      );
+      addressesWithPrivateKeys = JSON.parse(result.toString());
+    } catch (e) {
+      if (e.status === NOTFOUND) {
+        // if the array doesn't exist yet, initialize it
+        addressesWithPrivateKeys = [];
+        await base.put(
+          PrivateKeyManager.AccountsWithPrivateKeysKey,
+          Buffer.from(JSON.stringify(addressesWithPrivateKeys))
+        );
+      } else {
+        throw e;
+      }
+    }
+
+    const manager = new PrivateKeyManager(base, addressesWithPrivateKeys);
+
     return manager;
   }
 
-  constructor(base: LevelUp) {
+  constructor(base: LevelUp, addressesWithPrivateKeys: string[]) {
     this.base = base;
+    this.#addressesWithPrivateKeys = addressesWithPrivateKeys;
   }
 
   async getPrivateKey(address: string): Promise<string | null> {
@@ -27,33 +53,24 @@ export default class PrivateKeyManager {
     }
   }
 
-  async putPrivateKey(address: string, privateKey: string) {
-    await this.base.put(Buffer.from(address), Buffer.from(privateKey));
-    const addresses = await this.getAddressesWithPrivateKeys();
-    if (!addresses.includes(address)) {
-      addresses.push(address);
-      await this.base.put(
-        PrivateKeyManager.AccountsWithPrivateKeysKey,
-        Buffer.from(JSON.stringify(addresses))
-      );
-    }
-  }
+  /**
+   * NOTE: This function should only be called from
+   * `AccountManager.putAccount` to ensure fields are written
+   * atomically. Only call this function if you know what you're doing.
+   */
+  putPrivateKey(address: string, privateKey: string) {
+    this.base.put(Buffer.from(address), Buffer.from(privateKey));
 
-  async getAddressesWithPrivateKeys(): Promise<Array<string>> {
-    try {
-      const result: Buffer = await this.base.get(
-        PrivateKeyManager.AccountsWithPrivateKeysKey
+    if (!this.#addressesWithPrivateKeys.includes(address)) {
+      this.#addressesWithPrivateKeys.push(address);
+
+      // TODO(perf): (Issue ganache-core#875) If the number of private
+      // keys becomes very large (a highly unlikely event), this would
+      // kill performance whenever accounts were created
+      this.base.put(
+        PrivateKeyManager.AccountsWithPrivateKeysKey,
+        Buffer.from(JSON.stringify(this.#addressesWithPrivateKeys))
       );
-      return JSON.parse(result.toString());
-    } catch (e) {
-      if (e.status === NOTFOUND) {
-        await this.base.put(
-          PrivateKeyManager.AccountsWithPrivateKeysKey,
-          Buffer.from(JSON.stringify([]))
-        );
-        return [];
-      }
-      throw e;
     }
   }
 }

--- a/src/chains/filecoin/filecoin/src/database.ts
+++ b/src/chains/filecoin/filecoin/src/database.ts
@@ -21,6 +21,8 @@ export default class Database extends Emittery {
 
   public tipsets: LevelUp | null = null;
   public blocks: LevelUp | null = null;
+  public accounts: LevelUp | null = null;
+  public privateKeys: LevelUp | null = null;
 
   #initialized: boolean = false;
   get initialized() {
@@ -86,6 +88,8 @@ export default class Database extends Emittery {
 
     this.tipsets = sub(db, "t", levelupOptions);
     this.blocks = sub(db, "b", levelupOptions);
+    this.accounts = sub(db, "a", levelupOptions);
+    this.privateKeys = sub(db, "pk", levelupOptions);
 
     this.#initialized = true;
     return this.emit("ready");
@@ -166,6 +170,12 @@ export default class Database extends Emittery {
       }
       if (this.blocks) {
         await this.blocks.close();
+      }
+      if (this.accounts) {
+        await this.accounts.close();
+      }
+      if (this.privateKeys) {
+        await this.privateKeys.close();
       }
     }
     return this.#cleanupDirectory();

--- a/src/chains/filecoin/filecoin/src/provider.ts
+++ b/src/chains/filecoin/filecoin/src/provider.ts
@@ -52,16 +52,21 @@ export default class FilecoinProvider
   /**
    * Returns the unlocked accounts
    */
-  public getInitialAccounts() {
+  public async getInitialAccounts() {
     const accounts: Record<
       string,
       { unlocked: boolean; secretKey: string; balance: bigint }
     > = {};
-    accounts[this.blockchain.address.serialize()] = {
-      unlocked: true,
-      secretKey: this.blockchain.address.privateKey!,
-      balance: this.blockchain.balance.value
-    };
+
+    const controllableAccounts = await this.blockchain.accountManager!.getControllableAccounts();
+    for (const account of controllableAccounts) {
+      accounts[account.address.serialize()] = {
+        unlocked: true,
+        secretKey: account.address.privateKey!,
+        balance: account.balance.value
+      };
+    }
+
     return accounts;
   }
 

--- a/src/chains/filecoin/filecoin/src/things/account.ts
+++ b/src/chains/filecoin/filecoin/src/things/account.ts
@@ -1,4 +1,4 @@
-import { RandomNumberGenerator } from "@ganache/utils/src/utils";
+import { utils } from "@ganache/utils";
 import { Address, SerializedAddress } from "./address";
 import { Balance, SerializedBalance } from "./balance";
 import {
@@ -58,7 +58,7 @@ class Account extends SerializableObject<C> implements DeserializedObject<C> {
 
   static random(
     defaultFIL: number,
-    rng: RandomNumberGenerator = new RandomNumberGenerator()
+    rng: utils.RandomNumberGenerator = new utils.RandomNumberGenerator()
   ): Account {
     return new Account({
       address: Address.random(rng),

--- a/src/chains/filecoin/filecoin/src/things/account.ts
+++ b/src/chains/filecoin/filecoin/src/things/account.ts
@@ -1,0 +1,101 @@
+import { RandomNumberGenerator } from "@ganache/utils/src/utils";
+import { Address, SerializedAddress } from "./address";
+import { Balance, SerializedBalance } from "./balance";
+import {
+  Definitions,
+  DeserializedObject,
+  SerializableObject,
+  SerializedObject
+} from "./serializable-object";
+
+// This is not a Filecoin type; this is used for Ganache stuff, but uses the
+// same structure as the Filecoin types for easy (de)-serialization for persistence
+
+type AccountConfig = {
+  properties: {
+    address: {
+      type: Address;
+      serializedType: SerializedAddress;
+      serializedName: "Address";
+    };
+    balance: {
+      type: Balance;
+      serializedType: SerializedBalance;
+      serializedName: "Balance";
+    };
+    nonce: {
+      type: number;
+      serializedType: number;
+      serializedName: "Nonce";
+    };
+  };
+};
+
+type C = AccountConfig;
+
+class Account extends SerializableObject<C> implements DeserializedObject<C> {
+  get config(): Definitions<C> {
+    return {
+      address: {
+        deserializedName: "address",
+        serializedName: "Address",
+        defaultValue: literal =>
+          literal ? new Address(literal) : Address.random()
+      },
+      balance: {
+        deserializedName: "balance",
+        serializedName: "Balance",
+        defaultValue: literal =>
+          literal ? new Balance(literal) : new Balance("0")
+      },
+      nonce: {
+        deserializedName: "nonce",
+        serializedName: "Nonce",
+        defaultValue: 0
+      }
+    };
+  }
+
+  static random(
+    defaultFIL: number,
+    rng: RandomNumberGenerator = new RandomNumberGenerator()
+  ): Account {
+    return new Account({
+      address: Address.random(rng),
+      balance: new Balance(
+        Balance.FILToLowestDenomination(defaultFIL).toString()
+      ),
+      nonce: 0
+    });
+  }
+
+  constructor(
+    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+  ) {
+    super();
+
+    this.address = super.initializeValue(this.config.address, options);
+    this.#balance = super.initializeValue(this.config.balance, options);
+    this.nonce = super.initializeValue(this.config.nonce, options);
+  }
+
+  addBalance(val: string | number | bigint): void {
+    this.#balance.add(val);
+  }
+
+  subtractBalance(val: string | number | bigint): void {
+    this.#balance.sub(val);
+  }
+
+  readonly address: Address;
+  #balance: Balance;
+  nonce: number;
+
+  get balance(): Balance {
+    return this.#balance;
+  }
+}
+
+type SerializedAccount = SerializedObject<C>;
+
+export { Account, AccountConfig, SerializedAccount };

--- a/src/chains/filecoin/filecoin/src/things/account.ts
+++ b/src/chains/filecoin/filecoin/src/things/account.ts
@@ -31,10 +31,10 @@ type AccountConfig = {
   };
 };
 
-type C = AccountConfig;
-
-class Account extends SerializableObject<C> implements DeserializedObject<C> {
-  get config(): Definitions<C> {
+class Account
+  extends SerializableObject<AccountConfig>
+  implements DeserializedObject<AccountConfig> {
+  get config(): Definitions<AccountConfig> {
     return {
       address: {
         deserializedName: "address",
@@ -70,7 +70,9 @@ class Account extends SerializableObject<C> implements DeserializedObject<C> {
   }
 
   constructor(
-    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+    options?:
+      | Partial<SerializedObject<AccountConfig>>
+      | Partial<DeserializedObject<AccountConfig>>
   ) {
     super();
 
@@ -96,6 +98,6 @@ class Account extends SerializableObject<C> implements DeserializedObject<C> {
   }
 }
 
-type SerializedAccount = SerializedObject<C>;
+type SerializedAccount = SerializedObject<AccountConfig>;
 
 export { Account, AccountConfig, SerializedAccount };

--- a/src/chains/filecoin/filecoin/src/things/balance.ts
+++ b/src/chains/filecoin/filecoin/src/things/balance.ts
@@ -10,20 +10,33 @@ class Balance extends SerializableLiteral<BalanceConfig> {
   get config(): LiteralDefinition<BalanceConfig> {
     return {
       defaultValue: literal =>
-        literal ? BigInt(literal) : 500n * 1000000000000000000n
+        literal ? BigInt(literal) : Balance.FILToLowestDenomination(100)
     };
   }
 
-  sub(val: string | number | bigint): Balance {
-    const newBalance = this.value - BigInt(val);
-    return new Balance(newBalance.toString(10));
+  sub(val: string | number | bigint): void {
+    this.value -= BigInt(val);
+  }
+
+  add(val: string | number | bigint): void {
+    this.value += BigInt(val);
   }
 
   toFIL(): number {
-    return new BN(this.value.toString(10))
+    return Balance.LowestDenominationToFIL(this.value);
+  }
+
+  static FILToLowestDenomination(fil: number): bigint {
+    return BigInt(fil) * 1000000000000000000n;
+  }
+
+  static LowestDenominationToFIL(attoFil: bigint): number {
+    return new BN(attoFil.toString(10))
       .div(new BN(10).pow(new BN(18)))
       .toNumber();
   }
 }
 
-export default Balance;
+type SerializedBalance = string;
+
+export { Balance, SerializedBalance };

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
@@ -48,8 +48,9 @@ describe("api", () => {
 
       it("should accept a new deal", async () => {
         let miners = await client.stateListMiners();
-        let address = await client.walletDefaultAddress();
-        let beginningBalance = await client.walletBalance(address);
+        const accounts = await provider.blockchain.accountManager.getControllableAccounts();
+        const address = accounts[0].address;
+        let beginningBalance = await client.walletBalance(address.serialize());
 
         let result = await ipfs.add({
           content: data
@@ -64,7 +65,7 @@ describe("api", () => {
             }),
             pieceSize: 0
           }),
-          Wallet: address,
+          wallet: address,
           miner: miners[0],
           epochPrice: 2500n,
           minBlocksDuration: 300
@@ -152,7 +153,7 @@ describe("api", () => {
         const content = await fs.promises.readFile(file, { encoding: "utf-8" });
         assert.strictEqual(content, data);
 
-        // No error? Great, let's make sure it subtracted the retreival cost.
+        // No error? Great, let's make sure it subtracted the retrieval cost.
 
         let endingBalance = await client.walletBalance(address);
         assert(new BN(endingBalance).lt(new BN(beginningBalance)));

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
@@ -50,7 +50,7 @@ describe("api", () => {
         let miners = await client.stateListMiners();
         const accounts = await provider.blockchain.accountManager.getControllableAccounts();
         const address = accounts[0].address;
-        let beginningBalance = await client.walletBalance(address.serialize());
+        let beginningBalance = await client.walletBalance(address.value);
 
         let result = await ipfs.add({
           content: data
@@ -84,7 +84,7 @@ describe("api", () => {
         assert.strictEqual(deal.ProposalCid["/"], proposalCid["/"]);
         assert.strictEqual(deal.Size, expectedSize);
 
-        let endingBalance = await client.walletBalance(address);
+        let endingBalance = await client.walletBalance(address.value);
 
         assert(new BN(endingBalance).lt(new BN(beginningBalance)));
       });

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/wallet.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/wallet.test.ts
@@ -41,7 +41,7 @@ describe("api", () => {
 
       it("should return a balance for the default address", async () => {
         const balance = await client.walletBalance(address);
-        assert.strictEqual(balance, "500000000000000000000");
+        assert.strictEqual(balance, "100000000000000000000");
       });
 
       it("should not return a balance for any other address", async () => {

--- a/src/chains/filecoin/options/src/wallet-options.ts
+++ b/src/chains/filecoin/options/src/wallet-options.ts
@@ -26,6 +26,16 @@ export type OptionsAccount = {
 export type WalletConfig = {
   options: {
     /**
+     * Number of accounts to generate at startup.
+     *
+     * @default 10
+     */
+    totalAccounts: {
+      type: number;
+      hasDefault: true;
+    };
+
+    /**
      * Use pre-defined, deterministic seed.
      */
     deterministic: {
@@ -40,11 +50,28 @@ export type WalletConfig = {
       type: string;
       hasDefault: true;
     };
+
+    /**
+     * The default account balance, specified in FIL.
+     *
+     * @default 100 // FIL
+     */
+    defaultBalance: {
+      type: number;
+      hasDefault: true;
+    };
   };
   exclusiveGroups: [["deterministic", "seed"]];
 };
 
 export const WalletOptions: Definitions<WalletConfig> = {
+  totalAccounts: {
+    normalize,
+    cliDescription: "Number of accounts to generate at startup.",
+    default: () => 10,
+    cliAliases: ["a"],
+    cliType: "number"
+  },
   deterministic: {
     normalize,
     cliDescription: "Use pre-defined, deterministic seed.",
@@ -66,5 +93,12 @@ export const WalletOptions: Definitions<WalletConfig> = {
     cliAliases: ["s"],
     cliType: "string",
     conflicts: ["deterministic"]
+  },
+  defaultBalance: {
+    normalize,
+    cliDescription: "The default account balance, specified in FIL.",
+    default: () => 100,
+    cliAliases: ["b"],
+    cliType: "number"
   }
 };

--- a/src/chains/filecoin/types/src/blockchain.d.ts
+++ b/src/chains/filecoin/types/src/blockchain.d.ts
@@ -1,9 +1,7 @@
 import { Tipset } from "./things/tipset";
 import { RootCID } from "./things/root-cid";
 import Emittery from "emittery";
-import { Address } from "./things/address";
 import { DealInfo } from "./things/deal-info";
-import Balance from "./things/balance";
 import { StartDealParams } from "./things/start-deal-params";
 import { RetrievalOrder } from "./things/retrieval-order";
 import { FilecoinInternalOptions } from "@ganache/filecoin-options";
@@ -12,6 +10,8 @@ import { FileRef } from "./things/file-ref";
 import { IPFS } from "ipfs";
 import TipsetManager from "./data-managers/tipset-manager";
 import BlockHeaderManager from "./data-managers/block-header-manager";
+import AccountManager from "./data-managers/account-manager";
+import PrivateKeyManager from "./data-managers/private-key-manager";
 export declare type BlockchainEvents = {
   ready(): void;
   tipset: Tipset;
@@ -23,9 +23,9 @@ export default class Blockchain extends Emittery.Typed<
   #private;
   tipsetManager: TipsetManager | null;
   blockHeaderManager: BlockHeaderManager | null;
+  accountManager: AccountManager | null;
+  privateKeyManager: PrivateKeyManager | null;
   readonly miner: string;
-  readonly address: Address;
-  get balance(): Balance;
   readonly deals: Array<DealInfo>;
   readonly dealsByCid: Record<string, DealInfo>;
   readonly inProcessDeals: Array<DealInfo>;

--- a/src/chains/filecoin/types/src/data-managers/account-manager.d.ts
+++ b/src/chains/filecoin/types/src/data-managers/account-manager.d.ts
@@ -1,0 +1,24 @@
+import Manager from "./manager";
+import { LevelUp } from "levelup";
+import { Account, AccountConfig } from "../things/account";
+import PrivateKeyManager from "./private-key-manager";
+export default class AccountManager extends Manager<Account, AccountConfig> {
+  #private;
+  static initialize(
+    base: LevelUp,
+    privateKeyManager: PrivateKeyManager
+  ): Promise<AccountManager>;
+  constructor(base: LevelUp, privateKeyManager: PrivateKeyManager);
+  putAccount(account: Account): Promise<void>;
+  getAccount(address: string): Promise<Account>;
+  /**
+   * Returns an array of accounts which we have private keys
+   * for. The order is the order in which they were stored.
+   * To add a controllable account, use `AccountManager.putAccount(account)`
+   * where `account.address.privateKey` is set.
+   */
+  getControllableAccounts(): Promise<Array<Account>>;
+  mintFunds(address: string, amount: bigint): Promise<void>;
+  transferFunds(from: string, to: string, amount: bigint): Promise<boolean>;
+  incrementNonce(address: string): Promise<void>;
+}

--- a/src/chains/filecoin/types/src/data-managers/private-key-manager.d.ts
+++ b/src/chains/filecoin/types/src/data-managers/private-key-manager.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="node" />
+import { LevelUp } from "levelup";
+export default class PrivateKeyManager {
+  static AccountsWithPrivateKeysKey: Buffer;
+  private base;
+  static initialize(base: LevelUp): Promise<PrivateKeyManager>;
+  constructor(base: LevelUp);
+  getPrivateKey(address: string): Promise<string | null>;
+  putPrivateKey(address: string, privateKey: string): Promise<void>;
+  getAddressesWithPrivateKeys(): Promise<Array<string>>;
+}

--- a/src/chains/filecoin/types/src/database.d.ts
+++ b/src/chains/filecoin/types/src/database.d.ts
@@ -7,6 +7,8 @@ export default class Database extends Emittery {
   db: LevelUp | null;
   tipsets: LevelUp | null;
   blocks: LevelUp | null;
+  accounts: LevelUp | null;
+  privateKeys: LevelUp | null;
   get initialized(): boolean;
   /**
    * The Database handles the creation of the database, and all access to it.

--- a/src/chains/filecoin/types/src/provider.d.ts
+++ b/src/chains/filecoin/types/src/provider.d.ts
@@ -22,13 +22,15 @@ export default class FilecoinProvider
   /**
    * Returns the unlocked accounts
    */
-  getInitialAccounts(): Record<
-    string,
-    {
-      unlocked: boolean;
-      secretKey: string;
-      balance: bigint;
-    }
+  getInitialAccounts(): Promise<
+    Record<
+      string,
+      {
+        unlocked: boolean;
+        secretKey: string;
+        balance: bigint;
+      }
+    >
   >;
   connect(): Promise<void>;
   send(payload: JsonRpc.Request<FilecoinApi>): Promise<any>;

--- a/src/chains/filecoin/types/src/things/account.d.ts
+++ b/src/chains/filecoin/types/src/things/account.d.ts
@@ -26,15 +26,16 @@ declare type AccountConfig = {
     };
   };
 };
-declare type C = AccountConfig;
 declare class Account
-  extends SerializableObject<C>
-  implements DeserializedObject<C> {
+  extends SerializableObject<AccountConfig>
+  implements DeserializedObject<AccountConfig> {
   #private;
-  get config(): Definitions<C>;
+  get config(): Definitions<AccountConfig>;
   static random(defaultFIL: number, rng?: utils.RandomNumberGenerator): Account;
   constructor(
-    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+    options?:
+      | Partial<SerializedObject<AccountConfig>>
+      | Partial<DeserializedObject<AccountConfig>>
   );
   addBalance(val: string | number | bigint): void;
   subtractBalance(val: string | number | bigint): void;
@@ -42,5 +43,5 @@ declare class Account
   nonce: number;
   get balance(): Balance;
 }
-declare type SerializedAccount = SerializedObject<C>;
+declare type SerializedAccount = SerializedObject<AccountConfig>;
 export { Account, AccountConfig, SerializedAccount };

--- a/src/chains/filecoin/types/src/things/account.d.ts
+++ b/src/chains/filecoin/types/src/things/account.d.ts
@@ -1,0 +1,46 @@
+import { RandomNumberGenerator } from "@ganache/utils/src/utils";
+import { Address, SerializedAddress } from "./address";
+import { Balance, SerializedBalance } from "./balance";
+import {
+  Definitions,
+  DeserializedObject,
+  SerializableObject,
+  SerializedObject
+} from "./serializable-object";
+declare type AccountConfig = {
+  properties: {
+    address: {
+      type: Address;
+      serializedType: SerializedAddress;
+      serializedName: "Address";
+    };
+    balance: {
+      type: Balance;
+      serializedType: SerializedBalance;
+      serializedName: "Balance";
+    };
+    nonce: {
+      type: number;
+      serializedType: number;
+      serializedName: "Nonce";
+    };
+  };
+};
+declare type C = AccountConfig;
+declare class Account
+  extends SerializableObject<C>
+  implements DeserializedObject<C> {
+  #private;
+  get config(): Definitions<C>;
+  static random(defaultFIL: number, rng?: RandomNumberGenerator): Account;
+  constructor(
+    options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
+  );
+  addBalance(val: string | number | bigint): void;
+  subtractBalance(val: string | number | bigint): void;
+  readonly address: Address;
+  nonce: number;
+  get balance(): Balance;
+}
+declare type SerializedAccount = SerializedObject<C>;
+export { Account, AccountConfig, SerializedAccount };

--- a/src/chains/filecoin/types/src/things/account.d.ts
+++ b/src/chains/filecoin/types/src/things/account.d.ts
@@ -1,4 +1,4 @@
-import { RandomNumberGenerator } from "@ganache/utils/src/utils";
+import { utils } from "@ganache/utils";
 import { Address, SerializedAddress } from "./address";
 import { Balance, SerializedBalance } from "./balance";
 import {
@@ -32,7 +32,7 @@ declare class Account
   implements DeserializedObject<C> {
   #private;
   get config(): Definitions<C>;
-  static random(defaultFIL: number, rng?: RandomNumberGenerator): Account;
+  static random(defaultFIL: number, rng?: utils.RandomNumberGenerator): Account;
   constructor(
     options?: Partial<SerializedObject<C>> | Partial<DeserializedObject<C>>
   );

--- a/src/chains/filecoin/types/src/things/address.d.ts
+++ b/src/chains/filecoin/types/src/things/address.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 import { SerializableLiteral } from "./serializable-literal";
 import { StartDealParams } from "./start-deal-params";
-import { RandomNumberGenerator } from "@ganache/utils/src/utils";
+import { utils } from "@ganache/utils";
 interface AddressConfig {
   type: string;
 }
@@ -33,7 +33,7 @@ declare class Address extends SerializableLiteral<AddressConfig> {
     network?: AddressNetwork
   ): Address;
   static random(
-    rng?: RandomNumberGenerator,
+    rng?: utils.RandomNumberGenerator,
     protocol?: AddressProtocol,
     network?: AddressNetwork
   ): Address;

--- a/src/chains/filecoin/types/src/things/address.d.ts
+++ b/src/chains/filecoin/types/src/things/address.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 import { SerializableLiteral } from "./serializable-literal";
 import { StartDealParams } from "./start-deal-params";
-import { utils } from "@ganache/utils";
+import { RandomNumberGenerator } from "@ganache/utils/src/utils";
 interface AddressConfig {
   type: string;
 }
@@ -33,7 +33,7 @@ declare class Address extends SerializableLiteral<AddressConfig> {
     network?: AddressNetwork
   ): Address;
   static random(
-    rng?: utils.RandomNumberGenerator,
+    rng?: RandomNumberGenerator,
     protocol?: AddressProtocol,
     network?: AddressNetwork
   ): Address;

--- a/src/chains/filecoin/types/src/things/balance.d.ts
+++ b/src/chains/filecoin/types/src/things/balance.d.ts
@@ -4,7 +4,11 @@ interface BalanceConfig {
 }
 declare class Balance extends SerializableLiteral<BalanceConfig> {
   get config(): LiteralDefinition<BalanceConfig>;
-  sub(val: string | number | bigint): Balance;
+  sub(val: string | number | bigint): void;
+  add(val: string | number | bigint): void;
   toFIL(): number;
+  static FILToLowestDenomination(fil: number): bigint;
+  static LowestDenominationToFIL(attoFil: bigint): number;
 }
-export default Balance;
+declare type SerializedBalance = string;
+export { Balance, SerializedBalance };

--- a/src/packages/cli/src/cli.ts
+++ b/src/packages/cli/src/cli.ts
@@ -123,12 +123,18 @@ async function startGanache(err: Error) {
 
   switch (flavor) {
     case FilecoinFlavorName: {
-      initializeFilecoin(server.provider as FilecoinProvider, cliSettings);
+      await initializeFilecoin(
+        server.provider as FilecoinProvider,
+        cliSettings
+      );
       break;
     }
     case EthereumFlavorName:
     default: {
-      initializeEthereum(server.provider as EthereumProvider, cliSettings);
+      await initializeEthereum(
+        server.provider as EthereumProvider,
+        cliSettings
+      );
       break;
     }
   }

--- a/src/packages/cli/src/cli.ts
+++ b/src/packages/cli/src/cli.ts
@@ -131,10 +131,7 @@ async function startGanache(err: Error) {
     }
     case EthereumFlavorName:
     default: {
-      await initializeEthereum(
-        server.provider as EthereumProvider,
-        cliSettings
-      );
+      initializeEthereum(server.provider as EthereumProvider, cliSettings);
       break;
     }
   }

--- a/src/packages/cli/src/initialize/ethereum.ts
+++ b/src/packages/cli/src/initialize/ethereum.ts
@@ -2,7 +2,7 @@ import { Provider } from "@ganache/ethereum";
 import { toChecksumAddress } from "ethereumjs-util";
 import { CliSettings } from "../types";
 
-export default function (provider: Provider, cliSettings: CliSettings) {
+export default async function (provider: Provider, cliSettings: CliSettings) {
   const liveOptions = provider.getOptions();
   const accounts = provider.getInitialAccounts();
 

--- a/src/packages/cli/src/initialize/ethereum.ts
+++ b/src/packages/cli/src/initialize/ethereum.ts
@@ -2,7 +2,7 @@ import { Provider } from "@ganache/ethereum";
 import { toChecksumAddress } from "ethereumjs-util";
 import { CliSettings } from "../types";
 
-export default async function (provider: Provider, cliSettings: CliSettings) {
+export default function (provider: Provider, cliSettings: CliSettings) {
   const liveOptions = provider.getOptions();
   const accounts = provider.getInitialAccounts();
 

--- a/src/packages/cli/src/initialize/filecoin.ts
+++ b/src/packages/cli/src/initialize/filecoin.ts
@@ -1,11 +1,11 @@
 import { Provider } from "@ganache/filecoin-types";
 
-export default function (
+export default async function (
   provider: Provider,
   serverSettings: { host: string; port: number }
 ) {
   const liveOptions = provider.getOptions();
-  const accounts = provider.getInitialAccounts();
+  const accounts = await provider.getInitialAccounts();
 
   console.log("");
   console.log("Available Accounts");


### PR DESCRIPTION
This PR adds the support necessary to generate a configurable amount of accounts, instead of only having one account. The implementation allows for recovery of all of those accounts on subsequent runs using the same DB without needing to specify the same wallet options (seed, total accounts, etc). Users only need to run `ganache filecoin --database.dbPath </path/to/db>` to resume where they left off.