### PR TITLE
implement deal update subscription

### DIFF
--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -40,6 +40,7 @@ export type BlockchainEvents = {
   ready(): void;
   tipset: Tipset;
   minerEnabled: boolean;
+  dealUpdate: DealInfo;
 };
 
 // Reference implementation: https://git.io/JtEVW
@@ -619,6 +620,7 @@ export default class Blockchain extends Emittery.Typed<
       // Advance the state of all deals in process.
       for (const deal of this.inProcessDeals) {
         deal.advanceState();
+        this.emit("dealUpdate", deal);
 
         if (deal.state == StorageDealStatus.Active) {
           // Remove the deal from the in-process array
@@ -780,6 +782,7 @@ export default class Blockchain extends Emittery.Typed<
 
     this.deals.push(deal);
     this.inProcessDeals.push(deal);
+    this.emit("dealUpdate", deal);
 
     // If we're automining, mine a new block. Note that this will
     // automatically advance the deal to the active state.

--- a/src/chains/filecoin/types/src/api.d.ts
+++ b/src/chains/filecoin/types/src/api.d.ts
@@ -103,6 +103,7 @@ export default class FilecoinApi implements types.Api {
     serializedProposal: SerializedStartDealParams
   ): Promise<SerializedRootCID>;
   "Filecoin.ClientListDeals"(): Promise<Array<SerializedDealInfo>>;
+  "Filecoin.ClientGetDealUpdates"(rpcId?: string): PromiEvent<Subscription>;
   "Filecoin.ClientFindData"(
     rootCid: SerializedRootCID
   ): Promise<Array<SerializedQueryOffer>>;

--- a/src/chains/filecoin/types/src/blockchain.d.ts
+++ b/src/chains/filecoin/types/src/blockchain.d.ts
@@ -23,6 +23,7 @@ export declare type BlockchainEvents = {
   ready(): void;
   tipset: Tipset;
   minerEnabled: boolean;
+  dealUpdate: DealInfo;
 };
 export default class Blockchain extends Emittery.Typed<
   BlockchainEvents,


### PR DESCRIPTION
This PR adds the `Filecoin.ClientGetDealUpdates` method, which is a subscription to receive updates on changes to deals. This is used by Ganache UI to be able to track what the latest deal id is (to know which ones to query), as well as updates to **Deals** screen in real time as deals progress.