### PR TITLE
implement `Filecoin.ClientGetDealStatus` method

### DIFF
--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -37,6 +37,7 @@ import { SerializedSignature, Signature } from "./things/signature";
 import { SigType } from "./things/sig-type";
 import { SerializedBlockHeader } from "./things/block-header";
 import { SerializedBlockMessages } from "./things/block-messages";
+import { StorageDealStatus } from "./types/storage-deal-status";
 
 export default class FilecoinApi implements types.Api {
   readonly [index: string]: (...args: any) => Promise<any>;
@@ -685,6 +686,15 @@ export default class FilecoinApi implements types.Api {
     } else {
       throw new Error("Could not find a deal for the provided CID");
     }
+  }
+
+  // Reference implementation: https://git.io/JqUXg
+  async "Filecoin.ClientGetDealStatus"(statusCode: number): Promise<string> {
+    const status = StorageDealStatus[statusCode];
+    if (!status) {
+      throw new Error(`no such deal state ${statusCode}`);
+    }
+    return `StorageDeal${status}`;
   }
 
   "Filecoin.ClientGetDealUpdates"(rpcId?: string): PromiEvent<Subscription> {

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
@@ -41,6 +41,21 @@ describe("api", () => {
       }
     });
 
+    describe("Filecoin.ClientGetDealStatus", () => {
+      it("retrieves a string for a status code", async () => {
+        let status = await client.clientGetDealStatus(5);
+        assert.strictEqual(status, "StorageDealSealing");
+        try {
+          status = await client.clientGetDealStatus(500);
+        } catch (e) {
+          if (e.code === "ERR_ASSERTION") {
+            throw e;
+          }
+          assert.strictEqual(e.message, "no such deal state 500");
+        }
+      });
+    });
+
     describe("Filecoin.ClientStartDeal, Filecoin.ClientListDeals, Ganache.GetDealById, Filecoin.ClientGetDealInfo, and Filecoin.ClientGetDealUpdates", () => {
       let ipfs: IPFSClient;
       let currentDeal: DealInfo = new DealInfo({

--- a/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
+++ b/src/chains/filecoin/filecoin/tests/api/filecoin/deals.test.ts
@@ -47,6 +47,9 @@ describe("api", () => {
         assert.strictEqual(status, "StorageDealSealing");
         try {
           status = await client.clientGetDealStatus(500);
+          assert.fail(
+            "Successfully retrieved status string for invalid status code"
+          );
         } catch (e) {
           if (e.code === "ERR_ASSERTION") {
             throw e;

--- a/src/chains/filecoin/types/src/api.d.ts
+++ b/src/chains/filecoin/types/src/api.d.ts
@@ -107,6 +107,7 @@ export default class FilecoinApi implements types.Api {
   "Filecoin.ClientGetDealInfo"(
     serializedCid: SerializedRootCID
   ): Promise<SerializedDealInfo>;
+  "Filecoin.ClientGetDealStatus"(statusCode: number): Promise<string>;
   "Filecoin.ClientGetDealUpdates"(rpcId?: string): PromiEvent<Subscription>;
   "Filecoin.ClientFindData"(
     rootCid: SerializedRootCID


### PR DESCRIPTION
This PR implements the `Filecoin.ClientGetDealStatus` method, requested for usage within Truffle