### PR TITLE
add miner enabling options and methods

### DIFF
--- a/src/chains/filecoin/filecoin/src/@types/@filecoin-shipyard/lotus-client-schema/index.d.ts
+++ b/src/chains/filecoin/filecoin/src/@types/@filecoin-shipyard/lotus-client-schema/index.d.ts
@@ -3,6 +3,7 @@ declare module "@filecoin-shipyard/lotus-client-schema" {
     methods: {
       [propertyName: string]: {
         subscription?: boolean;
+        namespace?: string;
       };
     };
   };

--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -610,11 +610,11 @@ export default class FilecoinApi implements types.Api {
   }
 
   async "Ganache.EnableMiner"(): Promise<void> {
-    this.#blockchain.enableMiner();
+    await this.#blockchain.enableMiner();
   }
 
   async "Ganache.DisableMiner"(): Promise<void> {
-    this.#blockchain.disableMiner();
+    await this.#blockchain.disableMiner();
   }
 
   async "Ganache.MinerEnabled"(): Promise<boolean> {

--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -239,16 +239,18 @@ export default class Blockchain extends Emittery.Typed<
     this.#minerEnabled = true;
     this.emit("minerEnabled", true);
 
-    const intervalMine = () => {
-      this.mineTipset();
-    };
+    if (this.options.miner.blockTime > 0) {
+      const intervalMine = () => {
+        this.mineTipset();
+      };
 
-    this.miningTimeout = setInterval(
-      intervalMine,
-      this.options.miner.blockTime * 1000
-    );
+      this.miningTimeout = setInterval(
+        intervalMine,
+        this.options.miner.blockTime * 1000
+      );
 
-    utils.unref(this.miningTimeout);
+      utils.unref(this.miningTimeout);
+    }
   }
 
   disableMiner() {

--- a/src/chains/filecoin/filecoin/src/schema.ts
+++ b/src/chains/filecoin/filecoin/src/schema.ts
@@ -15,14 +15,24 @@ const combinedMethods = {
 
 // Use the FilecoinAPI to create a schema object representing the functions supported.
 for (const methodName of Object.getOwnPropertyNames(FilecoinApi.prototype)) {
-  if (!methodName.startsWith("Filecoin.")) {
-    continue;
-  }
+  if (methodName.startsWith("Filecoin.")) {
+    const schemaName = methodName.replace("Filecoin.", "");
 
-  let schemaName = methodName.replace("Filecoin.", "");
-  GanacheSchema.methods[schemaName] = {
-    subscription: combinedMethods[schemaName].subscription === true
-  };
+    GanacheSchema.methods[schemaName] = {
+      subscription: combinedMethods[schemaName].subscription === true
+    };
+  } else {
+    const namespaceMatch = /^(.+)\./.exec(methodName);
+    if (namespaceMatch) {
+      const namespace = namespaceMatch[1];
+      const schemaName = methodName.replace(".", "");
+
+      GanacheSchema.methods[schemaName] = {
+        subscription: /Notify$/i.exec(methodName) !== null,
+        namespace
+      };
+    }
+  }
 }
 
 export default GanacheSchema;

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/ganache.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/ganache.test.ts
@@ -49,7 +49,7 @@ describe("api", () => {
       const enabledChanges: boolean[] = [];
 
       before(async () => {
-        provider = await getProvider({ miner: { blockTime: 0.5 } });
+        provider = await getProvider({ miner: { blockTime: 0.1 } });
         client = new LotusRPC(provider, { schema: FilecoinProvider.Schema });
       });
 
@@ -103,7 +103,7 @@ describe("api", () => {
         assert.strictEqual(provider.blockchain.minerEnabled, false);
 
         const head1 = await client.chainHead();
-        await new Promise(resolve => setInterval(resolve, 1500));
+        await new Promise(resolve => setInterval(resolve, 300));
         const head2 = await client.chainHead();
         assert.strictEqual(head2.Height, head1.Height);
 
@@ -128,7 +128,7 @@ describe("api", () => {
         };
         await client.mpoolPushMessage(message, messageSendSpec);
 
-        await new Promise(resolve => setInterval(resolve, 100));
+        await new Promise(resolve => setInterval(resolve, 300));
         const head3 = await client.chainHead();
         assert.strictEqual(head3.Height, head2.Height);
       });
@@ -149,7 +149,7 @@ describe("api", () => {
         assert.strictEqual(isEnabled, true);
         assert.strictEqual(provider.blockchain.minerEnabled, true);
         const head1 = await client.chainHead();
-        await new Promise(resolve => setInterval(resolve, 1500));
+        await new Promise(resolve => setInterval(resolve, 300));
         const head2 = await client.chainHead();
         assert(head2.Height > head1.Height);
 
@@ -174,7 +174,7 @@ describe("api", () => {
         };
         await client.mpoolPushMessage(message, messageSendSpec);
 
-        await new Promise(resolve => setInterval(resolve, 100));
+        await new Promise(resolve => setInterval(resolve, 300));
         const head3 = await client.chainHead();
         assert(head3.Height > head2.Height);
       });

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/ganache.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/ganache.test.ts
@@ -9,7 +9,7 @@ const LotusRPC = require("@filecoin-shipyard/lotus-client-rpc").LotusRPC;
 
 type LotusClient = any;
 
-describe.only("api", () => {
+describe("api", () => {
   describe("ganache", () => {
     describe("Ganache.MineTipset", () => {
       let provider: FilecoinProvider;

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/ganache.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/ganache.test.ts
@@ -1,0 +1,115 @@
+import assert from "assert";
+import FilecoinProvider from "../../../src/provider";
+import { SubscriptionMethod } from "../../../src/types/subscriptions";
+import getProvider from "../../helpers/getProvider";
+
+const LotusRPC = require("@filecoin-shipyard/lotus-client-rpc").LotusRPC;
+
+type LotusClient = any;
+
+describe("api", () => {
+  describe("ganache", () => {
+    let provider: FilecoinProvider;
+    let client: LotusClient;
+
+    before(async () => {
+      provider = await getProvider();
+      client = new LotusRPC(provider, { schema: FilecoinProvider.Schema });
+    });
+
+    after(async () => {
+      if (provider) {
+        await provider.stop();
+      }
+    });
+
+    describe("Ganache.MineTipset", () => {
+      it("should return a serialized tipset with blocks", async () => {
+        const { Height: priorHeight } = await client.chainHead();
+
+        for (let i = 0; i < 5; i++) {
+          await provider.send({
+            jsonrpc: "2.0",
+            id: "0",
+            method: "Ganache.MineTipset"
+          });
+        }
+
+        const { Height: currentHeight } = await client.chainHead();
+
+        assert.strictEqual(currentHeight, priorHeight + 5);
+      });
+    });
+
+    describe("Enabling/Disabling the Miner", () => {
+      const enabledChanges: boolean[] = [];
+
+      it("subscribes to miner enabled changes", async () => {
+        await provider.sendSubscription(
+          {
+            jsonrpc: "2.0",
+            id: "0",
+            method: "Ganache.MinerEnabledNotify"
+          },
+          { subscription: true },
+          message => {
+            if (message.type === SubscriptionMethod.ChannelUpdated) {
+              enabledChanges.push(message.data[1]);
+            }
+          }
+        );
+      });
+
+      it("Ganache.MinerEnabled", async () => {
+        const isEnabled = await provider.send({
+          jsonrpc: "2.0",
+          id: "0",
+          method: "Ganache.MinerEnabled"
+        });
+
+        assert.strictEqual(isEnabled, true);
+        assert.strictEqual(provider.blockchain.minerEnabled, true);
+      });
+
+      it("Ganache.DisableMiner", async () => {
+        await provider.send({
+          jsonrpc: "2.0",
+          id: "0",
+          method: "Ganache.DisableMiner"
+        });
+
+        const isEnabled = await provider.send({
+          jsonrpc: "2.0",
+          id: "0",
+          method: "Ganache.MinerEnabled"
+        });
+
+        assert.strictEqual(isEnabled, false);
+        assert.strictEqual(provider.blockchain.minerEnabled, false);
+      });
+
+      it("Ganache.EnableMiner", async () => {
+        await provider.send({
+          jsonrpc: "2.0",
+          id: "0",
+          method: "Ganache.EnableMiner"
+        });
+
+        const isEnabled = await provider.send({
+          jsonrpc: "2.0",
+          id: "0",
+          method: "Ganache.MinerEnabled"
+        });
+
+        assert.strictEqual(isEnabled, true);
+        assert.strictEqual(provider.blockchain.minerEnabled, true);
+      });
+
+      it("Ganache.MinerEnabledNotify", async () => {
+        assert.strictEqual(enabledChanges.length, 2);
+        assert.strictEqual(enabledChanges[0], false);
+        assert.strictEqual(enabledChanges[1], true);
+      });
+    });
+  });
+});

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/generic.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/generic.test.ts
@@ -126,23 +126,5 @@ describe("api", () => {
         assert.strictEqual(head.Blocks[0].Height, head.Height);
       });
     });
-
-    describe("Ganache.MineTipset", () => {
-      it("should return a serialized tipset with blocks", async () => {
-        const { Height: priorHeight } = await client.chainHead();
-
-        for (let i = 0; i < 5; i++) {
-          await provider.send({
-            jsonrpc: "2.0",
-            id: "0",
-            method: "Ganache.MineTipset"
-          });
-        }
-
-        const { Height: currentHeight } = await client.chainHead();
-
-        assert.strictEqual(currentHeight, priorHeight + 5);
-      });
-    });
   });
 });

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/messages.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/messages.test.ts
@@ -1563,7 +1563,7 @@ describe("api", () => {
             ipfsPort: 5003
           },
           miner: {
-            blockTime: 120 // effectively disable mining
+            mine: false
           }
         });
         client2 = new LotusRPC(provider2, { schema: FilecoinProvider.Schema });

--- a/src/chains/filecoin/filecoin/tests/blockchain/blockchain.test.ts
+++ b/src/chains/filecoin/filecoin/tests/blockchain/blockchain.test.ts
@@ -170,7 +170,7 @@ describe("Blockchain", () => {
       blockchain = new Blockchain(
         FilecoinOptionsConfig.normalize({
           miner: {
-            blockTime: -1
+            mine: false
           },
           logging: {
             logger: {

--- a/src/chains/filecoin/options/src/miner-options.ts
+++ b/src/chains/filecoin/options/src/miner-options.ts
@@ -4,10 +4,9 @@ import { Definitions } from "@ganache/options";
 export type MinerConfig = {
   options: {
     /**
-     * Sets the `blockTime` in seconds for automatic mining. A blockTime of `0`
-     * (default) enables "instamine mode", where new executable transactions
-     * will be mined instantly. A negative blockTime will require mining by
-     * manually calling Ganache.MineTipset.
+     * Sets the `blockTime` in seconds for automatic mining. A `blockTime` of `0`
+     * (default) or a negative number enables "instamine mode", where new executable transactions
+     * will be mined instantly.
      *
      * Using the `blockTime` option is discouraged unless you have tests which
      * require a specific mining interval.
@@ -18,15 +17,35 @@ export type MinerConfig = {
       type: number;
       hasDefault: true;
     };
+
+    /**
+     * Enable mining. Set to `false` to pause the miner. If set to `false`,
+     * calling `Ganache.MineTipset` method will still mine a tipset/block.
+     *
+     * Call `Ganache.EnableMiner` or `Ganache.DisableMiner` to enable/disable
+     * during runtime.
+     *
+     * @default true
+     */
+    mine: {
+      type: boolean;
+      hasDefault: true;
+    };
   };
 };
 
 export const MinerOptions: Definitions<MinerConfig> = {
   blockTime: {
-    normalize,
+    normalize: value => Math.max(0, value),
     cliDescription:
-      'Sets the `blockTime` in seconds for automatic mining. A blockTime of `0`  enables "instamine mode", where new executable transactions will be mined instantly.',
+      'Sets the `blockTime` in seconds for automatic mining. A `blockTime` of `0` or a negative number enables "instamine mode", where new executable transactions will be mined instantly.',
     default: () => 0,
     cliType: "number"
+  },
+  mine: {
+    normalize,
+    cliDescription: "Enable mining. Set to `false` to pause the miner.",
+    default: () => true,
+    cliType: "boolean"
   }
 };

--- a/src/chains/filecoin/types/src/api.d.ts
+++ b/src/chains/filecoin/types/src/api.d.ts
@@ -94,4 +94,8 @@ export default class FilecoinApi implements types.Api {
     ref: SerializedFileRef
   ): Promise<object>;
   "Ganache.MineTipset"(): Promise<SerializedTipset>;
+  "Ganache.EnableMiner"(): Promise<void>;
+  "Ganache.DisableMiner"(): Promise<void>;
+  "Ganache.MinerEnabled"(): Promise<boolean>;
+  "Ganache.MinerEnabledNotify"(rpcId?: string): PromiEvent<Subscription>;
 }

--- a/src/chains/filecoin/types/src/blockchain.d.ts
+++ b/src/chains/filecoin/types/src/blockchain.d.ts
@@ -22,6 +22,7 @@ import PrivateKeyManager from "./data-managers/private-key-manager";
 export declare type BlockchainEvents = {
   ready(): void;
   tipset: Tipset;
+  minerEnabled: boolean;
 };
 export default class Blockchain extends Emittery.Typed<
   BlockchainEvents,
@@ -35,6 +36,7 @@ export default class Blockchain extends Emittery.Typed<
   signedMessagesManager: SignedMessageManager | null;
   blockMessagesManager: BlockMessagesManager | null;
   readonly miner: Address;
+  get minerEnabled(): boolean;
   messagePool: Array<SignedMessage>;
   readonly deals: Array<DealInfo>;
   readonly dealsByCid: Record<string, DealInfo>;
@@ -51,6 +53,8 @@ export default class Blockchain extends Emittery.Typed<
    */
   stop(): Promise<void>;
   get ipfs(): IPFS | null;
+  enableMiner(): void;
+  disableMiner(): void;
   genesisTipset(): Tipset;
   latestTipset(): Tipset;
   push(message: Message, spec: MessageSendSpec): Promise<SignedMessage>;


### PR DESCRIPTION
This PR adds the `miner.mine` option to be able to pause/start the miner; see more details from the [comment thread here](https://github.com/trufflesuite/ganache-core/issues/248#issuecomment-780777681). The provided `miner.mine` option is in addition to `miner.blockTime`. The latter dictates how frequently to mine (instantly or on an interval), and `miner.mine` specifies whether or not to actually use `miner.blockTime`.