### PR TITLE
Improve message when throwing an error

### DIFF
--- a/src/packages/cli/src/cli.ts
+++ b/src/packages/cli/src/cli.ts
@@ -43,9 +43,15 @@ const flavor = argv.flavor;
 
 const cliSettings = argv.server;
 
-const server = Ganache.server(argv);
-
 console.log(detailedVersion);
+
+let server;
+try {
+  server = Ganache.server(argv);
+} catch (error) {
+  console.log(error.message);
+  process.exit(1);
+}
 
 let started = false;
 process.on("uncaughtException", function (e) {

--- a/src/packages/cli/src/cli.ts
+++ b/src/packages/cli/src/cli.ts
@@ -45,11 +45,11 @@ const cliSettings = argv.server;
 
 console.log(detailedVersion);
 
-let server;
+let server: ReturnType<typeof Ganache.server>;
 try {
   server = Ganache.server(argv);
 } catch (error) {
-  console.log(error.message);
+  console.error(error.message);
   process.exit(1);
 }
 


### PR DESCRIPTION
Wrap Ganache server start in try/catch for a nicer error message. Previously there would be a bunch of webpack garbage displayed to the screen when Ganache threw an error. Now Ganache will error and display things in the following format:

<img width="1440" alt="Screen Shot 2021-03-05 at 4 27 54 PM" src="https://user-images.githubusercontent.com/14827965/110175658-260d2f80-7dd0-11eb-9bae-508ad070d3a1.png">

Should we start the message with "Error: Values for ..."?
