### PR TITLE
implement wallet modification/auxiliary functions

### DIFF
--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -352,15 +352,15 @@ export default class FilecoinApi implements types.Api {
     }
   }
 
-  async "Filecoin.WalletDefaultAddress"(address: string): Promise<void> {
-    await this.#blockchain.waitForReady();
-    await this.#blockchain.privateKeyManager!.setDefault(address);
-  }
-
-  async "Filecoin.WalletSetDefault"(): Promise<SerializedAddress> {
+  async "Filecoin.WalletDefaultAddress"(): Promise<SerializedAddress> {
     await this.#blockchain.waitForReady();
     const accounts = await this.#blockchain.accountManager!.getControllableAccounts();
     return accounts[0].address.serialize();
+  }
+
+  async "Filecoin.WalletSetDefault"(address: string): Promise<void> {
+    await this.#blockchain.waitForReady();
+    await this.#blockchain.privateKeyManager!.setDefault(address);
   }
 
   async "Filecoin.WalletBalance"(address: string): Promise<string> {
@@ -379,6 +379,7 @@ export default class FilecoinApi implements types.Api {
       }
       case KeyType.KeyTypeSecp256k1: {
         protocol = AddressProtocol.SECP256K1;
+        break;
       }
       case KeyType.KeyTypeSecp256k1Ledger:
       default: {
@@ -436,7 +437,7 @@ export default class FilecoinApi implements types.Api {
 
   async "Filecoin.WalletImport"(
     serializedKeyInfo: SerializedKeyInfo
-  ): Promise<void> {
+  ): Promise<SerializedAddress> {
     await this.#blockchain.waitForReady();
 
     const keyInfo = new KeyInfo(serializedKeyInfo);
@@ -461,6 +462,8 @@ export default class FilecoinApi implements types.Api {
       address.value,
       address.privateKey!
     );
+
+    return address.serialize();
   }
 
   async "Filecoin.WalletSign"(

--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -811,6 +811,14 @@ export default class Blockchain extends Emittery.Typed<
     );
   }
 
+  async createAccount(protocol: AddressProtocol): Promise<Account> {
+    await this.waitForReady();
+
+    const account = Account.random(0, this.rng, protocol);
+    await this.accountManager!.putAccount(account);
+    return account;
+  }
+
   private logLatestTipset() {
     let date = new Date().toISOString();
     let tipset = this.latestTipset();

--- a/src/chains/filecoin/filecoin/src/data-managers/private-key-manager.ts
+++ b/src/chains/filecoin/filecoin/src/data-managers/private-key-manager.ts
@@ -30,7 +30,7 @@ export default class PrivateKeyManager {
 
   async putPrivateKey(address: string, privateKey: string) {
     address = address.toLowerCase();
-    await this.base.put(Buffer.from(address), Buffer.from(privateKey));
+    await this.base.put(Buffer.from(address), Buffer.from(privateKey, "hex"));
     const addresses = await this.getAddressesWithPrivateKeys();
     if (!addresses.includes(address)) {
       addresses.push(address);

--- a/src/chains/filecoin/filecoin/src/things/account.ts
+++ b/src/chains/filecoin/filecoin/src/things/account.ts
@@ -1,5 +1,10 @@
 import { utils } from "@ganache/utils";
-import { Address, SerializedAddress } from "./address";
+import {
+  Address,
+  AddressProtocol,
+  SerializedAddress,
+  AddressNetwork
+} from "./address";
 import { Balance, SerializedBalance } from "./balance";
 import {
   Definitions,
@@ -58,10 +63,12 @@ class Account
 
   static random(
     defaultFIL: number,
-    rng: utils.RandomNumberGenerator = new utils.RandomNumberGenerator()
+    rng: utils.RandomNumberGenerator = new utils.RandomNumberGenerator(),
+    protocol: AddressProtocol = AddressProtocol.BLS,
+    network: AddressNetwork = AddressNetwork.Testnet
   ): Account {
     return new Account({
-      address: Address.random(rng),
+      address: Address.random(rng, protocol, network),
       balance: new Balance(
         Balance.FILToLowestDenomination(defaultFIL).toString()
       ),

--- a/src/chains/filecoin/filecoin/src/things/address.ts
+++ b/src/chains/filecoin/filecoin/src/things/address.ts
@@ -133,6 +133,32 @@ class Address extends SerializableLiteral<AddressConfig> {
     }
   }
 
+  async verifySignature(
+    buffer: Buffer,
+    signature: Signature
+  ): Promise<boolean> {
+    switch (this.protocol) {
+      case AddressProtocol.BLS: {
+        return await bls.verify(
+          signature.data,
+          buffer,
+          Address.recoverBLSPublicKey(this.value)
+        );
+      }
+      case AddressProtocol.SECP256K1: {
+        const hash = blake.blake2b(buffer, null, 32);
+        return secp256K1.ecdsaVerify(
+          signature.data.slice(0, 64), // remove the recid suffix (should be the last/65th byte)
+          hash,
+          Address.recoverSECP256K1PublicKey(signature, hash)
+        );
+      }
+      default: {
+        return false; // TODO: throw?
+      }
+    }
+  }
+
   static recoverBLSPublicKey(address: string): Buffer {
     const protocol = Address.parseProtocol(address);
     const customBase32Alphabet = "abcdefghijklmnopqrstuvwxyz234567";
@@ -188,13 +214,7 @@ class Address extends SerializableLiteral<AddressConfig> {
       );
     }
 
-    // Create a checksum using the blake2b algorithm
-    const checksumBuffer = Buffer.concat([Buffer.from([protocol]), payload]);
-    const checksum = blake.blake2b(
-      checksumBuffer,
-      null,
-      Address.CHECKSUM_BYTES
-    );
+    const checksum = Address.createChecksum(protocol, payload);
 
     // Merge the public key and checksum
     const payloadAndChecksum = Buffer.concat([payload, checksum]);
@@ -296,8 +316,90 @@ class Address extends SerializableLiteral<AddressConfig> {
       }`
     );
   }
+
+  static createChecksum(protocol: AddressProtocol, payload: Buffer): Buffer {
+    // Create a checksum using the blake2b algorithm
+    const checksumBuffer = Buffer.concat([Buffer.from([protocol]), payload]);
+    const checksum = blake.blake2b(
+      checksumBuffer,
+      null,
+      Address.CHECKSUM_BYTES
+    );
+    return Buffer.from(checksum.buffer);
+  }
+
+  static validate(inputAddress: string): Address {
+    inputAddress = inputAddress.trim();
+
+    if (inputAddress === "" || inputAddress === "<empty>") {
+      throw new Error("invalid address length");
+    }
+
+    // MaxAddressStringLength is the max length of an address encoded as a string
+    // it includes the network prefix, protocol, and bls publickey (bls is the longest)
+    const MaxAddressStringLength = 2 + 84;
+    if (
+      inputAddress.length > MaxAddressStringLength ||
+      inputAddress.length < 3
+    ) {
+      throw new Error("invalid address length");
+    }
+
+    const address = new Address(inputAddress);
+    const raw = address.value.slice(2);
+
+    if (address.network === AddressNetwork.Unknown) {
+      throw new Error("unknown address network");
+    }
+
+    if (address.protocol === AddressProtocol.Unknown) {
+      throw new Error("unknown address protocol");
+    }
+
+    if (address.protocol === AddressProtocol.ID) {
+      if (raw.length > 20) {
+        throw new Error("invalid address length");
+      }
+      const id = parseInt(raw, 10);
+      if (isNaN(id) || id.toString(10) !== raw) {
+        throw new Error("invalid address payload");
+      }
+      return address;
+    }
+
+    const customBase32Alphabet = "abcdefghijklmnopqrstuvwxyz234567";
+    const payloadWithChecksum = base32.parse(raw, customBase32Alphabet);
+
+    if (payloadWithChecksum.length < Address.CHECKSUM_BYTES) {
+      throw new Error("invalid address checksum");
+    }
+
+    const payload = payloadWithChecksum.slice(
+      0,
+      payloadWithChecksum.length - Address.CHECKSUM_BYTES
+    );
+    const providedChecksum = payloadWithChecksum.slice(
+      payloadWithChecksum.length - Address.CHECKSUM_BYTES
+    );
+
+    if (
+      address.protocol === AddressProtocol.SECP256K1 ||
+      address.protocol === AddressProtocol.Actor
+    ) {
+      if (payload.length !== 20) {
+        throw new Error("invalid address payload");
+      }
+    }
+
+    const generatedChecksum = Address.createChecksum(address.protocol, payload);
+    if (!generatedChecksum.equals(providedChecksum)) {
+      throw new Error("invalid address checksum");
+    }
+
+    return address;
+  }
 }
 
 type SerializedAddress = string;
 
-export { Address, SerializedAddress, AddressProtocol };
+export { Address, SerializedAddress, AddressProtocol, AddressNetwork };

--- a/src/chains/filecoin/filecoin/src/things/address.ts
+++ b/src/chains/filecoin/filecoin/src/things/address.ts
@@ -242,11 +242,6 @@ class Address extends SerializableLiteral<AddressConfig> {
     return Address.fromPrivateKey(privateKey, protocol, network);
   }
 
-  // Note: This does not (yet) check for cryptographic validity!
-  static isValid(value: string): boolean {
-    return value.length == 86 && value.indexOf("t3") == 0;
-  }
-
   static parseNetwork(publicAddress: string): AddressNetwork {
     if (publicAddress.length < 1) {
       return AddressNetwork.Unknown;

--- a/src/chains/filecoin/filecoin/src/things/address.ts
+++ b/src/chains/filecoin/filecoin/src/things/address.ts
@@ -45,6 +45,7 @@ class Address extends SerializableLiteral<AddressConfig> {
   static readonly FirstNonSingletonActorId = 100; // Ref impl: https://git.io/JtgqT
   static readonly FirstMinerId = 1000; // Ref impl: https://git.io/Jt2WE
   static readonly CHECKSUM_BYTES = 4;
+  static readonly CustomBase32Alphabet = "abcdefghijklmnopqrstuvwxyz234567";
 
   #privateKey?: string;
   get privateKey(): string | undefined {
@@ -161,8 +162,10 @@ class Address extends SerializableLiteral<AddressConfig> {
 
   static recoverBLSPublicKey(address: string): Buffer {
     const protocol = Address.parseProtocol(address);
-    const customBase32Alphabet = "abcdefghijklmnopqrstuvwxyz234567";
-    const decoded = base32.parse(address.slice(2), customBase32Alphabet);
+    const decoded = base32.parse(
+      address.slice(2),
+      Address.CustomBase32Alphabet
+    );
     const payload = decoded.slice(0, decoded.length - 4);
 
     if (protocol === AddressProtocol.BLS) {
@@ -221,10 +224,9 @@ class Address extends SerializableLiteral<AddressConfig> {
 
     // Use a custom alphabet to base32 encode the checksummed public key,
     // and prepend the network and protocol identifiers.
-    const customBase32Alphabet = "abcdefghijklmnopqrstuvwxyz234567";
     const address = `${network}${protocol}${base32.stringify(
       payloadAndChecksum,
-      customBase32Alphabet
+      Address.CustomBase32Alphabet
     )}`;
 
     return new Address(address, privateKey);
@@ -362,8 +364,7 @@ class Address extends SerializableLiteral<AddressConfig> {
       return address;
     }
 
-    const customBase32Alphabet = "abcdefghijklmnopqrstuvwxyz234567";
-    const payloadWithChecksum = base32.parse(raw, customBase32Alphabet);
+    const payloadWithChecksum = base32.parse(raw, Address.CustomBase32Alphabet);
 
     if (payloadWithChecksum.length < Address.CHECKSUM_BYTES) {
       throw new Error("invalid address checksum");

--- a/src/chains/filecoin/filecoin/src/things/key-info.ts
+++ b/src/chains/filecoin/filecoin/src/things/key-info.ts
@@ -1,0 +1,64 @@
+import { KeyType } from "./key-type";
+import {
+  SerializableObject,
+  SerializedObject,
+  DeserializedObject,
+  Definitions
+} from "./serializable-object";
+
+// https://pkg.go.dev/github.com/filecoin-project/lotus@v1.4.0/chain/types#KeyInfo
+
+interface KeyInfoConfig {
+  properties: {
+    type: {
+      type: KeyType;
+      serializedType: KeyType;
+      serializedName: "Type";
+    };
+    privateKey: {
+      type: Buffer;
+      serializedType: string;
+      serializedName: "PrivateKey";
+    };
+  };
+}
+
+class KeyInfo
+  extends SerializableObject<KeyInfoConfig>
+  implements DeserializedObject<KeyInfoConfig> {
+  get config(): Definitions<KeyInfoConfig> {
+    return {
+      type: {
+        deserializedName: "type",
+        serializedName: "Type",
+        defaultValue: KeyType.KeyTypeBLS
+      },
+      privateKey: {
+        deserializedName: "privateKey",
+        serializedName: "PrivateKey",
+        defaultValue: literal =>
+          typeof literal !== "undefined"
+            ? Buffer.from(literal, "base64")
+            : Buffer.from([0])
+      }
+    };
+  }
+
+  constructor(
+    options?:
+      | Partial<SerializedObject<KeyInfoConfig>>
+      | Partial<DeserializedObject<KeyInfoConfig>>
+  ) {
+    super();
+
+    this.type = super.initializeValue(this.config.type, options);
+    this.privateKey = super.initializeValue(this.config.privateKey, options);
+  }
+
+  type: KeyType;
+  privateKey: Buffer;
+}
+
+type SerializedKeyInfo = SerializedObject<KeyInfoConfig>;
+
+export { KeyInfo, SerializedKeyInfo };

--- a/src/chains/filecoin/filecoin/src/things/key-type.ts
+++ b/src/chains/filecoin/filecoin/src/things/key-type.ts
@@ -1,0 +1,6 @@
+// Reference implementation: https://git.io/JtwmZ
+export enum KeyType {
+  KeyTypeBLS = "bls",
+  KeyTypeSecp256k1 = "secp256k1",
+  KeyTypeSecp256k1Ledger = "secp256k1-ledger"
+}

--- a/src/chains/filecoin/filecoin/src/things/signature.ts
+++ b/src/chains/filecoin/filecoin/src/things/signature.ts
@@ -11,8 +11,8 @@ import { SigType } from "./sig-type";
 interface SignatureConfig {
   properties: {
     type: {
-      type: number;
-      serializedType: number;
+      type: SigType;
+      serializedType: SigType;
       serializedName: "Type";
     };
     data: {

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/wallet.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/wallet.test.ts
@@ -1,7 +1,14 @@
 import assert from "assert";
 import FilecoinProvider from "../../../src/provider";
 import getProvider from "../../helpers/getProvider";
-import { Address } from "../../../src/things/address";
+import { Address, AddressProtocol } from "../../../src/things/address";
+import { KeyType } from "../../../src/things/key-type";
+import { SerializedKeyInfo } from "../../../src/things/key-info";
+import { SigType } from "../../../src/things/sig-type";
+import { utils } from "@ganache/utils";
+import { Message, SerializedMessage } from "../../../src/things/message";
+import { SerializedSignature } from "../../../src/things/signature";
+import { SerializedSignedMessage } from "../../../src/things/signed-message";
 
 const LotusRPC = require("@filecoin-shipyard/lotus-client-rpc").LotusRPC;
 
@@ -11,6 +18,7 @@ describe("api", () => {
   describe("filecoin", () => {
     let provider: FilecoinProvider;
     let client: LotusClient;
+    let walletAddresses: string[];
 
     before(async () => {
       provider = await getProvider();
@@ -23,12 +31,329 @@ describe("api", () => {
       }
     });
 
+    describe("Filecoin.WalletList", () => {
+      it("should return an array of controlled addresses", async () => {
+        walletAddresses = await client.walletList();
+        assert(Array.isArray(walletAddresses));
+        assert.strictEqual(walletAddresses.length, 10);
+      });
+    });
+
     describe("Filecoin.WalletDefaultAddress", () => {
       it("should return a single address", async () => {
         const address = await client.walletDefaultAddress();
         assert.strictEqual(address.length, 86);
         assert.strictEqual(address.indexOf("t3"), 0);
-        assert(Address.isValid(address));
+        assert.strictEqual(address, walletAddresses[0]);
+      });
+    });
+
+    describe("Filecoin.WalletSetDefault", () => {
+      it("should change the default address", async () => {
+        const oldDefault = walletAddresses[0];
+        const newDefault = walletAddresses[1];
+        let address = await client.walletDefaultAddress();
+        assert.strictEqual(oldDefault, address);
+        await client.walletSetDefault(newDefault);
+        address = await client.walletDefaultAddress();
+        assert.strictEqual(address, newDefault);
+        walletAddresses = await client.walletList();
+        assert.strictEqual(walletAddresses[0], newDefault);
+        assert.strictEqual(walletAddresses[1], oldDefault);
+        assert.strictEqual(walletAddresses.length, 10);
+      });
+    });
+
+    describe("Filecoin.WalletNew", () => {
+      it("should create a new account with a random BLS address", async () => {
+        const addressString = await client.walletNew(KeyType.KeyTypeBLS);
+        const address = new Address(addressString);
+        assert.strictEqual(address.protocol, AddressProtocol.BLS);
+        walletAddresses = await client.walletList();
+        assert.strictEqual(walletAddresses.length, 11);
+        assert.strictEqual(walletAddresses[10], address.value);
+      });
+
+      it("should create a new account with a random SECP256K1 address", async () => {
+        const addressString = await client.walletNew(KeyType.KeyTypeSecp256k1);
+        const address = new Address(addressString);
+        assert.strictEqual(address.protocol, AddressProtocol.SECP256K1);
+        walletAddresses = await client.walletList();
+        assert.strictEqual(walletAddresses.length, 12);
+        assert.strictEqual(walletAddresses[11], address.value);
+      });
+
+      it("should reject creation of a new account for secp256k1-ledger", async () => {
+        try {
+          await client.walletNew("secp256k1-ledger");
+          assert.fail(
+            "Successfully created an account for KeyType secp256k1-ledger"
+          );
+        } catch (e) {
+          if (e.code === "ERR_ASSERTION") {
+            throw e;
+          }
+          assert(
+            e.message.includes(
+              `KeyType of secp256k1-ledger is not supported. Please use "bls" or "secp256k1".`
+            ),
+            e.message
+          );
+        }
+      });
+    });
+
+    describe("Filecoin.WalletHas", () => {
+      it("should confirm that the wallet has a known address", async () => {
+        const hasAddress = await client.walletHas(walletAddresses[0]);
+        assert.strictEqual(hasAddress, true);
+      });
+
+      it("should confirm that the wallet doesn't have an unknown address", async () => {
+        const address = Address.random();
+        const hasAddress = await client.walletHas(address.value);
+        assert.strictEqual(hasAddress, false);
+      });
+    });
+
+    describe("Filecoin.WalletDelete", () => {
+      it("should delete the first address", async () => {
+        const oldDefault = walletAddresses[0];
+        const newDefault = walletAddresses[1];
+        assert.strictEqual(walletAddresses.length, 12);
+        await client.walletDelete(oldDefault);
+        const address = await client.walletDefaultAddress();
+        assert.strictEqual(address, newDefault);
+        walletAddresses = await client.walletList();
+        assert.strictEqual(walletAddresses.length, 11);
+        assert.strictEqual(walletAddresses.includes(oldDefault), false);
+      });
+
+      it("should do nothing when deleting a random address", async () => {
+        const address = Address.random();
+        walletAddresses = await client.walletList();
+        assert.strictEqual(walletAddresses.length, 11);
+        await client.walletDelete(address.value);
+        walletAddresses = await client.walletList();
+        assert.strictEqual(walletAddresses.length, 11);
+      });
+    });
+
+    describe("Filecoin.WalletImport and Filecoin.WalletExport", () => {
+      let addressBLS: Address;
+      let addressSECP256K1: Address;
+
+      it("should import a random BLS address/privatekey", async () => {
+        addressBLS = Address.random();
+        const importedAddress = await client.walletImport({
+          Type: KeyType.KeyTypeBLS,
+          PrivateKey: Buffer.from(addressBLS.privateKey, "hex").toString(
+            "base64"
+          )
+        });
+        assert.strictEqual(importedAddress, addressBLS.value);
+        walletAddresses = await client.walletList();
+        assert.strictEqual(walletAddresses.length, 12);
+        assert.strictEqual(walletAddresses[11], addressBLS.value);
+      });
+
+      it("should import a random SECP256K1 address/privatekey", async () => {
+        addressSECP256K1 = Address.random(
+          new utils.RandomNumberGenerator(),
+          AddressProtocol.SECP256K1
+        );
+        const importedAddress = await client.walletImport({
+          Type: KeyType.KeyTypeSecp256k1,
+          PrivateKey: Buffer.from(addressSECP256K1.privateKey, "hex").toString(
+            "base64"
+          )
+        });
+        assert.strictEqual(importedAddress, addressSECP256K1.value);
+        walletAddresses = await client.walletList();
+        assert.strictEqual(walletAddresses.length, 13);
+        assert.strictEqual(walletAddresses[12], addressSECP256K1.value);
+      });
+
+      it("should reject importing a secp256k1-ledger address", async () => {
+        try {
+          const address = Address.random(
+            new utils.RandomNumberGenerator(),
+            AddressProtocol.SECP256K1
+          );
+          await client.walletImport({
+            Type: KeyType.KeyTypeSecp256k1Ledger,
+            PrivateKey: Buffer.from(address.privateKey, "hex").toString(
+              "base64"
+            )
+          });
+          assert.fail(
+            "Successfully imported an account with KeyType secp256k1-ledger"
+          );
+        } catch (e) {
+          if (e.code === "ERR_ASSERTION") {
+            throw e;
+          }
+          assert(
+            e.message.includes(`Ganache doesn't support ledger accounts`),
+            e.message
+          );
+        }
+      });
+
+      it("should export the private key of a BLS address", async () => {
+        const keyInfo: SerializedKeyInfo = await client.walletExport(
+          addressBLS.value
+        );
+        assert.strictEqual(keyInfo.Type, KeyType.KeyTypeBLS);
+        assert.strictEqual(
+          Buffer.from(keyInfo.PrivateKey, "base64").toString("hex"),
+          addressBLS.privateKey
+        );
+      });
+
+      it("should export the private key of a SECP256K1 address", async () => {
+        const keyInfo: SerializedKeyInfo = await client.walletExport(
+          addressSECP256K1.value
+        );
+        assert.strictEqual(keyInfo.Type, KeyType.KeyTypeSecp256k1);
+        assert.strictEqual(
+          Buffer.from(keyInfo.PrivateKey, "base64").toString("hex"),
+          addressSECP256K1.privateKey
+        );
+      });
+    });
+
+    describe("Filecoin.WalletSign", () => {
+      it("signs a buffer via API", async () => {
+        const account = await provider.blockchain.accountManager!.getAccount(
+          walletAddresses[0]
+        );
+        const buffer = Buffer.from([0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]);
+        const directSignature = await account.address.signBuffer(buffer);
+        const apiSignature: SerializedSignature = await client.walletSign(
+          account.address.value,
+          buffer.toString("base64")
+        );
+        assert.strictEqual(apiSignature.Type, SigType.SigTypeBLS);
+        assert.strictEqual(
+          directSignature.toString("base64"),
+          apiSignature.Data
+        );
+      });
+
+      it("fails to sign a buffer via API for an unknown address", async () => {
+        try {
+          const address = Address.random();
+          const buffer = Buffer.from([0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]);
+          await client.walletSign(address.value, buffer.toString("base64"));
+          assert.fail("Successfully signed a buffer with an unknown address");
+        } catch (e) {
+          if (e.code === "ERR_ASSERTION") {
+            throw e;
+          }
+          assert(
+            e.message.includes(`due to not having the associated private key.`),
+            e.message
+          );
+        }
+      });
+    });
+
+    describe("Filecoin.WalletSignMessage", () => {
+      it("signs a Message via API", async () => {
+        const account = await provider.blockchain.accountManager!.getAccount(
+          walletAddresses[0]
+        );
+        const serializedMessage: SerializedMessage = {
+          Version: 0,
+          To: walletAddresses[1],
+          From: account.address.value,
+          Nonce: 0,
+          Value: "42",
+          GasLimit: 0,
+          GasFeeCap: "0",
+          GasPremium: "0",
+          Method: 0,
+          Params: ""
+        };
+        const directSignature = await account.address.signMessage(
+          new Message(serializedMessage)
+        );
+        const apiSignature: SerializedSignedMessage = await client.walletSignMessage(
+          account.address.value,
+          serializedMessage
+        );
+        assert.strictEqual(apiSignature.Signature.Type, SigType.SigTypeBLS);
+        assert.strictEqual(
+          directSignature.toString("base64"),
+          apiSignature.Signature.Data
+        );
+      });
+
+      it("fails to sign a Message via API for an unknown address", async () => {
+        try {
+          const address = Address.random();
+          const serializedMessage: SerializedMessage = {
+            Version: 0,
+            To: walletAddresses[1],
+            From: address.value,
+            Nonce: 0,
+            Value: "42",
+            GasLimit: 0,
+            GasFeeCap: "0",
+            GasPremium: "0",
+            Method: 0,
+            Params: ""
+          };
+          await client.walletSignMessage(address.value, serializedMessage);
+          assert.fail("Successfully signed a Message with an unknown address");
+        } catch (e) {
+          if (e.code === "ERR_ASSERTION") {
+            throw e;
+          }
+          assert(
+            e.message.includes(`due to not having the associated private key.`),
+            e.message
+          );
+        }
+      });
+    });
+
+    describe("Filecoin.WalletVerify", () => {
+      it("verifies a valid signature", async () => {
+        const account = await provider.blockchain.accountManager!.getAccount(
+          walletAddresses[0]
+        );
+        const buffer = Buffer.from([0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]);
+        const signature = await account.address.signBuffer(buffer);
+        const serializedSignature: SerializedSignature = {
+          Type: SigType.SigTypeBLS,
+          Data: signature.toString("base64")
+        };
+        const isValid = await client.walletVerify(
+          account.address.value,
+          buffer.toString("base64"),
+          serializedSignature
+        );
+        assert.strictEqual(isValid, true);
+      });
+
+      it("rejects an invalid signature", async () => {
+        const account = await provider.blockchain.accountManager!.getAccount(
+          walletAddresses[0]
+        );
+        const buffer = Buffer.from([0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]);
+        const signature = await account.address.signBuffer(buffer);
+        const serializedSignature: SerializedSignature = {
+          Type: SigType.SigTypeBLS,
+          Data: signature.toString("base64")
+        };
+        const isValid = await client.walletVerify(
+          walletAddresses[1],
+          buffer.toString("base64"),
+          serializedSignature
+        );
+        assert.strictEqual(isValid, false);
       });
     });
 

--- a/src/chains/filecoin/filecoin/tests/things/address.test.ts
+++ b/src/chains/filecoin/filecoin/tests/things/address.test.ts
@@ -58,7 +58,7 @@ describe("things", () => {
     it("should create a random address when calling Address.random()", async () => {
       const address = Address.random();
 
-      assert(Address.isValid(address.value));
+      assert.ok(Address.validate(address.value));
     });
 
     it("properly signs a buffer with a BLS address", async () => {

--- a/src/chains/filecoin/types/src/api.d.ts
+++ b/src/chains/filecoin/types/src/api.d.ts
@@ -15,6 +15,9 @@ import { SerializedVersion } from "./things/version";
 import { SerializedMessage } from "./things/message";
 import { SerializedMessageSendSpec } from "./things/message-send-spec";
 import { SerializedSignedMessage } from "./things/signed-message";
+import { KeyType } from "./things/key-type";
+import { SerializedKeyInfo } from "./things/key-info";
+import { SerializedSignature } from "./things/signature";
 export default class FilecoinApi implements types.Api {
   #private;
   readonly [index: string]: (...args: any) => Promise<any>;
@@ -52,7 +55,32 @@ export default class FilecoinApi implements types.Api {
   ): Promise<SerializedMinerPower>;
   "Filecoin.StateMinerInfo"(minerAddress: string): Promise<SerializedMinerInfo>;
   "Filecoin.WalletDefaultAddress"(): Promise<SerializedAddress>;
+  "Filecoin.WalletSetDefault"(address: string): Promise<void>;
   "Filecoin.WalletBalance"(address: string): Promise<string>;
+  "Filecoin.WalletNew"(keyType: KeyType): Promise<SerializedAddress>;
+  "Filecoin.WalletList"(): Promise<Array<SerializedAddress>>;
+  "Filecoin.WalletHas"(address: string): Promise<boolean>;
+  "Filecoin.WalletDelete"(address: string): Promise<void>;
+  "Filecoin.WalletExport"(address: string): Promise<SerializedKeyInfo>;
+  "Filecoin.WalletImport"(
+    serializedKeyInfo: SerializedKeyInfo
+  ): Promise<SerializedAddress>;
+  "Filecoin.WalletSign"(
+    address: string,
+    data: string
+  ): Promise<SerializedSignature>;
+  "Filecoin.WalletSignMessage"(
+    address: string,
+    serializedMessage: SerializedMessage
+  ): Promise<SerializedSignedMessage>;
+  "Filecoin.WalletVerify"(
+    inputAddress: string,
+    data: string,
+    serializedSignature: SerializedSignature
+  ): Promise<boolean>;
+  "Filecoin.WalletValidateAddress"(
+    inputAddress: string
+  ): Promise<SerializedAddress>;
   "Filecoin.ClientStartDeal"(
     serializedProposal: SerializedStartDealParams
   ): Promise<SerializedRootCID>;

--- a/src/chains/filecoin/types/src/blockchain.d.ts
+++ b/src/chains/filecoin/types/src/blockchain.d.ts
@@ -8,12 +8,13 @@ import { FilecoinInternalOptions } from "@ganache/filecoin-options";
 import { QueryOffer } from "./things/query-offer";
 import { FileRef } from "./things/file-ref";
 import { IPFS } from "ipfs";
+import { Account } from "./things/account";
 import TipsetManager from "./data-managers/tipset-manager";
 import BlockHeaderManager from "./data-managers/block-header-manager";
 import { SignedMessage } from "./things/signed-message";
 import { Message } from "./things/message";
 import { MessageSendSpec } from "./things/message-send-spec";
-import { Address } from "./things/address";
+import { Address, AddressProtocol } from "./things/address";
 import SignedMessageManager from "./data-managers/message-manager";
 import BlockMessagesManager from "./data-managers/block-messages-manager";
 import AccountManager from "./data-managers/account-manager";
@@ -66,5 +67,6 @@ export default class Blockchain extends Emittery.Typed<
   startDeal(proposal: StartDealParams): Promise<RootCID>;
   createQueryOffer(rootCid: RootCID): Promise<QueryOffer>;
   retrieve(retrievalOrder: RetrievalOrder, ref: FileRef): Promise<void>;
+  createAccount(protocol: AddressProtocol): Promise<Account>;
   private logLatestTipset;
 }

--- a/src/chains/filecoin/types/src/data-managers/private-key-manager.d.ts
+++ b/src/chains/filecoin/types/src/data-managers/private-key-manager.d.ts
@@ -8,4 +8,7 @@ export default class PrivateKeyManager {
   getPrivateKey(address: string): Promise<string | null>;
   putPrivateKey(address: string, privateKey: string): Promise<void>;
   getAddressesWithPrivateKeys(): Promise<Array<string>>;
+  hasPrivateKey(address: string): Promise<boolean>;
+  deletePrivateKey(address: string): Promise<void>;
+  setDefault(address: string): Promise<void>;
 }

--- a/src/chains/filecoin/types/src/things/account.d.ts
+++ b/src/chains/filecoin/types/src/things/account.d.ts
@@ -1,5 +1,10 @@
 import { utils } from "@ganache/utils";
-import { Address, SerializedAddress } from "./address";
+import {
+  Address,
+  AddressProtocol,
+  SerializedAddress,
+  AddressNetwork
+} from "./address";
 import { Balance, SerializedBalance } from "./balance";
 import {
   Definitions,
@@ -31,7 +36,12 @@ declare class Account
   implements DeserializedObject<AccountConfig> {
   #private;
   get config(): Definitions<AccountConfig>;
-  static random(defaultFIL: number, rng?: utils.RandomNumberGenerator): Account;
+  static random(
+    defaultFIL: number,
+    rng?: utils.RandomNumberGenerator,
+    protocol?: AddressProtocol,
+    network?: AddressNetwork
+  ): Account;
   constructor(
     options?:
       | Partial<SerializedObject<AccountConfig>>

--- a/src/chains/filecoin/types/src/things/address.d.ts
+++ b/src/chains/filecoin/types/src/things/address.d.ts
@@ -33,6 +33,7 @@ declare class Address extends SerializableLiteral<AddressConfig> {
   signProposal(proposal: StartDealParams): Promise<Buffer>;
   signMessage(message: Message): Promise<Buffer>;
   signBuffer(buffer: Buffer): Promise<Buffer>;
+  verifySignature(buffer: Buffer, signature: Signature): Promise<boolean>;
   static recoverBLSPublicKey(address: string): Buffer;
   static recoverSECP256K1PublicKey(
     signature: Signature,
@@ -48,7 +49,6 @@ declare class Address extends SerializableLiteral<AddressConfig> {
     protocol?: AddressProtocol,
     network?: AddressNetwork
   ): Address;
-  static isValid(value: string): boolean;
   static parseNetwork(publicAddress: string): AddressNetwork;
   static parseProtocol(publicAddress: string): AddressProtocol;
   /**
@@ -64,6 +64,8 @@ declare class Address extends SerializableLiteral<AddressConfig> {
     isMiner?: boolean,
     network?: AddressNetwork
   ): Address;
+  static createChecksum(protocol: AddressProtocol, payload: Buffer): Buffer;
+  static validate(inputAddress: string): Address;
 }
 declare type SerializedAddress = string;
-export { Address, SerializedAddress, AddressProtocol };
+export { Address, SerializedAddress, AddressProtocol, AddressNetwork };

--- a/src/chains/filecoin/types/src/things/key-info.d.ts
+++ b/src/chains/filecoin/types/src/things/key-info.d.ts
@@ -1,0 +1,36 @@
+/// <reference types="node" />
+import { KeyType } from "./key-type";
+import {
+  SerializableObject,
+  SerializedObject,
+  DeserializedObject,
+  Definitions
+} from "./serializable-object";
+interface KeyInfoConfig {
+  properties: {
+    type: {
+      type: KeyType;
+      serializedType: KeyType;
+      serializedName: "Type";
+    };
+    privateKey: {
+      type: Buffer;
+      serializedType: string;
+      serializedName: "PrivateKey";
+    };
+  };
+}
+declare class KeyInfo
+  extends SerializableObject<KeyInfoConfig>
+  implements DeserializedObject<KeyInfoConfig> {
+  get config(): Definitions<KeyInfoConfig>;
+  constructor(
+    options?:
+      | Partial<SerializedObject<KeyInfoConfig>>
+      | Partial<DeserializedObject<KeyInfoConfig>>
+  );
+  type: KeyType;
+  privateKey: Buffer;
+}
+declare type SerializedKeyInfo = SerializedObject<KeyInfoConfig>;
+export { KeyInfo, SerializedKeyInfo };

--- a/src/chains/filecoin/types/src/things/key-type.d.ts
+++ b/src/chains/filecoin/types/src/things/key-type.d.ts
@@ -1,0 +1,5 @@
+export declare enum KeyType {
+  KeyTypeBLS = "bls",
+  KeyTypeSecp256k1 = "secp256k1",
+  KeyTypeSecp256k1Ledger = "secp256k1-ledger"
+}

--- a/src/chains/filecoin/types/src/things/signature.d.ts
+++ b/src/chains/filecoin/types/src/things/signature.d.ts
@@ -5,11 +5,12 @@ import {
   Definitions,
   SerializedObject
 } from "./serializable-object";
+import { SigType } from "./sig-type";
 interface SignatureConfig {
   properties: {
     type: {
-      type: number;
-      serializedType: number;
+      type: SigType;
+      serializedType: SigType;
       serializedName: "Type";
     };
     data: {


### PR DESCRIPTION
This PR implements the remaining wallet functions:
- `Filecoin.WalletSetDefault` moves the specified address to the front of the array to become the new default address
- `Filecoin.WalletNew` generates a new account to the wallet
- `Filecoin.WalletList` lists the current addresses in the wallet
- `Filecoin.WalletHas` checks if the wallet has (and therefore can sign for) the specified address
- `Filecoin.WalletDelete` removes the specified address from our wallet; this action is irrevocable sans importing the private key again
- `Filecoin.WalletExport` exports the private key for the specified address if it is in the wallet
- `Filecoin.WalletImport` adds the private key/address to the wallet to be able to sign it
- `Filecoin.WalletSign` signs a buffer with the specified address's private key in the wallet
- `Filecoin.WalletSignMessage` signs a `Message` with the specified address's private key in the wallet
- `Filecoin.WalletVerify` checks if the provided signature is valid for the provided address (doesn't require the address to be in the wallet)
- `Filecoin.WalletValidateAddress` checks if the address is a valid address