### PR TITLE
implement ID protocol addresses

### DIFF
--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -252,11 +252,11 @@ export default class FilecoinApi implements types.Api {
   // for the mining side of things (since Ganache
   // represents multiple actors in this simulator)
   async "Filecoin.ActorAddress"(): Promise<string> {
-    return this.#blockchain.miner;
+    return this.#blockchain.miner.value;
   }
 
   async "Filecoin.StateListMiners"(): Promise<Array<string>> {
-    return [this.#blockchain.miner];
+    return [this.#blockchain.miner.value];
   }
 
   // "A storage miner's storage power is a value roughly proportional
@@ -275,7 +275,7 @@ export default class FilecoinApi implements types.Api {
   async "Filecoin.StateMinerPower"(
     minerAddress: string
   ): Promise<SerializedMinerPower> {
-    if (minerAddress === this.#blockchain.miner) {
+    if (minerAddress === this.#blockchain.miner.value) {
       const power = new MinerPower({
         minerPower: new PowerClaim({
           rawBytePower: 1n,
@@ -312,9 +312,9 @@ export default class FilecoinApi implements types.Api {
   async "Filecoin.StateMinerInfo"(
     minerAddress: string
   ): Promise<SerializedMinerInfo> {
-    if (minerAddress === this.#blockchain.miner) {
+    if (minerAddress === this.#blockchain.miner.value) {
       // The defaults are set up to correspond to the current
-      // miner address t01000, which is not configurable currently
+      // miner address t0100, which is not configurable currently
       return new MinerInfo().serialize();
     } else {
       throw new Error("Failed to load miner actor: actor not found");

--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -42,7 +42,7 @@ export type BlockchainEvents = {
 };
 
 // Reference implementation: https://git.io/JtEVW
-const BurntFundsAddress = "t099";
+const BurntFundsAddress = Address.fromId(99, true);
 
 export default class Blockchain extends Emittery.Typed<
   BlockchainEvents,
@@ -55,7 +55,7 @@ export default class Blockchain extends Emittery.Typed<
   public signedMessagesManager: SignedMessageManager | null;
   public blockMessagesManager: BlockMessagesManager | null;
 
-  readonly miner: string; // using string until we can support more address types in Address
+  readonly miner: Address;
   readonly #miningLock: Sema;
 
   public messagePool: Array<SignedMessage>;
@@ -81,7 +81,7 @@ export default class Blockchain extends Emittery.Typed<
 
     this.rng = new utils.RandomNumberGenerator(this.options.wallet.seed);
 
-    this.miner = "t01000";
+    this.miner = Address.fromId(0);
 
     this.messagePool = [];
     this.#messagePoolLock = new Sema(1);
@@ -470,7 +470,7 @@ export default class Blockchain extends Emittery.Typed<
           // send mining funds
           let successful = await this.accountManager!.transferFunds(
             from,
-            this.miner,
+            this.miner.value,
             getMinerFee(signedMessage.message)
           );
 

--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -452,7 +452,7 @@ export default class Blockchain extends Emittery.Typed<
           if (baseFee !== 0) {
             const successful = await this.accountManager!.transferFunds(
               from,
-              BurntFundsAddress,
+              BurntFundsAddress.value,
               getMinerFee(signedMessage.message)
             );
 
@@ -704,7 +704,7 @@ export default class Blockchain extends Emittery.Typed<
     let totalPrice = BigInt(deal.pricePerEpoch) * BigInt(deal.duration);
     await this.accountManager!.transferFunds(
       proposal.wallet.value,
-      proposal.miner,
+      proposal.miner.value,
       totalPrice
     );
 
@@ -730,7 +730,7 @@ export default class Blockchain extends Emittery.Typed<
     let hasLocal: boolean = await this.hasLocal(retrievalOrder.root.root.value);
 
     const account = await this.accountManager!.getAccount(
-      retrievalOrder.client
+      retrievalOrder.client.value
     );
     if (!account.address.privateKey) {
       throw new Error(
@@ -745,8 +745,8 @@ export default class Blockchain extends Emittery.Typed<
     await this.downloadFile(retrievalOrder.root.root.value, ref);
 
     await this.accountManager!.transferFunds(
-      retrievalOrder.client,
-      retrievalOrder.miner,
+      retrievalOrder.client.value,
+      retrievalOrder.miner.value,
       retrievalOrder.total
     );
   }

--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -81,7 +81,7 @@ export default class Blockchain extends Emittery.Typed<
 
     this.rng = new utils.RandomNumberGenerator(this.options.wallet.seed);
 
-    this.miner = Address.fromId(0);
+    this.miner = Address.fromId(0, false, true);
 
     this.messagePool = [];
     this.#messagePoolLock = new Sema(1);

--- a/src/chains/filecoin/filecoin/src/things/address.ts
+++ b/src/chains/filecoin/filecoin/src/things/address.ts
@@ -42,6 +42,7 @@ class Address extends SerializableLiteral<AddressConfig> {
     return {};
   }
 
+  static readonly FirstNonSingletonActorId = 100; // Ref impl: https://git.io/JtgqT
   static readonly CHECKSUM_BYTES = 4;
 
   #privateKey?: string;
@@ -265,6 +266,29 @@ class Address extends SerializableLiteral<AddressConfig> {
         return AddressProtocol.Unknown;
       }
     }
+  }
+
+  /**
+   * Creates an AddressProtocol.ID address
+   * @param id A positive integer for the id.
+   * @param isSingletonSystemActor If false, it adds Address.FirstNonSingletonActorId to the id.
+   * Almost always `false`. See https://git.io/JtgqL for examples of singleton system actors.
+   * @param network The AddressNetwork prefix for the address; usually AddressNetwork.Testnet for Ganache.
+   */
+  static fromId(
+    id: number,
+    isSingletonSystemActor: boolean = false,
+    network: AddressNetwork = AddressNetwork.Testnet
+  ): Address {
+    if (Math.round(id) !== id || id < 0) {
+      throw new Error("id must be a positive integer");
+    }
+
+    return new Address(
+      `${network}${AddressProtocol.ID}${
+        isSingletonSystemActor ? id : Address.FirstNonSingletonActorId + id
+      }`
+    );
   }
 }
 

--- a/src/chains/filecoin/filecoin/src/things/address.ts
+++ b/src/chains/filecoin/filecoin/src/things/address.ts
@@ -43,6 +43,7 @@ class Address extends SerializableLiteral<AddressConfig> {
   }
 
   static readonly FirstNonSingletonActorId = 100; // Ref impl: https://git.io/JtgqT
+  static readonly FirstMinerId = 1000; // Ref impl: https://git.io/Jt2WE
   static readonly CHECKSUM_BYTES = 4;
 
   #privateKey?: string;
@@ -278,6 +279,7 @@ class Address extends SerializableLiteral<AddressConfig> {
   static fromId(
     id: number,
     isSingletonSystemActor: boolean = false,
+    isMiner: boolean = false,
     network: AddressNetwork = AddressNetwork.Testnet
   ): Address {
     if (Math.round(id) !== id || id < 0) {
@@ -286,7 +288,11 @@ class Address extends SerializableLiteral<AddressConfig> {
 
     return new Address(
       `${network}${AddressProtocol.ID}${
-        isSingletonSystemActor ? id : Address.FirstNonSingletonActorId + id
+        isSingletonSystemActor
+          ? id
+          : isMiner
+          ? Address.FirstMinerId + id
+          : Address.FirstNonSingletonActorId + id
       }`
     );
   }

--- a/src/chains/filecoin/filecoin/src/things/block-header.ts
+++ b/src/chains/filecoin/filecoin/src/things/block-header.ts
@@ -10,14 +10,15 @@ import {
 import { PoStProof, SerializedPoStProof } from "./post-proof";
 import { RootCID, SerializedRootCID } from "./root-cid";
 import { SerializedSignature, Signature } from "./signature";
+import { Address, SerializedAddress } from "./address";
 
 // https://pkg.go.dev/github.com/filecoin-project/lotus@v1.4.0/chain/types#BlockHeader
 
 interface BlockHeaderConfig {
   properties: {
     miner: {
-      type: string; // string until we can support more address types in Address
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Miner";
     };
     ticket: {
@@ -106,7 +107,8 @@ class BlockHeader
       miner: {
         deserializedName: "miner",
         serializedName: "Miner",
-        defaultValue: "t01000"
+        defaultValue: literal =>
+          literal ? new Address(literal) : Address.fromId(0)
       },
       ticket: {
         deserializedName: "ticket",
@@ -246,7 +248,7 @@ class BlockHeader
     );
   }
 
-  miner: string;
+  miner: Address;
   ticket: Ticket;
   electionProof: ElectionProof;
   beaconEntries: Array<BeaconEntry>;

--- a/src/chains/filecoin/filecoin/src/things/block-header.ts
+++ b/src/chains/filecoin/filecoin/src/things/block-header.ts
@@ -108,7 +108,7 @@ class BlockHeader
         deserializedName: "miner",
         serializedName: "Miner",
         defaultValue: literal =>
-          literal ? new Address(literal) : Address.fromId(0)
+          literal ? new Address(literal) : Address.fromId(0, false, true)
       },
       ticket: {
         deserializedName: "ticket",

--- a/src/chains/filecoin/filecoin/src/things/deal-info.ts
+++ b/src/chains/filecoin/filecoin/src/things/deal-info.ts
@@ -18,6 +18,7 @@ import {
   DataTransferChannel,
   SerializedDataTransferChannel
 } from "./data-transfer-channel";
+import { Address, SerializedAddress } from "./address";
 
 // https://pkg.go.dev/github.com/filecoin-project/lotus@v1.4.0/api#DealInfo
 
@@ -39,8 +40,8 @@ type DealInfoConfig = {
       serializedName: "Message";
     };
     provider: {
-      type: string; // using string until we can support more address types in Address
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Provider";
     };
     dataRef: {
@@ -119,7 +120,8 @@ class DealInfo
       provider: {
         deserializedName: "provider",
         serializedName: "Provider",
-        defaultValue: "t01000"
+        defaultValue: literal =>
+          literal ? new Address(literal) : Address.fromId(0)
       },
       dataRef: {
         deserializedName: "dataRef",
@@ -212,7 +214,7 @@ class DealInfo
   proposalCid: RootCID;
   state: StorageDealStatus;
   message: string;
-  provider: string;
+  provider: Address;
   dataRef: StorageMarketDataRef;
   pieceCid: RootCID | null;
   size: number;

--- a/src/chains/filecoin/filecoin/src/things/deal-info.ts
+++ b/src/chains/filecoin/filecoin/src/things/deal-info.ts
@@ -121,7 +121,7 @@ class DealInfo
         deserializedName: "provider",
         serializedName: "Provider",
         defaultValue: literal =>
-          literal ? new Address(literal) : Address.fromId(0)
+          literal ? new Address(literal) : Address.fromId(0, false, true)
       },
       dataRef: {
         deserializedName: "dataRef",

--- a/src/chains/filecoin/filecoin/src/things/miner-info.ts
+++ b/src/chains/filecoin/filecoin/src/things/miner-info.ts
@@ -5,24 +5,25 @@ import {
   Definitions
 } from "./serializable-object";
 import { RegisteredSealProof } from "../types/registered-seal-proof";
+import { Address, SerializedAddress } from "./address";
 
 // https://pkg.go.dev/github.com/filecoin-project/lotus@v1.4.0/chain/actors/builtin/miner#MinerInfo
 
 type MinerInfoConfig = {
   properties: {
     owner: {
-      type: string;
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Owner";
     };
     worker: {
-      type: string;
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Worker";
     };
     newWorker: {
-      type: string;
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "NewWorker";
     };
     controlAddresses: {
@@ -76,17 +77,20 @@ class MinerInfo
       owner: {
         deserializedName: "owner",
         serializedName: "Owner",
-        defaultValue: "t01000"
+        defaultValue: literal =>
+          literal ? new Address(literal) : Address.fromId(0)
       },
       worker: {
         deserializedName: "worker",
         serializedName: "Worker",
-        defaultValue: "t01000"
+        defaultValue: literal =>
+          literal ? new Address(literal) : Address.fromId(0)
       },
       newWorker: {
         deserializedName: "newWorker",
         serializedName: "NewWorker",
-        defaultValue: "<empty>" // This is how lotus-devnet responds to StateMinerInfo
+        defaultValue: literal =>
+          literal ? new Address(literal) : Address.fromId(0)
       },
       controlAddresses: {
         deserializedName: "controlAddresses",
@@ -172,12 +176,12 @@ class MinerInfo
   /**
    * The owner address corresponds to a Lotus node address provided during the miner initialization.
    */
-  owner: string;
+  owner: Address;
   /**
    * The worker address is used to send and pay for day-to-day operations performed by the miner.
    */
-  worker: string;
-  newWorker: string;
+  worker: Address;
+  newWorker: Address;
   /**
    * Control addresses are used to submit WindowPoSts proofs to the chain (unused by Ganache).
    */

--- a/src/chains/filecoin/filecoin/src/things/miner-info.ts
+++ b/src/chains/filecoin/filecoin/src/things/miner-info.ts
@@ -78,19 +78,19 @@ class MinerInfo
         deserializedName: "owner",
         serializedName: "Owner",
         defaultValue: literal =>
-          literal ? new Address(literal) : Address.fromId(0)
+          literal ? new Address(literal) : Address.fromId(0, false, true)
       },
       worker: {
         deserializedName: "worker",
         serializedName: "Worker",
         defaultValue: literal =>
-          literal ? new Address(literal) : Address.fromId(0)
+          literal ? new Address(literal) : Address.fromId(0, false, true)
       },
       newWorker: {
         deserializedName: "newWorker",
         serializedName: "NewWorker",
         defaultValue: literal =>
-          literal ? new Address(literal) : Address.fromId(0)
+          literal ? new Address(literal) : Address.fromId(0, false, true)
       },
       controlAddresses: {
         deserializedName: "controlAddresses",

--- a/src/chains/filecoin/filecoin/src/things/query-offer.ts
+++ b/src/chains/filecoin/filecoin/src/things/query-offer.ts
@@ -6,6 +6,7 @@ import {
   Definitions
 } from "./serializable-object";
 import { RetrievalPeer, SerializedRetrievalPeer } from "./retrieval-peer";
+import { Address, SerializedAddress } from "./address";
 
 // https://pkg.go.dev/github.com/filecoin-project/lotus@v1.4.0/api#QueryOffer
 
@@ -52,8 +53,8 @@ type QueryOfferConfig = {
       serializedName: "PaymentIntervalIncrease";
     };
     miner: {
-      type: string; // using string until we can support more address types in Address
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Miner";
     };
     minerPeer: {
@@ -112,7 +113,8 @@ class QueryOffer
       miner: {
         deserializedName: "miner",
         serializedName: "Miner",
-        defaultValue: "t01000"
+        defaultValue: literal =>
+          literal ? new Address(literal) : Address.fromId(0)
       },
       minerPeer: {
         deserializedName: "minerPeer",
@@ -155,7 +157,7 @@ class QueryOffer
   unsealPrice: bigint;
   paymentInterval: number;
   paymentIntervalIncrease: number;
-  miner: string;
+  miner: Address;
   minerPeer: RetrievalPeer;
 }
 

--- a/src/chains/filecoin/filecoin/src/things/query-offer.ts
+++ b/src/chains/filecoin/filecoin/src/things/query-offer.ts
@@ -114,7 +114,7 @@ class QueryOffer
         deserializedName: "miner",
         serializedName: "Miner",
         defaultValue: literal =>
-          literal ? new Address(literal) : Address.fromId(0)
+          literal ? new Address(literal) : Address.fromId(0, false, true)
       },
       minerPeer: {
         deserializedName: "minerPeer",

--- a/src/chains/filecoin/filecoin/src/things/retrieval-order.ts
+++ b/src/chains/filecoin/filecoin/src/things/retrieval-order.ts
@@ -109,13 +109,13 @@ class RetrievalOrder
         deserializedName: "client",
         serializedName: "Client",
         defaultValue: literal =>
-          literal ? new Address(literal) : Address.fromId(1)
+          literal ? new Address(literal) : Address.fromId(0)
       },
       miner: {
         deserializedName: "miner",
         serializedName: "Miner",
         defaultValue: literal =>
-          literal ? new Address(literal) : Address.fromId(0)
+          literal ? new Address(literal) : Address.fromId(0, false, true)
       },
       minerPeer: {
         deserializedName: "minerPeer",
@@ -157,8 +157,8 @@ class RetrievalOrder
   unsealPrice: bigint;
   paymentInterval: number;
   paymentIntervalIncrease: number;
-  client: string;
-  miner: string;
+  client: Address;
+  miner: Address;
   minerPeer: RetrievalPeer;
 }
 

--- a/src/chains/filecoin/filecoin/src/things/retrieval-order.ts
+++ b/src/chains/filecoin/filecoin/src/things/retrieval-order.ts
@@ -6,6 +6,7 @@ import {
   Definitions
 } from "./serializable-object";
 import { RetrievalPeer, SerializedRetrievalPeer } from "./retrieval-peer";
+import { Address, SerializedAddress } from "./address";
 
 // https://pkg.go.dev/github.com/filecoin-project/lotus@v1.4.0/api#RetrievalOrder
 
@@ -47,12 +48,12 @@ type RetrievalOrderConfig = {
       serializedName: "PaymentIntervalIncrease";
     };
     client: {
-      type: string; // using string until we can support more address types in Address
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Client";
     };
     miner: {
-      type: string; // using string until we can support more address types in Address
+      type: Address;
       serializedType: string;
       serializedName: "Miner";
     };
@@ -107,12 +108,14 @@ class RetrievalOrder
       client: {
         deserializedName: "client",
         serializedName: "Client",
-        defaultValue: "t02000"
+        defaultValue: literal =>
+          literal ? new Address(literal) : Address.fromId(1)
       },
       miner: {
         deserializedName: "miner",
         serializedName: "Miner",
-        defaultValue: "t01000"
+        defaultValue: literal =>
+          literal ? new Address(literal) : Address.fromId(0)
       },
       minerPeer: {
         deserializedName: "minerPeer",

--- a/src/chains/filecoin/filecoin/src/things/retrieval-order.ts
+++ b/src/chains/filecoin/filecoin/src/things/retrieval-order.ts
@@ -54,7 +54,7 @@ type RetrievalOrderConfig = {
     };
     miner: {
       type: Address;
-      serializedType: string;
+      serializedType: SerializedAddress;
       serializedName: "Miner";
     };
     minerPeer: {

--- a/src/chains/filecoin/filecoin/src/things/retrieval-peer.ts
+++ b/src/chains/filecoin/filecoin/src/things/retrieval-peer.ts
@@ -5,14 +5,15 @@ import {
   Definitions
 } from "./serializable-object";
 import { RootCID, SerializedRootCID } from "./root-cid";
+import { Address, SerializedAddress } from "./address";
 
 // https://pkg.go.dev/github.com/filecoin-project/go-fil-markets@v1.1.1/retrievalmarket#RetrievalPeer
 
 type RetrievalPeerConfig = {
   properties: {
     address: {
-      type: string; // using string until we can support more address types in Address
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Address";
     };
     id: {
@@ -36,7 +37,8 @@ class RetrievalPeer
       address: {
         deserializedName: "address",
         serializedName: "Address",
-        defaultValue: "t01000"
+        defaultValue: literal =>
+          literal ? new Address(literal) : Address.fromId(0)
       },
       id: {
         deserializedName: "id",
@@ -63,7 +65,7 @@ class RetrievalPeer
     this.pieceCID = super.initializeValue(this.config.pieceCID, options);
   }
 
-  address: string;
+  address: Address;
   id: string;
   pieceCID: RootCID;
 }

--- a/src/chains/filecoin/filecoin/src/things/retrieval-peer.ts
+++ b/src/chains/filecoin/filecoin/src/things/retrieval-peer.ts
@@ -38,7 +38,7 @@ class RetrievalPeer
         deserializedName: "address",
         serializedName: "Address",
         defaultValue: literal =>
-          literal ? new Address(literal) : Address.fromId(0)
+          literal ? new Address(literal) : Address.fromId(0, false, true)
       },
       id: {
         deserializedName: "id",

--- a/src/chains/filecoin/filecoin/src/things/start-deal-params.ts
+++ b/src/chains/filecoin/filecoin/src/things/start-deal-params.ts
@@ -25,8 +25,8 @@ type StartDealParamsConfig = {
       serializedName: "Wallet";
     };
     miner: {
-      type: string; // using string until we can support more address types in Address
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Miner";
     };
     epochPrice: {
@@ -80,7 +80,8 @@ class StartDealParams
       miner: {
         deserializedName: "miner",
         serializedName: "Miner",
-        defaultValue: "t01000"
+        defaultValue: literal =>
+          literal ? new Address(literal) : Address.fromId(0)
       },
       epochPrice: {
         deserializedName: "epochPrice",
@@ -150,7 +151,7 @@ class StartDealParams
 
   data: StorageMarketDataRef;
   wallet: Address | null;
-  miner: string;
+  miner: Address;
   epochPrice: bigint;
   minBlocksDuration: number;
   providerCollateral: bigint;

--- a/src/chains/filecoin/filecoin/src/things/start-deal-params.ts
+++ b/src/chains/filecoin/filecoin/src/things/start-deal-params.ts
@@ -81,7 +81,7 @@ class StartDealParams
         deserializedName: "miner",
         serializedName: "Miner",
         defaultValue: literal =>
-          literal ? new Address(literal) : Address.fromId(0)
+          literal ? new Address(literal) : Address.fromId(0, false, true)
       },
       epochPrice: {
         deserializedName: "epochPrice",

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
@@ -15,6 +15,7 @@ import { SerializedFileRef } from "../../../src/things/file-ref";
 import tmp from "tmp-promise";
 import path from "path";
 import fs from "fs";
+import { Address } from "../../../src/things/address";
 
 const LotusRPC = require("@filecoin-shipyard/lotus-client-rpc").LotusRPC;
 
@@ -175,10 +176,10 @@ describe("api", () => {
           PaymentInterval: 1048576,
           PaymentIntervalIncrease: 1048576,
           Client: address,
-          Miner: "t01000",
+          Miner: Address.fromId(0).value,
           MinerPeer: {
-            Address: "t01000",
-            ID: "t01000",
+            Address: Address.fromId(0).value,
+            ID: "0",
             PieceCID: {
               "/": "6vuxqgevbl6irx7tymbj7o4t8bz1s5vy88zmum7flxywy1qugjfd"
             }

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
@@ -176,9 +176,9 @@ describe("api", () => {
           PaymentInterval: 1048576,
           PaymentIntervalIncrease: 1048576,
           Client: address,
-          Miner: Address.fromId(0).value,
+          Miner: Address.fromId(0, false, true).value,
           MinerPeer: {
-            Address: Address.fromId(0).value,
+            Address: Address.fromId(0, false, true).value,
             ID: "0",
             PieceCID: {
               "/": "6vuxqgevbl6irx7tymbj7o4t8bz1s5vy88zmum7flxywy1qugjfd"

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/miners.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/miners.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import FilecoinProvider from "../../../src/provider";
+import { Address } from "../../../src/things/address";
 import getProvider from "../../helpers/getProvider";
 
 const LotusRPC = require("@filecoin-shipyard/lotus-client-rpc").LotusRPC;
@@ -26,13 +27,13 @@ describe("api", () => {
       it("should return a single miner", async () => {
         const miners = await client.stateListMiners();
         assert.strictEqual(miners.length, 1);
-        assert.strictEqual(miners[0], "t01000");
+        assert.strictEqual(miners[0], Address.fromId(0));
       });
     });
 
     describe("Filecoin.StateMinerPower", () => {
       it("should returns a nonzero power for the default miner", async () => {
-        const minerPower = await client.stateMinerPower("t01000");
+        const minerPower = await client.stateMinerPower(Address.fromId(0));
 
         // current implementation uses the default for both of these
         assert.deepStrictEqual(minerPower.MinerPower, minerPower.TotalPower);
@@ -42,7 +43,7 @@ describe("api", () => {
       });
 
       it("should returns a zero power for other miners", async () => {
-        const minerPower = await client.stateMinerPower("t01001");
+        const minerPower = await client.stateMinerPower(Address.fromId(1));
 
         // current implementation uses the default for both of these
         assert.deepStrictEqual(minerPower.MinerPower, minerPower.TotalPower);
@@ -54,10 +55,10 @@ describe("api", () => {
 
     describe("Filecoin.StateMinerInfo", () => {
       it("should return the miner info for the default miner", async () => {
-        const minerInfo = await client.stateMinerInfo("t01000");
+        const minerInfo = await client.stateMinerInfo(Address.fromId(0));
 
-        assert.strictEqual(minerInfo.Owner, "t01000");
-        assert.strictEqual(minerInfo.Worker, "t01000");
+        assert.strictEqual(minerInfo.Owner, Address.fromId(0));
+        assert.strictEqual(minerInfo.Worker, Address.fromId(0));
         assert.strictEqual(minerInfo.WorkerChangeEpoch, -1);
         assert.strictEqual(minerInfo.SectorSize, 2048);
         assert.strictEqual(minerInfo.ConsensusFaultElapsed, -1);
@@ -65,9 +66,11 @@ describe("api", () => {
 
       it("should fail to retrieve miner info for other miners", async () => {
         try {
-          const minerInfo = await client.stateMinerInfo("t01001");
+          const minerInfo = await client.stateMinerInfo(Address.fromId(1));
           assert.fail(
-            `Should not have retrieved a miner info for miner t01001, but receive: ${minerInfo}`
+            `Should not have retrieved a miner info for miner ${Address.fromId(
+              1
+            )}, but receive: ${minerInfo}`
           );
         } catch (e) {
           if (e.code === "ERR_ASSERTION") {
@@ -82,7 +85,7 @@ describe("api", () => {
       it("should return the miner info for the default miner", async () => {
         const minerActorAddress = await client.actorAddress();
 
-        assert.strictEqual(minerActorAddress, "t01000");
+        assert.strictEqual(minerActorAddress, Address.fromId(0));
       });
     });
   });

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/miners.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/miners.test.ts
@@ -11,6 +11,7 @@ describe("api", () => {
   describe("filecoin", () => {
     let provider: FilecoinProvider;
     let client: LotusClient;
+    const minerAddress = Address.fromId(0, false, true);
 
     before(async () => {
       provider = await getProvider();
@@ -27,13 +28,13 @@ describe("api", () => {
       it("should return a single miner", async () => {
         const miners = await client.stateListMiners();
         assert.strictEqual(miners.length, 1);
-        assert.strictEqual(miners[0], Address.fromId(0));
+        assert.strictEqual(miners[0], minerAddress.value);
       });
     });
 
     describe("Filecoin.StateMinerPower", () => {
       it("should returns a nonzero power for the default miner", async () => {
-        const minerPower = await client.stateMinerPower(Address.fromId(0));
+        const minerPower = await client.stateMinerPower(minerAddress.value);
 
         // current implementation uses the default for both of these
         assert.deepStrictEqual(minerPower.MinerPower, minerPower.TotalPower);
@@ -43,7 +44,9 @@ describe("api", () => {
       });
 
       it("should returns a zero power for other miners", async () => {
-        const minerPower = await client.stateMinerPower(Address.fromId(1));
+        const minerPower = await client.stateMinerPower(
+          Address.fromId(1, false, true).value
+        );
 
         // current implementation uses the default for both of these
         assert.deepStrictEqual(minerPower.MinerPower, minerPower.TotalPower);
@@ -55,10 +58,10 @@ describe("api", () => {
 
     describe("Filecoin.StateMinerInfo", () => {
       it("should return the miner info for the default miner", async () => {
-        const minerInfo = await client.stateMinerInfo(Address.fromId(0));
+        const minerInfo = await client.stateMinerInfo(minerAddress.value);
 
-        assert.strictEqual(minerInfo.Owner, Address.fromId(0));
-        assert.strictEqual(minerInfo.Worker, Address.fromId(0));
+        assert.strictEqual(minerInfo.Owner, minerAddress.value);
+        assert.strictEqual(minerInfo.Worker, minerAddress.value);
         assert.strictEqual(minerInfo.WorkerChangeEpoch, -1);
         assert.strictEqual(minerInfo.SectorSize, 2048);
         assert.strictEqual(minerInfo.ConsensusFaultElapsed, -1);
@@ -66,11 +69,10 @@ describe("api", () => {
 
       it("should fail to retrieve miner info for other miners", async () => {
         try {
-          const minerInfo = await client.stateMinerInfo(Address.fromId(1));
+          const otherMiner = Address.fromId(1, false, true);
+          const minerInfo = await client.stateMinerInfo(otherMiner.value);
           assert.fail(
-            `Should not have retrieved a miner info for miner ${Address.fromId(
-              1
-            )}, but receive: ${minerInfo}`
+            `Should not have retrieved a miner info for miner ${otherMiner.value}, but receive: ${minerInfo}`
           );
         } catch (e) {
           if (e.code === "ERR_ASSERTION") {
@@ -85,7 +87,7 @@ describe("api", () => {
       it("should return the miner info for the default miner", async () => {
         const minerActorAddress = await client.actorAddress();
 
-        assert.strictEqual(minerActorAddress, Address.fromId(0));
+        assert.strictEqual(minerActorAddress, minerAddress.value);
       });
     });
   });

--- a/src/chains/filecoin/filecoin/tests/things/things.test.ts
+++ b/src/chains/filecoin/filecoin/tests/things/things.test.ts
@@ -5,6 +5,7 @@ import { Tipset } from "../../src/things/tipset";
 import { BlockHeader } from "../../src/things/block-header";
 import IPFSCid from "cids";
 import multihashing from "multihashing";
+import { Address } from "../../src/things/address";
 
 describe("things", () => {
   describe("general", () => {
@@ -94,7 +95,7 @@ describe("things", () => {
 
       let block = new BlockHeader();
 
-      assert.strictEqual(block.miner, "t01000");
+      assert.strictEqual(block.miner, Address.fromId(0));
       assert.strictEqual(block.beaconEntries.length, 0);
       assert.strictEqual(block.winPoStProof.length, 0);
       assert.strictEqual(block.parents.length, 0);

--- a/src/chains/filecoin/filecoin/tests/things/things.test.ts
+++ b/src/chains/filecoin/filecoin/tests/things/things.test.ts
@@ -95,7 +95,10 @@ describe("things", () => {
 
       let block = new BlockHeader();
 
-      assert.strictEqual(block.miner, Address.fromId(0));
+      assert.strictEqual(
+        block.miner.value,
+        Address.fromId(0, false, true).value
+      );
       assert.strictEqual(block.beaconEntries.length, 0);
       assert.strictEqual(block.winPoStProof.length, 0);
       assert.strictEqual(block.parents.length, 0);

--- a/src/chains/filecoin/types/src/blockchain.d.ts
+++ b/src/chains/filecoin/types/src/blockchain.d.ts
@@ -13,6 +13,7 @@ import BlockHeaderManager from "./data-managers/block-header-manager";
 import { SignedMessage } from "./things/signed-message";
 import { Message } from "./things/message";
 import { MessageSendSpec } from "./things/message-send-spec";
+import { Address } from "./things/address";
 import SignedMessageManager from "./data-managers/message-manager";
 import BlockMessagesManager from "./data-managers/block-messages-manager";
 import AccountManager from "./data-managers/account-manager";
@@ -32,7 +33,7 @@ export default class Blockchain extends Emittery.Typed<
   privateKeyManager: PrivateKeyManager | null;
   signedMessagesManager: SignedMessageManager | null;
   blockMessagesManager: BlockMessagesManager | null;
-  readonly miner: string;
+  readonly miner: Address;
   messagePool: Array<SignedMessage>;
   readonly deals: Array<DealInfo>;
   readonly dealsByCid: Record<string, DealInfo>;

--- a/src/chains/filecoin/types/src/things/address.d.ts
+++ b/src/chains/filecoin/types/src/things/address.d.ts
@@ -22,6 +22,8 @@ declare enum AddressNetwork {
 declare class Address extends SerializableLiteral<AddressConfig> {
   #private;
   get config(): {};
+  static readonly FirstNonSingletonActorId = 100;
+  static readonly FirstMinerId = 1000;
   static readonly CHECKSUM_BYTES = 4;
   get privateKey(): string | undefined;
   get network(): AddressNetwork;
@@ -49,6 +51,19 @@ declare class Address extends SerializableLiteral<AddressConfig> {
   static isValid(value: string): boolean;
   static parseNetwork(publicAddress: string): AddressNetwork;
   static parseProtocol(publicAddress: string): AddressProtocol;
+  /**
+   * Creates an AddressProtocol.ID address
+   * @param id A positive integer for the id.
+   * @param isSingletonSystemActor If false, it adds Address.FirstNonSingletonActorId to the id.
+   * Almost always `false`. See https://git.io/JtgqL for examples of singleton system actors.
+   * @param network The AddressNetwork prefix for the address; usually AddressNetwork.Testnet for Ganache.
+   */
+  static fromId(
+    id: number,
+    isSingletonSystemActor?: boolean,
+    isMiner?: boolean,
+    network?: AddressNetwork
+  ): Address;
 }
 declare type SerializedAddress = string;
 export { Address, SerializedAddress, AddressProtocol };

--- a/src/chains/filecoin/types/src/things/block-header.d.ts
+++ b/src/chains/filecoin/types/src/things/block-header.d.ts
@@ -10,11 +10,12 @@ import {
 import { PoStProof, SerializedPoStProof } from "./post-proof";
 import { RootCID, SerializedRootCID } from "./root-cid";
 import { SerializedSignature, Signature } from "./signature";
+import { Address, SerializedAddress } from "./address";
 interface BlockHeaderConfig {
   properties: {
     miner: {
-      type: string;
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Miner";
     };
     ticket: {
@@ -103,7 +104,7 @@ declare class BlockHeader
       | Partial<SerializedObject<BlockHeaderConfig>>
       | Partial<DeserializedObject<BlockHeaderConfig>>
   );
-  miner: string;
+  miner: Address;
   ticket: Ticket;
   electionProof: ElectionProof;
   beaconEntries: Array<BeaconEntry>;

--- a/src/chains/filecoin/types/src/things/deal-info.d.ts
+++ b/src/chains/filecoin/types/src/things/deal-info.d.ts
@@ -15,6 +15,7 @@ import {
   DataTransferChannel,
   SerializedDataTransferChannel
 } from "./data-transfer-channel";
+import { Address, SerializedAddress } from "./address";
 declare type DealInfoConfig = {
   properties: {
     proposalCid: {
@@ -33,8 +34,8 @@ declare type DealInfoConfig = {
       serializedName: "Message";
     };
     provider: {
-      type: string;
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Provider";
     };
     dataRef: {
@@ -101,7 +102,7 @@ declare class DealInfo
   proposalCid: RootCID;
   state: StorageDealStatus;
   message: string;
-  provider: string;
+  provider: Address;
   dataRef: StorageMarketDataRef;
   pieceCid: RootCID | null;
   size: number;

--- a/src/chains/filecoin/types/src/things/miner-info.d.ts
+++ b/src/chains/filecoin/types/src/things/miner-info.d.ts
@@ -4,21 +4,22 @@ import {
   DeserializedObject,
   Definitions
 } from "./serializable-object";
+import { Address, SerializedAddress } from "./address";
 declare type MinerInfoConfig = {
   properties: {
     owner: {
-      type: string;
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Owner";
     };
     worker: {
-      type: string;
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Worker";
     };
     newWorker: {
-      type: string;
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "NewWorker";
     };
     controlAddresses: {
@@ -75,12 +76,12 @@ declare class MinerInfo
   /**
    * The owner address corresponds to a Lotus node address provided during the miner initialization.
    */
-  owner: string;
+  owner: Address;
   /**
    * The worker address is used to send and pay for day-to-day operations performed by the miner.
    */
-  worker: string;
-  newWorker: string;
+  worker: Address;
+  newWorker: Address;
   /**
    * Control addresses are used to submit WindowPoSts proofs to the chain (unused by Ganache).
    */

--- a/src/chains/filecoin/types/src/things/query-offer.d.ts
+++ b/src/chains/filecoin/types/src/things/query-offer.d.ts
@@ -6,6 +6,7 @@ import {
   Definitions
 } from "./serializable-object";
 import { RetrievalPeer, SerializedRetrievalPeer } from "./retrieval-peer";
+import { Address, SerializedAddress } from "./address";
 declare type QueryOfferConfig = {
   properties: {
     err: {
@@ -49,8 +50,8 @@ declare type QueryOfferConfig = {
       serializedName: "PaymentIntervalIncrease";
     };
     miner: {
-      type: string;
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Miner";
     };
     minerPeer: {
@@ -77,7 +78,7 @@ declare class QueryOffer
   unsealPrice: bigint;
   paymentInterval: number;
   paymentIntervalIncrease: number;
-  miner: string;
+  miner: Address;
   minerPeer: RetrievalPeer;
 }
 declare type SerializedQueryOffer = SerializedObject<QueryOfferConfig>;

--- a/src/chains/filecoin/types/src/things/retrieval-order.d.ts
+++ b/src/chains/filecoin/types/src/things/retrieval-order.d.ts
@@ -6,6 +6,7 @@ import {
   Definitions
 } from "./serializable-object";
 import { RetrievalPeer, SerializedRetrievalPeer } from "./retrieval-peer";
+import { Address, SerializedAddress } from "./address";
 declare type RetrievalOrderConfig = {
   properties: {
     root: {
@@ -44,13 +45,13 @@ declare type RetrievalOrderConfig = {
       serializedName: "PaymentIntervalIncrease";
     };
     client: {
-      type: string;
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Client";
     };
     miner: {
-      type: string;
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Miner";
     };
     minerPeer: {
@@ -76,8 +77,8 @@ declare class RetrievalOrder
   unsealPrice: bigint;
   paymentInterval: number;
   paymentIntervalIncrease: number;
-  client: string;
-  miner: string;
+  client: Address;
+  miner: Address;
   minerPeer: RetrievalPeer;
 }
 declare type SerializedRetrievalOrder = SerializedObject<RetrievalOrderConfig>;

--- a/src/chains/filecoin/types/src/things/retrieval-peer.d.ts
+++ b/src/chains/filecoin/types/src/things/retrieval-peer.d.ts
@@ -5,11 +5,12 @@ import {
   Definitions
 } from "./serializable-object";
 import { RootCID, SerializedRootCID } from "./root-cid";
+import { Address, SerializedAddress } from "./address";
 declare type RetrievalPeerConfig = {
   properties: {
     address: {
-      type: string;
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Address";
     };
     id: {
@@ -33,7 +34,7 @@ declare class RetrievalPeer
       | Partial<SerializedObject<RetrievalPeerConfig>>
       | Partial<DeserializedObject<RetrievalPeerConfig>>
   );
-  address: string;
+  address: Address;
   id: string;
   pieceCID: RootCID;
 }

--- a/src/chains/filecoin/types/src/things/start-deal-params.d.ts
+++ b/src/chains/filecoin/types/src/things/start-deal-params.d.ts
@@ -22,8 +22,8 @@ declare type StartDealParamsConfig = {
       serializedName: "Wallet";
     };
     miner: {
-      type: string;
-      serializedType: string;
+      type: Address;
+      serializedType: SerializedAddress;
       serializedName: "Miner";
     };
     epochPrice: {
@@ -69,7 +69,7 @@ declare class StartDealParams
   );
   data: StorageMarketDataRef;
   wallet: Address | null;
-  miner: string;
+  miner: Address;
   epochPrice: bigint;
   minBlocksDuration: number;
   providerCollateral: bigint;


### PR DESCRIPTION
This PR adds support for the `ID` address protocol, and switches all of our usages of it (previously as `string`'s) to use the `Address` class with `AddressProtocol.ID`.