### PR TITLE
implement different chain retrieval methods

### DIFF
--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -64,7 +64,7 @@ export default class FilecoinApi implements types.Api {
   }
 
   async "Filecoin.ChainGetGenesis"(): Promise<SerializedTipset> {
-    const tipset = this.#blockchain.latestTipset();
+    const tipset = this.#blockchain.genesisTipset();
     return tipset.serialize();
   }
 
@@ -155,6 +155,36 @@ export default class FilecoinApi implements types.Api {
     } else {
       return Promise.resolve(false);
     }
+  }
+
+  async "Filecoin.ChainGetTipSet"(
+    serializedTipsetKey: Array<SerializedRootCID>
+  ): Promise<SerializedTipset> {
+    await this.#blockchain.waitForReady();
+
+    const tipset = await this.#blockchain.getTipsetFromKey(
+      serializedTipsetKey.map(serializedCid => new RootCID(serializedCid))
+    );
+    return tipset.serialize();
+  }
+
+  async "Filecoin.ChainGetTipSetByHeight"(
+    height: number,
+    serializedTipsetKey?: Array<SerializedRootCID>
+  ): Promise<SerializedTipset> {
+    await this.#blockchain.waitForReady();
+
+    let tipset: Tipset;
+    if (serializedTipsetKey) {
+      tipset = await this.#blockchain.getTipsetByHeight(
+        height,
+        serializedTipsetKey.map(serializedCid => new RootCID(serializedCid))
+      );
+    } else {
+      tipset = await this.#blockchain.getTipsetByHeight(height);
+    }
+
+    return tipset.serialize();
   }
 
   async "Filecoin.MpoolGetNonce"(address: string): Promise<number> {

--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -37,6 +37,8 @@ import { KeyInfo, SerializedKeyInfo } from "./things/key-info";
 import { SerializedSignature, Signature } from "./things/signature";
 import { SigType } from "./things/sig-type";
 import base32 from "base32-encoding";
+import { SerializedBlockHeader } from "./things/block-header";
+import { SerializedBlockMessages } from "./things/block-messages";
 
 export default class FilecoinApi implements types.Api {
   readonly [index: string]: (...args: any) => Promise<any>;
@@ -175,7 +177,9 @@ export default class FilecoinApi implements types.Api {
     await this.#blockchain.waitForReady();
 
     let tipset: Tipset;
-    if (serializedTipsetKey) {
+    // we check if serializedTipsetKey is an array as well because
+    // of our voodoo json rpc ID gets appended to the args
+    if (serializedTipsetKey && Array.isArray(serializedTipsetKey)) {
       tipset = await this.#blockchain.getTipsetByHeight(
         height,
         serializedTipsetKey.map(serializedCid => new RootCID(serializedCid))
@@ -185,6 +189,57 @@ export default class FilecoinApi implements types.Api {
     }
 
     return tipset.serialize();
+  }
+
+  async "Filecoin.ChainGetBlock"(
+    serializedBlockCid: SerializedRootCID
+  ): Promise<SerializedBlockHeader> {
+    await this.#blockchain.waitForReady();
+
+    const blockCid = new RootCID(serializedBlockCid);
+    const blockHeader = await this.#blockchain.blockHeaderManager!.get(
+      blockCid.root.value
+    );
+
+    if (!blockHeader) {
+      throw new Error("Could not find a block for the provided CID");
+    }
+
+    return blockHeader.serialize();
+  }
+
+  async "Filecoin.ChainGetBlockMessages"(
+    serializedBlockCid: SerializedRootCID
+  ): Promise<SerializedBlockMessages> {
+    await this.#blockchain.waitForReady();
+
+    const blockCid = new RootCID(serializedBlockCid);
+    const blockMessages = await this.#blockchain.blockMessagesManager!.getBlockMessages(
+      blockCid.root
+    );
+
+    if (!blockMessages) {
+      throw new Error("Could not find a block for the provided CID");
+    }
+
+    return blockMessages.serialize();
+  }
+
+  async "Filecoin.ChainGetMessage"(
+    serializedMessageCid: SerializedRootCID
+  ): Promise<SerializedMessage> {
+    await this.#blockchain.waitForReady();
+
+    const blockMessageCid = new RootCID(serializedMessageCid);
+    const signedMessage = await this.#blockchain.signedMessagesManager!.get(
+      blockMessageCid.root.value
+    );
+
+    if (!signedMessage) {
+      throw new Error("Could not find a message for the provided CID");
+    }
+
+    return signedMessage.message.serialize();
   }
 
   async "Filecoin.MpoolGetNonce"(address: string): Promise<number> {

--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -836,6 +836,69 @@ export default class Blockchain extends Emittery.Typed<
     );
   }
 
+  // Reference implementation: https://git.io/Jt7eQ
+  async getTipsetFromKey(tipsetKey?: Array<RootCID>): Promise<Tipset> {
+    await this.waitForReady();
+
+    if (!tipsetKey || tipsetKey.length === 0) {
+      return this.tipsetManager!.latest!;
+    }
+
+    // Instead of using the `LoadTipSet` implementation
+    // found in the reference implementation, we can greatly
+    // simplify the process due to our current "a block can
+    // only be part of one tipset". This is a special condition
+    // of Ganache due to not dealing with a real network.
+    for (const cid of tipsetKey) {
+      const cidString = cid.root.value;
+      const blockHeader = await this.blockHeaderManager!.get(
+        Buffer.from(cidString)
+      );
+      if (blockHeader) {
+        const tipset = await this.tipsetManager!.getTipsetWithBlocks(
+          blockHeader.height
+        );
+        if (tipset) {
+          return tipset;
+        }
+      }
+    }
+
+    throw new Error("Could not retrieve tipset from tipset key");
+  }
+
+  // Reference implementation: https://git.io/Jt7vk
+  async getTipsetByHeight(
+    height: number,
+    tipsetKey?: Array<RootCID>
+  ): Promise<Tipset> {
+    await this.waitForReady();
+
+    let tipset: Tipset | null = await this.getTipsetFromKey(tipsetKey);
+
+    // Reference implementation: https://git.io/Jt7vI
+    if (height > tipset.height) {
+      throw new Error(
+        "looking for tipset with height greater than start point"
+      );
+    }
+
+    if (height === tipset.height) {
+      return tipset;
+    }
+
+    // The reference implementation then calls `cs.cindex.GetTipsetByHeight`
+    // which is specific to their blockchain implementation of needing to
+    // walk back different caches. The way ganache stores these currently
+    // is much simpler, and we can fetch the tipset directly from the height
+    tipset = await this.tipsetManager!.getTipsetWithBlocks(height);
+    if (tipset) {
+      return tipset;
+    } else {
+      throw new Error("Could not find tipset with the provided height");
+    }
+  }
+
   async createAccount(protocol: AddressProtocol): Promise<Account> {
     await this.waitForReady();
 

--- a/src/chains/filecoin/filecoin/src/things/block-header.ts
+++ b/src/chains/filecoin/filecoin/src/things/block-header.ts
@@ -172,7 +172,9 @@ class BlockHeader
         deserializedName: "timestamp",
         serializedName: "Timestamp",
         defaultValue: literal => {
-          return literal || new Date().getTime() / 1000;
+          return typeof literal !== "undefined"
+            ? literal
+            : new Date().getTime() / 1000;
         }
       },
       blockSignature: {

--- a/src/chains/filecoin/filecoin/src/things/block-header.ts
+++ b/src/chains/filecoin/filecoin/src/things/block-header.ts
@@ -171,8 +171,8 @@ class BlockHeader
       timestamp: {
         deserializedName: "timestamp",
         serializedName: "Timestamp",
-        defaultValue: () => {
-          return new Date().getTime() / 1000;
+        defaultValue: literal => {
+          return literal || new Date().getTime() / 1000;
         }
       },
       blockSignature: {

--- a/src/chains/filecoin/filecoin/src/things/signed-message.ts
+++ b/src/chains/filecoin/filecoin/src/things/signed-message.ts
@@ -6,6 +6,8 @@ import {
 } from "./serializable-object";
 import { Message, SerializedMessage } from "./message";
 import { SerializedSignature, Signature } from "./signature";
+import { CID } from "./cid";
+import { SigType } from "./sig-type";
 
 // https://pkg.go.dev/github.com/filecoin-project/lotus@v1.4.0/chain/types#SignedMessage
 
@@ -55,6 +57,15 @@ class SignedMessage
 
   message: Message;
   signature: Signature;
+
+  // Reference implementation: https://git.io/Jt53i
+  get cid(): CID {
+    if (this.signature.type === SigType.SigTypeBLS) {
+      return this.message.cid;
+    } else {
+      return super.cid;
+    }
+  }
 }
 
 type SerializedSignedMessage = SerializedObject<SignedMessageConfig>;

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/generic.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/generic.test.ts
@@ -183,5 +183,14 @@ describe("api", () => {
         }
       });
     });
+
+    describe("Filecoin.ChainGetBlock", () => {
+      it("should retrieve a block directly by CID", async () => {
+        const tipset = await client.chainHead();
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        const block = await client.chainGetBlock(tipset.Cids[0]);
+        assert.deepStrictEqual(block, tipset.Blocks[0]);
+      });
+    });
   });
 });

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/messages.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/messages.test.ts
@@ -1643,5 +1643,27 @@ describe("api", () => {
         assert.strictEqual(head.Height, 0);
       });
     });
+
+    describe("Filecoin.ChainGetBlockMessages", () => {
+      it("should get the block messages for a block cid", async () => {
+        const tipset = await client.chainHead();
+        const blockMessages = await client.chainGetBlockMessages(
+          tipset.Cids[0]
+        );
+        assert.strictEqual(blockMessages.Cids.length, 1);
+        assert.strictEqual(blockMessages.BlsMessages.length, 1);
+      });
+    });
+
+    describe("Filecoin.ChainGetMessage", () => {
+      it("should get a message directly from a message cid", async () => {
+        const tipset = await client.chainHead();
+        const blockMessages = await client.chainGetBlockMessages(
+          tipset.Cids[0]
+        );
+        const message = await client.chainGetMessage(blockMessages.Cids[0]);
+        assert.deepStrictEqual(message, blockMessages.BlsMessages[0]);
+      });
+    });
   });
 });

--- a/src/chains/filecoin/types/src/api.d.ts
+++ b/src/chains/filecoin/types/src/api.d.ts
@@ -30,6 +30,13 @@ export default class FilecoinApi implements types.Api {
   [SubscriptionMethod.ChannelClosed](
     subscriptionId: SubscriptionId
   ): Promise<boolean>;
+  "Filecoin.ChainGetTipSet"(
+    serializedTipsetKey: Array<SerializedRootCID>
+  ): Promise<SerializedTipset>;
+  "Filecoin.ChainGetTipSetByHeight"(
+    height: number,
+    serializedTipsetKey?: Array<SerializedRootCID>
+  ): Promise<SerializedTipset>;
   "Filecoin.MpoolGetNonce"(address: string): Promise<number>;
   "Filecoin.MpoolPush"(
     signedMessage: SerializedSignedMessage

--- a/src/chains/filecoin/types/src/api.d.ts
+++ b/src/chains/filecoin/types/src/api.d.ts
@@ -18,6 +18,8 @@ import { SerializedSignedMessage } from "./things/signed-message";
 import { KeyType } from "./things/key-type";
 import { SerializedKeyInfo } from "./things/key-info";
 import { SerializedSignature } from "./things/signature";
+import { SerializedBlockHeader } from "./things/block-header";
+import { SerializedBlockMessages } from "./things/block-messages";
 export default class FilecoinApi implements types.Api {
   #private;
   readonly [index: string]: (...args: any) => Promise<any>;
@@ -37,6 +39,15 @@ export default class FilecoinApi implements types.Api {
     height: number,
     serializedTipsetKey?: Array<SerializedRootCID>
   ): Promise<SerializedTipset>;
+  "Filecoin.ChainGetBlock"(
+    serializedBlockCid: SerializedRootCID
+  ): Promise<SerializedBlockHeader>;
+  "Filecoin.ChainGetBlockMessages"(
+    serializedBlockCid: SerializedRootCID
+  ): Promise<SerializedBlockMessages>;
+  "Filecoin.ChainGetMessage"(
+    serializedMessageCid: SerializedRootCID
+  ): Promise<SerializedMessage>;
   "Filecoin.MpoolGetNonce"(address: string): Promise<number>;
   "Filecoin.MpoolPush"(
     signedMessage: SerializedSignedMessage

--- a/src/chains/filecoin/types/src/blockchain.d.ts
+++ b/src/chains/filecoin/types/src/blockchain.d.ts
@@ -71,6 +71,11 @@ export default class Blockchain extends Emittery.Typed<
   startDeal(proposal: StartDealParams): Promise<RootCID>;
   createQueryOffer(rootCid: RootCID): Promise<QueryOffer>;
   retrieve(retrievalOrder: RetrievalOrder, ref: FileRef): Promise<void>;
+  getTipsetFromKey(tipsetKey?: Array<RootCID>): Promise<Tipset>;
+  getTipsetByHeight(
+    height: number,
+    tipsetKey?: Array<RootCID>
+  ): Promise<Tipset>;
   createAccount(protocol: AddressProtocol): Promise<Account>;
   private logLatestTipset;
 }

--- a/src/chains/filecoin/types/src/things/signed-message.d.ts
+++ b/src/chains/filecoin/types/src/things/signed-message.d.ts
@@ -6,6 +6,7 @@ import {
 } from "./serializable-object";
 import { Message, SerializedMessage } from "./message";
 import { SerializedSignature, Signature } from "./signature";
+import { CID } from "./cid";
 declare type SignedMessageConfig = {
   properties: {
     message: {
@@ -31,6 +32,7 @@ declare class SignedMessage
   );
   message: Message;
   signature: Signature;
+  get cid(): CID;
 }
 declare type SerializedSignedMessage = SerializedObject<SignedMessageConfig>;
 export { SignedMessage, SignedMessageConfig, SerializedSignedMessage };


### PR DESCRIPTION
This PR adds various methods for retrieving indexed information from the chain to support Ganache UI usage:
- `Filecoin.ChainGetTipSet`
- `Filecoin.ChainGetTipSetByHeight`
- `Filecoin.ChainGetBlock`
- `Filecoin.ChainGetBlockMessages`
- `Filecoin.ChainGetMessage`