### PR TITLE
fix filecoin stop logic and make it more explicit

### DIFF
--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -87,6 +87,7 @@ export default class Blockchain extends Emittery.Typed<
   }
 
   private ready: boolean;
+  private stopped: boolean;
 
   constructor(options: FilecoinInternalOptions) {
     super();
@@ -100,6 +101,7 @@ export default class Blockchain extends Emittery.Typed<
     this.#messagePoolLock = new Sema(1);
 
     this.ready = false;
+    this.stopped = false;
 
     // Create the IPFS server
     this.ipfsServer = new IPFSServer(this.options.chain);
@@ -226,6 +228,12 @@ export default class Blockchain extends Emittery.Typed<
    * Gracefully shuts down the blockchain service and all of its dependencies.
    */
   async stop() {
+    // Don't try to stop if we're already stopped
+    if (this.stopped) {
+      return;
+    }
+    this.stopped = true;
+
     // make sure we wait until other stuff is finished,
     // prevent it from starting up again by not releasing
     await this.#miningLock.acquire();

--- a/src/chains/filecoin/filecoin/src/connector.ts
+++ b/src/chains/filecoin/filecoin/src/connector.ts
@@ -74,7 +74,7 @@ export class Connector
     return JSON.stringify(json);
   }
 
-  close() {
-    return this.#provider.stop();
+  async close() {
+    return await this.#provider.stop();
   }
 }

--- a/src/chains/filecoin/filecoin/src/database.ts
+++ b/src/chains/filecoin/filecoin/src/database.ts
@@ -164,12 +164,7 @@ export default class Database extends Emittery {
   #cleanup = async () => {
     const db = this.db;
     if (db) {
-      await new Promise((resolve, reject) =>
-        db.close(err => {
-          if (err) return void reject(err);
-          resolve(void 0);
-        })
-      );
+      await db.close();
 
       if (this.tipsets) {
         await this.tipsets.close();
@@ -193,6 +188,6 @@ export default class Database extends Emittery {
         await this.deals.close();
       }
     }
-    return this.#cleanupDirectory();
+    return await this.#cleanupDirectory();
   };
 }

--- a/src/chains/filecoin/types/src/blockchain.d.ts
+++ b/src/chains/filecoin/types/src/blockchain.d.ts
@@ -47,6 +47,7 @@ export default class Blockchain extends Emittery.Typed<
   private rng;
   get dbDirectory(): string | null;
   private ready;
+  private stopped;
   constructor(options: FilecoinInternalOptions);
   waitForReady(): Promise<unknown>;
   /**

--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -156,6 +156,13 @@ export class Server extends Emittery<{ open: undefined; close: undefined }> {
   }
 
   public async close() {
+    // the connector gets initialized in the constructor
+    // rather than in the initialize function, so we need
+    // to make sure that we close it before throwing for
+    // the below conditions (i.e. connector tried to load
+    // but failed before initialize was called)
+    await this.#connector.close();
+
     if (this.#status === Status.opening) {
       // if opening
       throw new Error(`Cannot close server while it is opening.`);
@@ -177,7 +184,6 @@ export class Server extends Emittery<{ open: undefined; close: undefined }> {
 
     // and do all http cleanup, if any
     this.#httpServer.close();
-    await this.#connector.close();
     this.#status = Status.closed;
     this.#app = void 0;
 


### PR DESCRIPTION
This PR resolves an issue that I discovered in Ganache UI where the database lock did not get unlocked properly.

The reproduction issue was:
1. Start ganache cli
2. Start ganache ui with same ports
3. UI would fail to start
4. Try to restart ganache ui
5. Receive error saying something along the lines of the `path/to/database/LOCK was already held by another process`

I tracked this down to the `packages/core/src/server.ts` not closing the `connector` because `#status === Status.closed`. This logic is invalid since `#status` is updated asynchronously, but `connector` is loaded on construction

Theoretically this bug would exist for the ethereum flavor too

In addition to solving this bug, this PR adds a `stopped` boolean to the filecoin blockchain to prevent multiple stops from being processed (which would cause us to constantly try to acquire a lock that purposely isn't released from a prior stop)