### PR TITLE
implement `Ganache.GetDealById`

### DIFF
--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -753,4 +753,15 @@ export default class FilecoinApi implements types.Api {
 
     return promiEvent;
   }
+
+  async "Ganache.GetDealById"(dealId: number): Promise<SerializedDealInfo> {
+    await this.#blockchain.waitForReady();
+
+    if (this.#blockchain.dealsById.has(dealId)) {
+      const deal = this.#blockchain.dealsById.get(dealId);
+      return deal!.serialize();
+    } else {
+      throw new Error("Could not find a deal for the provided ID");
+    }
+  }
 }

--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -67,7 +67,8 @@ export default class Blockchain extends Emittery.Typed<
   readonly #messagePoolLock: Sema;
 
   readonly deals: Array<DealInfo> = [];
-  readonly dealsByCid: Record<string, DealInfo> = {};
+  readonly dealsByCid: Map<string, DealInfo> = new Map<string, DealInfo>();
+  readonly dealsById: Map<number, DealInfo> = new Map<number, DealInfo>();
   readonly inProcessDeals: Array<DealInfo> = [];
 
   readonly options: FilecoinInternalOptions;
@@ -772,7 +773,10 @@ export default class Blockchain extends Emittery.Typed<
 
     // Because we're not cryptographically valid, let's
     // register the deal with the newly created CID
-    this.dealsByCid[proposalCid.value] = deal;
+    this.dealsByCid.set(proposalCid.value, deal);
+
+    // Lets keep deals by id for easy paginated lookup from Ganache UI
+    this.dealsById.set(deal.dealId, deal);
 
     this.deals.push(deal);
     this.inProcessDeals.push(deal);

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
@@ -40,7 +40,7 @@ describe("api", () => {
       }
     });
 
-    describe("Filecoin.ClientStartDeal and Filecoin.ClientListDeals", () => {
+    describe("Filecoin.ClientStartDeal, Filecoin.ClientListDeals, and Ganache.GetDealById", () => {
       let ipfs: IPFSClient;
 
       before(async () => {
@@ -88,6 +88,20 @@ describe("api", () => {
         let endingBalance = await client.walletBalance(address.value);
 
         assert(new BN(endingBalance).lt(new BN(beginningBalance)));
+      });
+
+      it("retrieves deal using ID", async () => {
+        const deals = await client.clientListDeals();
+        assert.strictEqual(deals.length, 1);
+
+        const deal = await provider.send({
+          jsonrpc: "2.0",
+          id: "0",
+          method: "Ganache.GetDealById",
+          params: [deals[0].DealID]
+        });
+
+        assert.deepStrictEqual(deal, deals[0]);
       });
     });
 

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
@@ -103,6 +103,25 @@ describe("api", () => {
 
         assert.deepStrictEqual(deal, deals[0]);
       });
+
+      it("fails to retrieve invalid deal using ID", async () => {
+        try {
+          await provider.send({
+            jsonrpc: "2.0",
+            id: "0",
+            method: "Ganache.GetDealById",
+            params: [1337]
+          });
+          assert.fail("Successfully retrieved a deal for an invalid ID");
+        } catch (e) {
+          if (e.code === "ERR_ASSERTION") {
+            throw e;
+          }
+          assert(
+            e.message.includes("Could not find a deal for the provided ID")
+          );
+        }
+      });
     });
 
     describe("Filecoin.ClientFindData, Filecoin.ClientRetrieve, and Filecoin.ClientHasLocal", () => {

--- a/src/chains/filecoin/filecoin/tests/blockchain/blockchain.test.ts
+++ b/src/chains/filecoin/filecoin/tests/blockchain/blockchain.test.ts
@@ -205,7 +205,7 @@ describe("Blockchain", () => {
 
       // First state should be validating
       assert.strictEqual(
-        blockchain.dealsByCid[proposalCid.value].state,
+        blockchain.dealsByCid.get(proposalCid.value)!.state,
         StorageDealStatus.Validating
       );
 
@@ -213,7 +213,7 @@ describe("Blockchain", () => {
 
       // Next state should be Staged
       assert.strictEqual(
-        blockchain.dealsByCid[proposalCid.value].state,
+        blockchain.dealsByCid.get(proposalCid.value)!.state,
         StorageDealStatus.Staged
       );
 
@@ -221,7 +221,7 @@ describe("Blockchain", () => {
 
       // Next state should be ReserveProviderFunds
       assert.strictEqual(
-        blockchain.dealsByCid[proposalCid.value].state,
+        blockchain.dealsByCid.get(proposalCid.value)!.state,
         StorageDealStatus.ReserveProviderFunds
       );
 
@@ -229,7 +229,7 @@ describe("Blockchain", () => {
 
       // Let's mine all the way to the Sealing state
       while (
-        blockchain.dealsByCid[proposalCid.value].state !=
+        blockchain.dealsByCid.get(proposalCid.value)!.state !=
         StorageDealStatus.Sealing
       ) {
         await blockchain.mineTipset();
@@ -247,7 +247,7 @@ describe("Blockchain", () => {
       await blockchain.mineTipset();
 
       assert.strictEqual(
-        blockchain.dealsByCid[proposalCid.value].state,
+        blockchain.dealsByCid.get(proposalCid.value)!.state,
         StorageDealStatus.Active
       );
       assert.strictEqual(blockchain.inProcessDeals.length, 0);
@@ -293,7 +293,7 @@ describe("Blockchain", () => {
       // Since we're automining, starting the deal will trigger
       // the state to be state to be set to active.
       assert.strictEqual(
-        blockchain.dealsByCid[proposalCid.value].state,
+        blockchain.dealsByCid.get(proposalCid.value)!.state,
         StorageDealStatus.Active
       );
 

--- a/src/chains/filecoin/types/src/api.d.ts
+++ b/src/chains/filecoin/types/src/api.d.ts
@@ -116,4 +116,5 @@ export default class FilecoinApi implements types.Api {
   "Ganache.DisableMiner"(): Promise<void>;
   "Ganache.MinerEnabled"(): Promise<boolean>;
   "Ganache.MinerEnabledNotify"(rpcId?: string): PromiEvent<Subscription>;
+  "Ganache.GetDealById"(dealId: number): Promise<SerializedDealInfo>;
 }

--- a/src/chains/filecoin/types/src/blockchain.d.ts
+++ b/src/chains/filecoin/types/src/blockchain.d.ts
@@ -39,7 +39,8 @@ export default class Blockchain extends Emittery.Typed<
   get minerEnabled(): boolean;
   messagePool: Array<SignedMessage>;
   readonly deals: Array<DealInfo>;
-  readonly dealsByCid: Record<string, DealInfo>;
+  readonly dealsByCid: Map<string, DealInfo>;
+  readonly dealsById: Map<number, DealInfo>;
   readonly inProcessDeals: Array<DealInfo>;
   readonly options: FilecoinInternalOptions;
   private ipfsServer;


### PR DESCRIPTION
This PR adds the `Ganache.GetDealById` method to query deals using their `deal.DealID` rather than using `Filecoin.ClientGetDealInfo` (implemented in a subsequent branch) which uses `deal.ProposalCid` to query for the deal. This is used on the **Deals** screen in Ganache UI.