### PR TITLE
implement `Filecoin.ClientGetDealInfo`

### DIFF
--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -655,6 +655,22 @@ export default class FilecoinApi implements types.Api {
     return this.#blockchain.deals.map(deal => deal.serialize());
   }
 
+  // Reference implementation: https://git.io/JthfU
+  async "Filecoin.ClientGetDealInfo"(
+    serializedCid: SerializedRootCID
+  ): Promise<SerializedDealInfo> {
+    if (this.#blockchain.dealsByCid.has(serializedCid["/"])) {
+      // Verified that this is the correct lookup since dealsByCid
+      // uses the ProposalCid (ref impl: https://git.io/Jthv7) and the
+      // reference implementation of the lookup follows suit: https://git.io/Jthvp
+      //
+      const dealInfo = this.#blockchain.dealsByCid.get(serializedCid["/"])!;
+      return dealInfo.serialize();
+    } else {
+      throw new Error("Could not find a deal for the provided CID");
+    }
+  }
+
   "Filecoin.ClientGetDealUpdates"(rpcId?: string): PromiEvent<Subscription> {
     const subscriptionId = this.#getId();
     let promiEvent: PromiEvent<Subscription>;

--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -775,6 +775,7 @@ export default class Blockchain extends Emittery.Typed<
 
     // Because we're not cryptographically valid, let's
     // register the deal with the newly created CID
+    // Reference implementation that ProposalCid is used: https://git.io/Jthv7
     this.dealsByCid.set(proposalCid.value, deal);
 
     // Lets keep deals by id for easy paginated lookup from Ganache UI

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
@@ -41,7 +41,7 @@ describe("api", () => {
       }
     });
 
-    describe("Filecoin.ClientStartDeal, Filecoin.ClientListDeals, Ganache.GetDealById, and Filecoin.ClientGetDealUpdates", () => {
+    describe("Filecoin.ClientStartDeal, Filecoin.ClientListDeals, Ganache.GetDealById, Filecoin.ClientGetDealInfo, and Filecoin.ClientGetDealUpdates", () => {
       let ipfs: IPFSClient;
       let currentDeal: DealInfo = new DealInfo({
         dealId: -1
@@ -152,6 +152,15 @@ describe("api", () => {
             e.message.includes("Could not find a deal for the provided ID")
           );
         }
+      });
+
+      it("retrieves deal using CID", async () => {
+        const deals = await client.clientListDeals();
+        assert.strictEqual(deals.length, 1);
+
+        const deal = await client.clientGetDealInfo(deals[0].ProposalCid);
+
+        assert.deepStrictEqual(deal, deals[0]);
       });
     });
 

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
@@ -162,6 +162,22 @@ describe("api", () => {
 
         assert.deepStrictEqual(deal, deals[0]);
       });
+
+      it("fails to retrieve invalid deal using CID", async () => {
+        try {
+          const invalidCid =
+            "bafyreifi6tnqdabvaid7o4qezjpcavkwtibctpfzuarr4erfxjqds52bba";
+          await client.clientGetDealInfo({ "/": invalidCid });
+          assert.fail("Successfully retrieved a deal for an invalid CID");
+        } catch (e) {
+          if (e.code === "ERR_ASSERTION") {
+            throw e;
+          }
+          assert(
+            e.message.includes("Could not find a deal for the provided CID")
+          );
+        }
+      });
     });
 
     describe("Filecoin.ClientFindData, Filecoin.ClientRetrieve, and Filecoin.ClientHasLocal", () => {

--- a/src/chains/filecoin/types/src/api.d.ts
+++ b/src/chains/filecoin/types/src/api.d.ts
@@ -103,6 +103,9 @@ export default class FilecoinApi implements types.Api {
     serializedProposal: SerializedStartDealParams
   ): Promise<SerializedRootCID>;
   "Filecoin.ClientListDeals"(): Promise<Array<SerializedDealInfo>>;
+  "Filecoin.ClientGetDealInfo"(
+    serializedCid: SerializedRootCID
+  ): Promise<SerializedDealInfo>;
   "Filecoin.ClientGetDealUpdates"(rpcId?: string): PromiEvent<Subscription>;
   "Filecoin.ClientFindData"(
     rootCid: SerializedRootCID


### PR DESCRIPTION
This PR adds the `Filecoin.ClientGetDealInfo` which queries the `DealInfo` object for a `deal.ProposalCid`. This was requested by Rosco for usage within the Truffle integration.