### PR TITLE
fix: rearchitect server status and move async functions from constructors to initialize functions

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -169,7 +169,7 @@ export default class EthereumApi implements types.Api {
   constructor(
     options: EthereumInternalOptions,
     wallet: Wallet,
-    emitter: Emittery.Typed<{ message: any }, "connect" | "disconnect">
+    emitter: Emittery.Typed<{ message: any }, "disconnect">
   ) {
     this.#options = options;
 
@@ -188,11 +188,13 @@ export default class EthereumApi implements types.Api {
     const blockchain = (this.#blockchain = new Blockchain(
       options,
       common,
-      initialAccounts,
       coinbaseAddress
     ));
-    blockchain.on("start", () => emitter.emit("connect"));
     emitter.on("disconnect", blockchain.stop.bind(blockchain));
+  }
+
+  async initialize() {
+    await this.#blockchain.initialize(this.#wallet.initialAccounts);
   }
 
   //#region db
@@ -482,7 +484,7 @@ export default class EthereumApi implements types.Api {
    *
    * @example
    * ```javascript
-   * const provider = ganache.provider();
+   * const provider = await ganache.provider();
    * const [from, to] = await provider.send("eth_accounts");
    * const startingBalance = BigInt(await provider.send("eth_getBalance", [from]));
    *
@@ -527,7 +529,7 @@ export default class EthereumApi implements types.Api {
    *
    * @example
    * ```javascript
-   * const provider = ganache.provider();
+   * const provider = await ganache.provider();
    * const [from, to] = await provider.send("eth_accounts");
    * const startingBalance = BigInt(await provider.send("eth_getBalance", [from]));
    *

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -169,7 +169,7 @@ export default class EthereumApi implements types.Api {
   constructor(
     options: EthereumInternalOptions,
     wallet: Wallet,
-    emitter: Emittery.Typed<{ message: any }, "disconnect">
+    emitter: Emittery.Typed<{ message: any }, "connect" | "disconnect">
   ) {
     this.#options = options;
 
@@ -484,7 +484,7 @@ export default class EthereumApi implements types.Api {
    *
    * @example
    * ```javascript
-   * const provider = await ganache.provider();
+   * const provider = ganache.provider();
    * const [from, to] = await provider.send("eth_accounts");
    * const startingBalance = BigInt(await provider.send("eth_getBalance", [from]));
    *
@@ -529,7 +529,7 @@ export default class EthereumApi implements types.Api {
    *
    * @example
    * ```javascript
-   * const provider = await ganache.provider();
+   * const provider = ganache.provider();
    * const [from, to] = await provider.send("eth_accounts");
    * const startingBalance = BigInt(await provider.send("eth_getBalance", [from]));
    *

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -180,7 +180,6 @@ export default class Blockchain extends Emittery.Typed<
   constructor(
     options: EthereumInternalOptions,
     common: Common,
-    initialAccounts: Account[],
     coinbaseAddress: Address
   ) {
     super();
@@ -214,113 +213,120 @@ export default class Blockchain extends Emittery.Typed<
       }
     }
 
-    const database = (this.#database = new Database(options.database, this));
-    database.once("ready").then(async () => {
-      const blocks = (this.blocks = await BlockManager.initialize(
-        common,
-        database.blockIndexes,
-        database.blocks
+    this.coinbase = coinbaseAddress;
+
+    this.#database = new Database(options.database, this);
+  }
+
+  async initialize(initialAccounts: Account[]) {
+    await this.#database.initialize();
+
+    const database = this.#database;
+    const options = this.#options;
+    const common = this.#common;
+
+    const blocks = (this.blocks = await BlockManager.initialize(
+      common,
+      database.blockIndexes,
+      database.blocks
+    ));
+
+    // if we have a latest block, use it to set up the trie.
+    const latest = blocks.latest;
+    if (latest) {
+      this.#blockBeingSavedPromise = Promise.resolve({
+        block: latest,
+        blockLogs: null
+      });
+      this.trie = new SecureTrie(
+        database.trie,
+        latest.header.stateRoot.toBuffer()
+      );
+    } else {
+      this.trie = new SecureTrie(database.trie, null);
+    }
+
+    this.blockLogs = new BlockLogManager(database.blockLogs);
+    this.transactions = new TransactionManager(
+      options.miner,
+      common,
+      this,
+      database.transactions
+    );
+    this.transactionReceipts = new Manager(
+      database.transactionReceipts,
+      TransactionReceipt
+    );
+    this.accounts = new AccountManager(this, database.trie);
+    this.storageKeys = database.storageKeys;
+
+    // create VM and listen to step events
+    this.vm = this.createVmFromStateTrie(
+      this.trie,
+      options.chain.allowUnlimitedContractSize
+    );
+
+    {
+      // create first block
+      let firstBlockTime: number;
+      if (options.chain.time != null) {
+        // If we were given a timestamp, use it instead of the `_currentTime`
+        const t = options.chain.time.getTime();
+        firstBlockTime = Math.floor(t / 1000);
+        this.setTime(t);
+      } else {
+        firstBlockTime = this.#currentTime();
+      }
+
+      // if we don't already have a latest block, create a genesis block!
+      if (!latest) {
+        await this.#commitAccounts(initialAccounts);
+
+        this.#blockBeingSavedPromise = this.#initializeGenesisBlock(
+          firstBlockTime,
+          options.miner.blockGasLimit
+        );
+        blocks.earliest = blocks.latest = await this.#blockBeingSavedPromise.then(
+          ({ block }) => block
+        );
+      }
+    }
+
+    {
+      // configure and start miner
+      const txPool = this.transactions.transactionPool;
+      const minerOpts = options.miner;
+      const miner = (this.#miner = new Miner(
+        minerOpts,
+        txPool.executables,
+        this.#instamine,
+        this.vm,
+        this.#readyNextBlock
       ));
 
-      // if we have a latest block, use it to set up the trie.
-      const latest = blocks.latest;
-      if (latest) {
-        this.#blockBeingSavedPromise = Promise.resolve({
-          block: latest,
-          blockLogs: null
-        });
-        this.trie = new SecureTrie(
-          database.trie,
-          latest.header.stateRoot.toBuffer()
-        );
+      //#region automatic mining
+      const nullResolved = Promise.resolve(null);
+      const mineAll = (maxTransactions: number) =>
+        this.#isPaused() ? nullResolved : this.mine(maxTransactions);
+      if (this.#instamine) {
+        // insta mining
+        // whenever the transaction pool is drained mine the txs into blocks
+        txPool.on("drain", mineAll.bind(null, 1));
       } else {
-        this.trie = new SecureTrie(database.trie, null);
+        // interval mining
+        const wait = () => unref(setTimeout(next, minerOpts.blockTime * 1e3));
+        const next = () => mineAll(-1).then(wait);
+        wait();
       }
+      //#endregion
 
-      this.blockLogs = new BlockLogManager(database.blockLogs);
-      this.transactions = new TransactionManager(
-        options.miner,
-        common,
-        this,
-        database.transactions
-      );
-      this.transactionReceipts = new Manager(
-        database.transactionReceipts,
-        TransactionReceipt
-      );
-      this.accounts = new AccountManager(this, database.trie);
-      this.storageKeys = database.storageKeys;
+      miner.on("block", this.#handleNewBlockData);
 
-      this.coinbase = coinbaseAddress;
+      this.once("stop").then(() => miner.clearListeners());
+    }
 
-      // create VM and listen to step events
-      this.vm = this.createVmFromStateTrie(
-        this.trie,
-        options.chain.allowUnlimitedContractSize
-      );
-
-      {
-        // create first block
-        let firstBlockTime: number;
-        if (options.chain.time != null) {
-          // If we were given a timestamp, use it instead of the `_currentTime`
-          const t = options.chain.time.getTime();
-          firstBlockTime = Math.floor(t / 1000);
-          this.setTime(t);
-        } else {
-          firstBlockTime = this.#currentTime();
-        }
-
-        // if we don't already have a latest block, create a genesis block!
-        if (!latest) {
-          await this.#commitAccounts(initialAccounts);
-
-          this.#blockBeingSavedPromise = this.#initializeGenesisBlock(
-            firstBlockTime,
-            options.miner.blockGasLimit
-          );
-          blocks.earliest = blocks.latest = await this.#blockBeingSavedPromise.then(
-            ({ block }) => block
-          );
-        }
-      }
-
-      {
-        // configure and start miner
-        const txPool = this.transactions.transactionPool;
-        const minerOpts = options.miner;
-        const miner = (this.#miner = new Miner(
-          minerOpts,
-          txPool.executables,
-          instamine,
-          this.vm,
-          this.#readyNextBlock
-        ));
-
-        //#region automatic mining
-        const nullResolved = Promise.resolve(null);
-        const mineAll = (maxTransactions: number) =>
-          this.#isPaused() ? nullResolved : this.mine(maxTransactions);
-        if (instamine) {
-          // insta mining
-          // whenever the transaction pool is drained mine the txs into blocks
-          txPool.on("drain", mineAll.bind(null, 1));
-        } else {
-          // interval mining
-          const wait = () => unref(setTimeout(next, minerOpts.blockTime * 1e3));
-          const next = () => mineAll(-1).then(wait);
-          wait();
-        }
-        //#endregion
-
-        miner.on("block", this.#handleNewBlockData);
-
-        this.once("stop").then(() => miner.clearListeners());
-      }
-
-      this.#state = Status.started;
-      this.emit("start");
-    });
+    this.#state = Status.started;
+    this.emit("start");
   }
 
   #saveNewBlock = ({

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -219,11 +219,11 @@ export default class Blockchain extends Emittery.Typed<
   }
 
   async initialize(initialAccounts: Account[]) {
-    await this.#database.initialize();
-
     const database = this.#database;
     const options = this.#options;
     const common = this.#common;
+
+    await database.initialize();
 
     const blocks = (this.blocks = await BlockManager.initialize(
       common,

--- a/src/chains/ethereum/ethereum/src/connector.ts
+++ b/src/chains/ethereum/ethereum/src/connector.ts
@@ -20,7 +20,7 @@ function isHttp(
 }
 
 export class Connector
-  extends Emittery.Typed<undefined, "ready" | "close">
+  extends Emittery.Typed<undefined, "close">
   implements
     types.Connector<
       EthereumApi,
@@ -39,14 +39,14 @@ export class Connector
   ) {
     super();
 
-    const provider = (this.#provider = new EthereumProvider(
+    this.#provider = new EthereumProvider(
       providerOptions,
       executor
-    ));
-    provider.on("connect", () => {
-      // tell the consumer (like a `ganache-core` server/connector) everything is ready
-      this.emit("ready");
-    });
+    );
+  }
+
+  async initialize() {
+    await this.#provider.initialize();
   }
 
   parse(message: Buffer) {

--- a/src/chains/ethereum/ethereum/src/connector.ts
+++ b/src/chains/ethereum/ethereum/src/connector.ts
@@ -20,7 +20,7 @@ function isHttp(
 }
 
 export class Connector
-  extends Emittery.Typed<undefined, "close">
+  extends Emittery.Typed<undefined, "ready" | "close">
   implements
     types.Connector<
       EthereumApi,
@@ -47,6 +47,9 @@ export class Connector
 
   async initialize() {
     await this.#provider.initialize();
+    // no need to wait for #provider.once("connect") as the initialize()
+    // promise has already accounted for that after the promise is resolved
+    await this.emit("ready");
   }
 
   parse(message: Buffer) {

--- a/src/chains/ethereum/ethereum/src/database.ts
+++ b/src/chains/ethereum/ethereum/src/database.ts
@@ -45,10 +45,9 @@ export default class Database extends Emittery {
 
     this.#options = options;
     this.blockchain = blockchain;
-    this.#initialize();
   }
 
-  #initialize = async () => {
+  initialize = async () => {
     const levelupOptions: any = {
       keyEncoding: "binary",
       valueEncoding: "binary"

--- a/src/chains/ethereum/ethereum/src/provider.ts
+++ b/src/chains/ethereum/ethereum/src/provider.ts
@@ -35,7 +35,7 @@ type RequestParams<Method extends RequestMethods> = {
 const hasOwn = utils.hasOwn;
 
 export default class EthereumProvider
-  extends Emittery.Typed<{ message: any }, "disconnect">
+  extends Emittery.Typed<{ message: any }, "connect" | "disconnect">
   implements types.Provider<EthereumApi> {
   #options: EthereumInternalOptions;
   #api: EthereumApi;
@@ -59,6 +59,7 @@ export default class EthereumProvider
 
   async initialize() {
     await this.#api.initialize();
+    await this.emit("connect");
   }
 
   /**

--- a/src/chains/ethereum/ethereum/src/provider.ts
+++ b/src/chains/ethereum/ethereum/src/provider.ts
@@ -35,7 +35,7 @@ type RequestParams<Method extends RequestMethods> = {
 const hasOwn = utils.hasOwn;
 
 export default class EthereumProvider
-  extends Emittery.Typed<{ message: any }, "connect" | "disconnect">
+  extends Emittery.Typed<{ message: any }, "disconnect">
   implements types.Provider<EthereumApi> {
   #options: EthereumInternalOptions;
   #api: EthereumApi;
@@ -55,6 +55,10 @@ export default class EthereumProvider
     const wallet = (this.#wallet = new Wallet(providerOptions.wallet));
 
     this.#api = new EthereumApi(providerOptions, wallet, this);
+  }
+
+  async initialize() {
+    await this.#api.initialize();
   }
 
   /**

--- a/src/chains/ethereum/ethereum/src/wallet.ts
+++ b/src/chains/ethereum/ethereum/src/wallet.ts
@@ -185,6 +185,11 @@ export default class Wallet {
         fileData.addresses[address] = address;
         fileData.private_keys[address] = privateKey;
       });
+
+      // WARNING: Do not turn this to an async method without
+      // making a Wallet.initialize() function and calling it via
+      // Provider.initialize(). No async methods in constructors.
+      // writeFileSync here is acceptable.
       writeFileSync(opts.accountKeysPath, JSON.stringify(fileData));
     }
     //#endregion

--- a/src/chains/ethereum/ethereum/tests/api/debug/debug.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/debug/debug.test.ts
@@ -200,11 +200,10 @@ describe("api", () => {
       const blockchain = new Blockchain(
         EthereumOptionsConfig.normalize({}),
         common,
-        initialAccounts,
         address
       );
 
-      await blockchain.once("start");
+      await blockchain.initialize(initialAccounts);
 
       // Deployment transaction
       const deploymentTransaction = new Transaction(

--- a/src/chains/ethereum/ethereum/tests/helpers/getProvider.ts
+++ b/src/chains/ethereum/ethereum/tests/helpers/getProvider.ts
@@ -29,12 +29,8 @@ const getProvider = async (
   const requestCoordinator = new RequestCoordinator(doAsync ? 0 : 1);
   const executor = new Executor(requestCoordinator);
   const provider = new EthereumProvider(options, executor);
-  await new Promise(resolve => {
-    provider.on("connect", () => {
-      requestCoordinator.resume();
-      resolve(void 0);
-    });
-  });
+  await provider.initialize();
+  requestCoordinator.resume();
   return provider;
 };
 

--- a/src/packages/core/index.ts
+++ b/src/packages/core/index.ts
@@ -1,3 +1,4 @@
+import { Providers } from "@ganache/flavors";
 import ConnectorLoader from "./src/connector-loader";
 import { ProviderOptions, ServerOptions } from "./src/options";
 import Server from "./src/server";
@@ -7,6 +8,8 @@ export { ProviderOptions, ServerOptions, serverDefaults } from "./src/options";
 
 export default {
   server: (options?: ServerOptions) => new Server(options),
-  provider: (options?: ProviderOptions) =>
-    ConnectorLoader.initialize(options).provider
+  provider: async (options?: ProviderOptions): Promise<Providers> => {
+    const connector = await ConnectorLoader.initialize(options);
+    return connector.provider;
+  }
 };

--- a/src/packages/core/index.ts
+++ b/src/packages/core/index.ts
@@ -7,9 +7,36 @@ export { Status } from "./src/server";
 export { ProviderOptions, ServerOptions, serverDefaults } from "./src/options";
 
 export default {
+  /**
+   * Creates a Ganache server instance that creates and
+   * serves an underlying Ganache provider. Initialization
+   * doesn't begin until `server.listen(...)` is called.
+   * `server.listen(...)` returns a promise that resolves
+   * when initialization is finished.
+   *
+   * @param options Configuration options for the server;
+   * `options` includes provider based options as well.
+   * @returns A provider instance for the flavor
+   * `options.flavor` which defaults to `ethereum`.
+   */
   server: (options?: ServerOptions) => new Server(options),
-  provider: async (options?: ProviderOptions): Promise<Providers> => {
-    const connector = await ConnectorLoader.initialize(options);
+
+  /**
+   * Initializes a Web3 provider for a Ganache instance.
+   * This function starts an asynchronous task, but does not
+   * finish it by the time the function returns. Listen to
+   * `provider.on("connect", () => {...})` or wait for
+   * `await provider.once("connect")` for initialization to
+   * finish. You may start sending requests to the provider
+   * before initialization finishes however; these requests
+   * will start being consumed after initialization finishes.
+   *
+   * @param options Configuration options for the provider.
+   * @returns A provider instance for the flavor
+   * `options.flavor` which defaults to `ethereum`.
+   */
+  provider: (options?: ProviderOptions): Providers => {
+    const connector = ConnectorLoader.initialize(options);
     return connector.provider;
   }
 };

--- a/src/packages/core/npm-shrinkwrap.json
+++ b/src/packages/core/npm-shrinkwrap.json
@@ -16,6 +16,12 @@
 			"integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==",
 			"dev": true
 		},
+		"@types/promise.allsettled": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@types/promise.allsettled/-/promise.allsettled-1.0.3.tgz",
+			"integrity": "sha512-b/IFHHTkYkTqu41IH9UtpICwqrpKj2oNlb4KHPzFQDMiz+h1BgAeATeO0/XTph4+UkH9W2U0E4B4j64KWOovag==",
+			"dev": true
+		},
 		"@types/superagent": {
 			"version": "4.1.10",
 			"resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.10.tgz",
@@ -26,11 +32,32 @@
 				"@types/node": "*"
 			}
 		},
+		"array.prototype.map": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.3.tgz",
+			"integrity": "sha512-nNcb30v0wfDyIe26Yif3PcV1JXQp4zEeEfupG7L4SRjnD6HLbO5b2a7eVSba53bOx4YCHYMBHt+Fp4vYstneRA==",
+			"requires": {
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.0-next.1",
+				"es-array-method-boxes-properly": "^1.0.0",
+				"is-string": "^1.0.5"
+			}
+		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
+		},
+		"call-bind": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
+			}
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -62,11 +89,72 @@
 				"ms": "2.1.2"
 			}
 		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"requires": {
+				"object-keys": "^1.0.12"
+			}
+		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
+		},
+		"es-abstract": {
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+			"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"es-to-primitive": "^1.2.1",
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.2",
+				"is-callable": "^1.2.3",
+				"is-negative-zero": "^2.0.1",
+				"is-regex": "^1.1.2",
+				"is-string": "^1.0.5",
+				"object-inspect": "^1.9.0",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.2",
+				"string.prototype.trimend": "^1.0.4",
+				"string.prototype.trimstart": "^1.0.4",
+				"unbox-primitive": "^1.0.0"
+			}
+		},
+		"es-array-method-boxes-properly": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
+		},
+		"es-get-iterator": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
+			"integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.0",
+				"has-symbols": "^1.0.1",
+				"is-arguments": "^1.1.0",
+				"is-map": "^2.0.2",
+				"is-set": "^2.0.2",
+				"is-string": "^1.0.5",
+				"isarray": "^2.0.5"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
 		},
 		"fast-safe-stringify": {
 			"version": "2.0.7",
@@ -91,11 +179,136 @@
 			"integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
 			"dev": true
 		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
+		"get-intrinsic": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-bigints": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+		},
+		"has-symbols": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+		},
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
+		},
+		"is-arguments": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+			"integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+			"requires": {
+				"call-bind": "^1.0.0"
+			}
+		},
+		"is-bigint": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
+			"integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
+		},
+		"is-boolean-object": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+			"integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+			"requires": {
+				"call-bind": "^1.0.0"
+			}
+		},
+		"is-callable": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+			"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+		},
+		"is-date-object": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+		},
+		"is-map": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+			"integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
+		},
+		"is-negative-zero": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+		},
+		"is-number-object": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+			"integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
+		},
+		"is-regex": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+			"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-symbols": "^1.0.1"
+			}
+		},
+		"is-set": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+			"integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
+		},
+		"is-string": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
+		},
+		"is-symbol": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+			"requires": {
+				"has-symbols": "^1.0.1"
+			}
+		},
+		"isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+		},
+		"iterate-iterator": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
+			"integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw=="
+		},
+		"iterate-value": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
+			"integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
+			"requires": {
+				"es-get-iterator": "^1.0.2",
+				"iterate-iterator": "^1.0.1"
+			}
 		},
 		"lru-cache": {
 			"version": "6.0.0",
@@ -139,6 +352,40 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
+		"object-inspect": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+			"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+		},
+		"object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+		},
+		"object.assign": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+			"requires": {
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3",
+				"has-symbols": "^1.0.1",
+				"object-keys": "^1.1.1"
+			}
+		},
+		"promise.allsettled": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.4.tgz",
+			"integrity": "sha512-o73CbvQh/OnPFShxHcHxk0baXR2a1m4ozb85ha0H14VEoi/EJJLa9mnPfEWJx9RjA9MLfhdjZ8I6HhWtBa64Ag==",
+			"requires": {
+				"array.prototype.map": "^1.0.3",
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.0-next.2",
+				"get-intrinsic": "^1.0.2",
+				"iterate-value": "^1.0.2"
+			}
+		},
 		"qs": {
 			"version": "6.9.4",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
@@ -169,6 +416,24 @@
 			"dev": true,
 			"requires": {
 				"lru-cache": "^6.0.0"
+			}
+		},
+		"string.prototype.trimend": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+			"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3"
+			}
+		},
+		"string.prototype.trimstart": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+			"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3"
 			}
 		},
 		"string_decoder": {
@@ -203,11 +468,34 @@
 			"version": "github:uNetworking/uWebSockets.js#3dbec7b56d627193e20705844b6bd10e49848b8c",
 			"from": "github:uNetworking/uWebSockets.js#v18.4.0"
 		},
+		"unbox-primitive": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has-bigints": "^1.0.1",
+				"has-symbols": "^1.0.2",
+				"which-boxed-primitive": "^1.0.2"
+			}
+		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"dev": true
+		},
+		"which-boxed-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"requires": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
+			}
 		},
 		"ws": {
 			"version": "7.3.1",

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -51,11 +51,11 @@
     "@ganache/options": "^0.1.0",
     "@ganache/tezos": "^0.1.0",
     "@ganache/utils": "^0.1.0",
-    "promise.allsettled": "^1.0.4",
+    "promise.allsettled": "1.0.4",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v18.4.0"
   },
   "devDependencies": {
-    "@types/promise.allsettled": "^1.0.3",
+    "@types/promise.allsettled": "1.0.3",
     "@types/superagent": "4.1.10",
     "superagent": "6.1.0",
     "ws": "7.3.1"

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -51,9 +51,11 @@
     "@ganache/options": "^0.1.0",
     "@ganache/tezos": "^0.1.0",
     "@ganache/utils": "^0.1.0",
+    "promise.allsettled": "^1.0.4",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v18.4.0"
   },
   "devDependencies": {
+    "@types/promise.allsettled": "^1.0.3",
     "@types/superagent": "4.1.10",
     "superagent": "6.1.0",
     "ws": "7.3.1"

--- a/src/packages/core/src/connector-loader.ts
+++ b/src/packages/core/src/connector-loader.ts
@@ -12,7 +12,7 @@ import { Base, Definitions } from "@ganache/options";
  * Loads the connector specified by the given `flavor`
  */
 export default {
-  initialize: async (
+  initialize: (
     providerOptions: ProviderOptions = {
       flavor: DefaultFlavor,
       chain: { asyncRequestProcessing: true }
@@ -41,11 +41,13 @@ export default {
       executor
     );
 
-    await connector.initialize();
+    // Purposely not awaiting on this to prevent a breaking change
+    // to the `Ganache.provider()` method
+    connector.initialize();
 
     // The request coordinator is initialized in a "paused" state; when the provider is ready we unpause.
     // This lets us accept queue requests before we've even fully initialized.
-    requestCoordinator.resume();
+    connector.on("ready", requestCoordinator.resume);
 
     return connector;
   }

--- a/src/packages/core/src/connector-loader.ts
+++ b/src/packages/core/src/connector-loader.ts
@@ -12,7 +12,7 @@ import { Base, Definitions } from "@ganache/options";
  * Loads the connector specified by the given `flavor`
  */
 export default {
-  initialize: (
+  initialize: async (
     providerOptions: ProviderOptions = {
       flavor: DefaultFlavor,
       chain: { asyncRequestProcessing: true }
@@ -41,9 +41,11 @@ export default {
       executor
     );
 
+    await connector.initialize();
+
     // The request coordinator is initialized in a "paused" state; when the provider is ready we unpause.
     // This lets us accept queue requests before we've even fully initialized.
-    connector.on("ready", requestCoordinator.resume);
+    requestCoordinator.resume();
 
     return connector;
   }

--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -1,6 +1,7 @@
 import { InternalOptions, ServerOptions, serverOptionsConfig } from "./options";
 
 import uWS, { TemplatedApp, us_listen_socket } from "uWebSockets.js";
+import allSettled from "promise.allsettled";
 import { Connector, DefaultFlavor } from "@ganache/flavors";
 import ConnectorLoader from "./connector-loader";
 import WebsocketServer, { WebSocketCapableFlavor } from "./servers/ws-server";
@@ -135,6 +136,10 @@ export default class Server {
     this.#status = Status.opening;
 
     const initializePromise = this.initialize();
+
+    // necessary for `Promise.allSettled` to be shimmed
+    // in `node@10`
+    allSettled.shim();
 
     const promise = Promise.allSettled([
       initializePromise,

--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -191,7 +191,7 @@ export default class Server {
 
     // clean up the websocket objects
     const _listenSocket = this.#listenSocket;
-    this.#listenSocket = void 0;
+    this.#listenSocket = null;
     // close the socket to prevent any more connections
     if (_listenSocket !== null) {
       uWS.us_listen_socket_close(_listenSocket);
@@ -213,6 +213,6 @@ export default class Server {
 
 
     this.#status = Status.closed;
-    this.#app = void 0;
+    this.#app = null;
   }
 }

--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -137,8 +137,12 @@ export default class Server {
 
     const initializePromise = this.initialize();
 
-    // necessary for `Promise.allSettled` to be shimmed
-    // in `node@10`
+    // This `shim()` is necessary for `Promise.allSettled` to be shimmed
+    // in `node@10`. We cannot use `allSettled([...])` directly due to
+    // https://github.com/es-shims/Promise.allSettled/issues/5 without
+    // upgrading Typescript. TODO: if Typescript is upgraded to 4.2.3+
+    // then this line could be removed and `Promise.allSettled` below
+    // could replaced with `allSettled`.
     allSettled.shim();
 
     const promise = Promise.allSettled([

--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -16,39 +16,57 @@ type Callback = (err: Error | null) => void;
  * Server ready state constants.
  *
  * These are bit flags. This means that you can check if the status is:
- *  * open: `status === Status.open`
- *  * opening: `status === Status.opening`
- *  * open || opening: `status & Status.open !== 0` or `status & Status.opening !== 0`
- *  * closed: `status === Status.closed`
- *  * closing: `status === Status.closing`
- *  * open || closing: `status & Status.closed !== 0` or `status & Status.closing !== 0`
+ *  * ready: `status === Status.ready` or `status & Status.ready !== 0`
+ *  * opening: `status === Status.opening` or `status & Status.opening !== 0`
+ *  * open: `status === Status.open` or `status & Status.open !== 0`
+ *  * opening || open: `status & Status.openingOrOpen !== 0` or `status & (Status.opening | Status.open) !== 0`
+ *  * closing: `status === Status.closing` or `status & Status.closing !== 0`
+ *  * closed: `status === Status.closed` or `status & Status.closed !== 0`
+ *  * closing || closed: `status & Status.closingOrClosed !== 0` or `status & (Status.closing | Status.closed) !== 0`
  */
 export enum Status {
   /**
-   * The connection is open and ready to communicate.
+   * The server is in an unknown state; perhaps construction didn't succeed
    */
-  open = 1,
+  unknown = 0,
   /**
-   * The connection is not yet open.
+   * The server has been constructed and is ready to be opened is open and ready to communicate.
    */
-  opening = 3,
+  ready = 1 << 0,
   /**
-   * The connection is closed.
+   * The server has started to open, but has not yet finished initialization.
    */
-  closed = 4,
+  opening = 1 << 1,
   /**
-   * The connection is in the process of closing.
+   * The server is open and ready for connection.
    */
-  closing = 12
+  open = 1 << 2,
+  /**
+   * The server is either opening or is already open
+   */
+  openingOrOpen = (1 << 1) | (1 << 2),
+  /**
+   * The server is in the process of closing.
+   */
+  closing = 1 << 3,
+  /**
+   * The server is closed and not accepting new connections.
+   */
+  closed = 1 << 4,
+  /**
+   * The server is either opening or is already open
+   */
+  closingOrClosed = (1 << 3) | (1 << 4)
 }
 
 export default class Server {
-  #app: TemplatedApp;
-  #httpServer: HttpServer;
-  #listenSocket?: us_listen_socket;
   #options: InternalOptions;
-  #connector: Connector;
-  #status = Status.closed;
+  #providerOptions: any;
+  #status: number = Status.unknown;
+  #app: TemplatedApp | null = null;
+  #httpServer: HttpServer | null = null;
+  #listenSocket: us_listen_socket | null = null;
+  #connector: Connector | null = null;
   #websocketServer: WebsocketServer | null = null;
 
   public get provider(): Provider {
@@ -59,10 +77,15 @@ export default class Server {
     return this.#status;
   }
 
-  constructor(serverOptions: ServerOptions = { flavor: DefaultFlavor }) {
-    const opts = (this.#options = serverOptionsConfig.normalize(serverOptions));
+  constructor(providerAndServerOptions: any = { flavor: DefaultFlavor }) {
+    this.#options = serverOptionsConfig.normalize(providerAndServerOptions);
+    this.#providerOptions = providerAndServerOptions;
+    this.#status = Status.ready;
+  }
+
+  async initialize() {
     const connector = (this.#connector = ConnectorLoader.initialize(
-      serverOptions
+      this.#providerOptions
     ));
 
     const _app = (this.#app = uWS.App());
@@ -71,16 +94,16 @@ export default class Server {
       this.#websocketServer = new WebsocketServer(
         _app,
         connector as WebSocketCapableFlavor,
-        opts.server
+        this.#options.server
       );
     }
     this.#httpServer = new HttpServer(_app, connector);
   }
 
-  listen(port: number): Promise<void>;
-  listen(port: number, host: string): Promise<void>;
   listen(port: number, callback: Callback): void;
   listen(port: number, host: string, callback: Callback): void;
+  listen(port: number): Promise<void>;
+  listen(port: number, host: string): Promise<void>;
   listen(
     port: number,
     host?: string | Callback,
@@ -99,9 +122,9 @@ export default class Server {
       return callbackIsFunction
         ? process.nextTick(callback!, err)
         : Promise.reject(err);
-    } else if (status & Status.open) {
-      // if open or opening
-      const err = new Error(`Server is already open on port: ${port}.`);
+    } else if ((status & Status.openingOrOpen) !== 0) {
+      // if opening or open
+      const err = new Error(`Server is already open, or is opening, on port: ${port}.`);
       return callbackIsFunction
         ? process.nextTick(callback!, err)
         : Promise.reject(err);
@@ -109,35 +132,43 @@ export default class Server {
 
     this.#status = Status.opening;
 
-    const promise = new Promise(
-      (resolve: (listenSocket: false | uWS.us_listen_socket) => void) => {
-        // Make sure we have *exclusive* use of this port.
-        // https://github.com/uNetworking/uSockets/commit/04295b9730a4d413895fa3b151a7337797dcb91f#diff-79a34a07b0945668e00f805838601c11R51
-        const LIBUS_LISTEN_EXCLUSIVE_PORT = 1;
-        hostname
-          ? this.#app.listen(
-              hostname,
-              port,
-              LIBUS_LISTEN_EXCLUSIVE_PORT,
-              resolve
-            )
-          : this.#app.listen(port as any, LIBUS_LISTEN_EXCLUSIVE_PORT, resolve);
-      }
-    ).then(listenSocket => {
-      if (listenSocket) {
-        this.#status = Status.open;
-        this.#listenSocket = listenSocket;
-        if (callbackIsFunction) callback!(null);
-      } else {
-        this.#status = Status.closed;
-        const err = new Error(
-          `listen EADDRINUSE: address already in use ${
-            hostname || DEFAULT_HOST
-          }:${port}.`
-        );
-        if (callbackIsFunction) callback!(err);
-        else throw err;
-      }
+    const initializePromise = this.initialize();
+
+    const promise = initializePromise.then(() => {
+      return new Promise(
+        (resolve: (listenSocket: false | uWS.us_listen_socket) => void) => {
+          // Make sure we have *exclusive* use of this port.
+          // https://github.com/uNetworking/uSockets/commit/04295b9730a4d413895fa3b151a7337797dcb91f#diff-79a34a07b0945668e00f805838601c11R51
+          const LIBUS_LISTEN_EXCLUSIVE_PORT = 1;
+          hostname
+            ? this.#app.listen(
+                hostname,
+                port,
+                LIBUS_LISTEN_EXCLUSIVE_PORT,
+                resolve
+              )
+            : this.#app.listen(port as any, LIBUS_LISTEN_EXCLUSIVE_PORT, resolve);
+        }
+      ).then(listenSocket => {
+        if (listenSocket) {
+          this.#status = Status.open;
+          this.#listenSocket = listenSocket;
+          if (callbackIsFunction) callback!(null);
+        } else {
+          this.#status = Status.closed;
+          const err = new Error(
+            `listen EADDRINUSE: address already in use ${
+              hostname || DEFAULT_HOST
+            }:${port}.`
+          );
+          if (callbackIsFunction) callback!(err);
+          else throw err;
+        }
+      });
+    }).catch(async error => {
+      this.#status = Status.unknown;
+      await this.close();
+      throw error;
     });
 
     if (!callbackIsFunction) {
@@ -149,25 +180,36 @@ export default class Server {
     if (this.#status === Status.opening) {
       // if opening
       throw new Error(`Cannot close server while it is opening.`);
-    } else if (this.#status & Status.closed) {
-      // if closed or closing
-      throw new Error(`Server is already closed or closing.`);
+    } else if ((this.#status & Status.closingOrClosed) !== 0) {
+      // if closing or closed
+      throw new Error(`Server is already closing or closed.`);
     }
 
-    const _listenSocket = this.#listenSocket;
     this.#status = Status.closing;
+
+    // clean up the websocket objects
+    const _listenSocket = this.#listenSocket;
     this.#listenSocket = void 0;
     // close the socket to prevent any more connections
-    uWS.us_listen_socket_close(_listenSocket);
+    if (_listenSocket !== null) {
+      uWS.us_listen_socket_close(_listenSocket);
+    }
     // close all the connected websockets:
-    const ws = this.#websocketServer;
-    if (ws) {
-      ws.close();
+    if (this.#websocketServer !== null) {
+      this.#websocketServer.close();
     }
 
     // and do all http cleanup, if any
-    this.#httpServer.close();
-    await this.#connector.close();
+    if (this.#httpServer !== null) {
+      this.#httpServer.close();
+    }
+
+    // cleanup the connector, provider, etc.
+    if (this.#connector !== null) {
+      await this.#connector.close();
+    }
+
+
     this.#status = Status.closed;
     this.#app = void 0;
   }

--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -102,10 +102,10 @@ export default class Server {
     this.#httpServer = new HttpServer(_app, connector);
   }
 
-  listen(port: number, callback: Callback): void;
-  listen(port: number, host: string, callback: Callback): void;
   listen(port: number): Promise<void>;
   listen(port: number, host: string): Promise<void>;
+  listen(port: number, callback: Callback): void;
+  listen(port: number, host: string, callback: Callback): void;
   listen(
     port: number,
     host?: string | Callback,

--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -83,10 +83,12 @@ export default class Server {
     this.#status = Status.ready;
   }
 
-  async initialize() {
-    const connector = (this.#connector = await ConnectorLoader.initialize(
+  private async initialize() {
+    const connector = (this.#connector = ConnectorLoader.initialize(
       this.#providerOptions
     ));
+
+    await connector.once("ready");
 
     const _app = (this.#app = uWS.App());
 

--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -84,7 +84,7 @@ export default class Server {
   }
 
   async initialize() {
-    const connector = (this.#connector = ConnectorLoader.initialize(
+    const connector = (this.#connector = await ConnectorLoader.initialize(
       this.#providerOptions
     ));
 

--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -61,7 +61,7 @@ export enum Status {
 
 export default class Server {
   #options: InternalOptions;
-  #providerOptions: any;
+  #providerOptions: ServerOptions;
   #status: number = Status.unknown;
   #app: TemplatedApp | null = null;
   #httpServer: HttpServer | null = null;
@@ -77,7 +77,7 @@ export default class Server {
     return this.#status;
   }
 
-  constructor(providerAndServerOptions: any = { flavor: DefaultFlavor }) {
+  constructor(providerAndServerOptions: ServerOptions = { flavor: DefaultFlavor }) {
     this.#options = serverOptionsConfig.normalize(providerAndServerOptions);
     this.#providerOptions = providerAndServerOptions;
     this.#status = Status.ready;

--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -88,8 +88,6 @@ export default class Server {
       this.#providerOptions
     ));
 
-    await connector.once("ready");
-
     const _app = (this.#app = uWS.App());
 
     if (this.#options.server.ws) {
@@ -100,6 +98,8 @@ export default class Server {
       );
     }
     this.#httpServer = new HttpServer(_app, connector);
+
+    await connector.once("ready");
   }
 
   listen(port: number): Promise<void>;

--- a/src/packages/core/tests/connector.test.ts
+++ b/src/packages/core/tests/connector.test.ts
@@ -4,12 +4,16 @@ import { Provider as EthereumProvider } from "@ganache/ethereum";
 
 describe("connector", () => {
   it("works without passing options", async () => {
-    assert.doesNotThrow(async () => await Ganache.provider());
+    assert.doesNotThrow(async () => {
+      const provider = Ganache.provider();
+      await provider.once("connect");
+    });
   });
 
   it("it logs when `options.verbose` is `true`", async () => {
     const logger = { log: (_msg: string) => {} };
-    const p = await Ganache.provider({ logging: { logger, verbose: true } });
+    const p = Ganache.provider({ logging: { logger, verbose: true } });
+    await p.once("connect");
 
     logger.log = msg => {
       assert.strictEqual(
@@ -32,7 +36,8 @@ describe("connector", () => {
   });
 
   it("it processes requests asyncronously when `asyncRequestProcessing` is default (true)", async () => {
-    const p = await Ganache.provider();
+    const p = Ganache.provider();
+    await p.once("connect");
     const accounts = await p.send("eth_accounts");
     // `eth_accounts` should always be faster than eth_getBalance; eth_accounts
     // should return before eth_getBalance because of the
@@ -45,7 +50,8 @@ describe("connector", () => {
   });
 
   it("it processes requests syncronously when `asyncRequestProcessing` is `false`", async () => {
-    const p = await Ganache.provider({ chain: { asyncRequestProcessing: false } });
+    const p = Ganache.provider({ chain: { asyncRequestProcessing: false } });
+    await p.once("connect");
     const accounts = await p.send("eth_accounts");
     // eth_getBalance should return first even though eth_accounts is faster;
     // eth_getBalance should return before eth_accounts because of the
@@ -60,7 +66,8 @@ describe("connector", () => {
   // to make sure that 3rd party API implementations can't shoot themselves
   // in the foot on accident
   it.skip("TODO: allow 'injecting' our own engine or API into a provider!", async () => {
-    const p = await Ganache.provider();
+    const p = Ganache.provider();
+    await p.once("connect");
     // this won't work becase ganache uses _real_ private properties that can't
     // be duck punched. This test is supposed to ensure that _real_ non-function
     // own properties (and __proto__ properties) can't be executed.
@@ -71,7 +78,8 @@ describe("connector", () => {
   });
 
   it("rejects invalid rpc methods", async () => {
-    const p = await Ganache.provider();
+    const p = Ganache.provider();
+    await p.once("connect");
 
     const illegalMethodNames = [
       "toString",

--- a/src/packages/core/tests/connector.test.ts
+++ b/src/packages/core/tests/connector.test.ts
@@ -4,12 +4,12 @@ import { Provider as EthereumProvider } from "@ganache/ethereum";
 
 describe("connector", () => {
   it("works without passing options", async () => {
-    assert.doesNotThrow(() => Ganache.provider());
+    assert.doesNotThrow(async () => await Ganache.provider());
   });
 
   it("it logs when `options.verbose` is `true`", async () => {
     const logger = { log: (_msg: string) => {} };
-    const p = Ganache.provider({ logging: { logger, verbose: true } });
+    const p = await Ganache.provider({ logging: { logger, verbose: true } });
 
     logger.log = msg => {
       assert.strictEqual(
@@ -32,7 +32,7 @@ describe("connector", () => {
   });
 
   it("it processes requests asyncronously when `asyncRequestProcessing` is default (true)", async () => {
-    const p = Ganache.provider();
+    const p = await Ganache.provider();
     const accounts = await p.send("eth_accounts");
     // `eth_accounts` should always be faster than eth_getBalance; eth_accounts
     // should return before eth_getBalance because of the
@@ -45,7 +45,7 @@ describe("connector", () => {
   });
 
   it("it processes requests syncronously when `asyncRequestProcessing` is `false`", async () => {
-    const p = Ganache.provider({ chain: { asyncRequestProcessing: false } });
+    const p = await Ganache.provider({ chain: { asyncRequestProcessing: false } });
     const accounts = await p.send("eth_accounts");
     // eth_getBalance should return first even though eth_accounts is faster;
     // eth_getBalance should return before eth_accounts because of the
@@ -60,7 +60,7 @@ describe("connector", () => {
   // to make sure that 3rd party API implementations can't shoot themselves
   // in the foot on accident
   it.skip("TODO: allow 'injecting' our own engine or API into a provider!", async () => {
-    const p = Ganache.provider();
+    const p = await Ganache.provider();
     // this won't work becase ganache uses _real_ private properties that can't
     // be duck punched. This test is supposed to ensure that _real_ non-function
     // own properties (and __proto__ properties) can't be executed.
@@ -71,7 +71,7 @@ describe("connector", () => {
   });
 
   it("rejects invalid rpc methods", async () => {
-    const p = Ganache.provider();
+    const p = await Ganache.provider();
 
     const illegalMethodNames = [
       "toString",

--- a/src/packages/core/tests/connector.test.ts
+++ b/src/packages/core/tests/connector.test.ts
@@ -6,14 +6,12 @@ describe("connector", () => {
   it("works without passing options", async () => {
     assert.doesNotThrow(async () => {
       const provider = Ganache.provider();
-      await provider.once("connect");
     });
   });
 
   it("it logs when `options.verbose` is `true`", async () => {
     const logger = { log: (_msg: string) => {} };
     const p = Ganache.provider({ logging: { logger, verbose: true } });
-    await p.once("connect");
 
     logger.log = msg => {
       assert.strictEqual(
@@ -37,7 +35,6 @@ describe("connector", () => {
 
   it("it processes requests asyncronously when `asyncRequestProcessing` is default (true)", async () => {
     const p = Ganache.provider();
-    await p.once("connect");
     const accounts = await p.send("eth_accounts");
     // `eth_accounts` should always be faster than eth_getBalance; eth_accounts
     // should return before eth_getBalance because of the
@@ -51,7 +48,6 @@ describe("connector", () => {
 
   it("it processes requests syncronously when `asyncRequestProcessing` is `false`", async () => {
     const p = Ganache.provider({ chain: { asyncRequestProcessing: false } });
-    await p.once("connect");
     const accounts = await p.send("eth_accounts");
     // eth_getBalance should return first even though eth_accounts is faster;
     // eth_getBalance should return before eth_accounts because of the
@@ -67,7 +63,6 @@ describe("connector", () => {
   // in the foot on accident
   it.skip("TODO: allow 'injecting' our own engine or API into a provider!", async () => {
     const p = Ganache.provider();
-    await p.once("connect");
     // this won't work becase ganache uses _real_ private properties that can't
     // be duck punched. This test is supposed to ensure that _real_ non-function
     // own properties (and __proto__ properties) can't be executed.
@@ -79,7 +74,6 @@ describe("connector", () => {
 
   it("rejects invalid rpc methods", async () => {
     const p = Ganache.provider();
-    await p.once("connect");
 
     const illegalMethodNames = [
       "toString",

--- a/src/packages/core/tests/helpers/getProvider.ts
+++ b/src/packages/core/tests/helpers/getProvider.ts
@@ -7,9 +7,7 @@ const mnemonic =
 const getProvider = async (
   options: ProviderOptions = { flavor: "ethereum", mnemonic }
 ) => {
-  const provider = Ganache.provider(options) as EthereumProvider;
-  await provider.once("connect");
-  return provider;
+  return Ganache.provider(options) as EthereumProvider;
 };
 
 export default getProvider;

--- a/src/packages/core/tests/helpers/getProvider.ts
+++ b/src/packages/core/tests/helpers/getProvider.ts
@@ -7,7 +7,9 @@ const mnemonic =
 const getProvider = async (
   options: ProviderOptions = { flavor: "ethereum", mnemonic }
 ) => {
-  return await Ganache.provider(options) as EthereumProvider;
+  const provider = Ganache.provider(options) as EthereumProvider;
+  await provider.once("connect");
+  return provider;
 };
 
 export default getProvider;

--- a/src/packages/core/tests/helpers/getProvider.ts
+++ b/src/packages/core/tests/helpers/getProvider.ts
@@ -4,10 +4,10 @@ import { EthereumProvider } from "@ganache/ethereum";
 
 const mnemonic =
   "into trim cross then helmet popular suit hammer cart shrug oval student";
-const getProvider = (
+const getProvider = async (
   options: ProviderOptions = { flavor: "ethereum", mnemonic }
 ) => {
-  return Ganache.provider(options) as EthereumProvider;
+  return await Ganache.provider(options) as EthereumProvider;
 };
 
 export default getProvider;

--- a/src/packages/core/tests/server.test.ts
+++ b/src/packages/core/tests/server.test.ts
@@ -181,9 +181,7 @@ describe("server", () => {
       server.listen(port);
 
       try {
-        await assert.rejects(setup, {
-          message: `listen EADDRINUSE: address already in use 127.0.0.1:${port}.`
-        });
+        await assert.rejects(setup, `listen EADDRINUSE: address already in use 127.0.0.1:${port}.`);
       } finally {
         await teardown();
         server.close();
@@ -214,9 +212,7 @@ describe("server", () => {
         const s2 = Ganache.server();
 
         try {
-          await assert.rejects(s2.listen(port), {
-            message: `listen EADDRINUSE: address already in use 127.0.0.1:${port}.`
-          });
+          await assert.rejects(s2.listen(port), `listen EADDRINUSE: address already in use 127.0.0.1:${port}.`);
         } catch (e) {
           // in case of failure, make sure we properly shut things down
           if (s2.status & Status.open) {

--- a/src/packages/core/tests/server.test.ts
+++ b/src/packages/core/tests/server.test.ts
@@ -41,8 +41,8 @@ describe("server", () => {
   }
 
   async function teardown() {
-    // if the server is open or opening, try to close it.
-    if (s && s.status & Status.open) {
+    // if the server is opening or open, try to close it.
+    if (s && (s.status & Status.openingOrOpen) !== 0) {
       await s.close();
     }
   }
@@ -62,30 +62,30 @@ describe("server", () => {
     it("returns its status", async () => {
       const s = Ganache.server();
       try {
-        assert.strictEqual(s.status, Status.closed);
+        assert.strictEqual(s.status, Status.ready);
         const pendingListen = s.listen(port);
         assert.strictEqual(s.status, Status.opening);
         assert.ok(
           s.status & Status.opening,
-          "Bitmask broken: can't be used to determine `open || closed` state"
+          "Bitmask broken: can't be used to determine `opening` state"
         );
         await pendingListen;
         assert.strictEqual(s.status, Status.open);
         assert.ok(
           s.status & Status.open,
-          "Bitmask broken: can't be used to determine `open || closed` state"
+          "Bitmask broken: can't be used to determine `open` state"
         );
         const pendingClose = s.close();
         assert.strictEqual(s.status, Status.closing);
         assert.ok(
           s.status & Status.closing,
-          "Bitmask broken: can't be used to determine `closed || closing` state"
+          "Bitmask broken: can't be used to determine `closing` state"
         );
         await pendingClose;
         assert.strictEqual(s.status, Status.closed);
         assert.ok(
           s.status & Status.closed,
-          "Bitmask broken: can't be used to determine `closed || closing` state"
+          "Bitmask broken: can't be used to determine `closed` state"
         );
       } catch (e) {
         // in case of failure, make sure we properly shut things down
@@ -125,7 +125,7 @@ describe("server", () => {
         // the call to `setup()` above calls `listen()` already. if we call it
         // again it should fail.
         await assert.rejects(s.listen(port), {
-          message: `Server is already open on port: ${port}.`
+          message: `Server is already open, or is opening, on port: ${port}.`
         });
       } finally {
         await teardown();
@@ -139,7 +139,7 @@ describe("server", () => {
         // again it should fail.
         const listen = promisify(s.listen.bind(s));
         await assert.rejects(listen(port), {
-          message: `Server is already open on port: ${port}.`
+          message: `Server is already open, or is opening, on port: ${port}.`
         });
       } finally {
         await teardown();
@@ -151,7 +151,7 @@ describe("server", () => {
       try {
         await s.close();
         assert.rejects(s.close(), {
-          message: "Server is already closed or closing."
+          message: "Server is already closing or closed."
         });
       } finally {
         await teardown();
@@ -163,7 +163,7 @@ describe("server", () => {
       try {
         s.close();
         assert.rejects(s.close(), {
-          message: "Server is already closed or closing."
+          message: "Server is already closing or closed."
         });
       } finally {
         await teardown();

--- a/src/packages/core/tests/server.test.ts
+++ b/src/packages/core/tests/server.test.ts
@@ -36,6 +36,7 @@ describe("server", () => {
       }
     }
   ) {
+    // @ts-expect-error
     s = Ganache.server(options);
     return s.listen(port);
   }
@@ -106,6 +107,7 @@ describe("server", () => {
     });
 
     it("returns the net_version over a legacy-style connection listener", done => {
+      // @ts-expect-error
       s = Ganache.server({
         chain: { networkId }
       });

--- a/src/packages/core/tests/server.test.ts
+++ b/src/packages/core/tests/server.test.ts
@@ -1,4 +1,10 @@
-import Ganache from "../";
+// Using `../index` instead of `../` is
+// necessary as `..` will point to the `package.json`
+// and point to `main` which uses `lib/index.js`
+// instead of `index.ts` causing TS errors during
+// construction due to missing private fields
+import Ganache from "../index";
+
 import * as assert from "assert";
 import request from "superagent";
 import WebSocket from "ws";
@@ -36,7 +42,6 @@ describe("server", () => {
       }
     }
   ) {
-    // @ts-expect-error
     s = Ganache.server(options);
     return s.listen(port);
   }
@@ -107,7 +112,6 @@ describe("server", () => {
     });
 
     it("returns the net_version over a legacy-style connection listener", done => {
-      // @ts-expect-error
       s = Ganache.server({
         chain: { networkId }
       });

--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -142,7 +142,7 @@ Then you can use ganache as an [EIP-1193 provider only](#as-an-eip-1193-provider
 const ganache = require("ganache");
 
 const options = {};
-const provider = await ganache.provider(options);
+const provider = ganache.provider(options);
 const accounts = await provider.request({ method: "eth_accounts", params: [] });
 ```
 
@@ -171,13 +171,13 @@ To use ganache as a Web3 provider:
 const Web3 = require("web3");
 const ganache = require("ganache");
 
-const web3 = new Web3(await ganache.provider());
+const web3 = new Web3(ganache.provider());
 ```
 
 NOTE: depending on your web3 version, you may need to set a number of confirmation blocks
 
 ```
-const web3 = new Web3(await ganache.provider(), null, { transactionConfirmationBlocks: 1 });
+const web3 = new Web3(ganache.provider(), null, { transactionConfirmationBlocks: 1 });
 ```
 
 #### As an [ethers.js]() provider:
@@ -185,7 +185,7 @@ const web3 = new Web3(await ganache.provider(), null, { transactionConfirmationB
 ```javascript
 const ganache = require("ganache");
 
-const provider = new ethers.providers.Web3Provider(await ganache.provider());
+const provider = new ethers.providers.Web3Provider(ganache.provider());
 ```
 
 ## Documentation

--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -142,7 +142,7 @@ Then you can use ganache as an [EIP-1193 provider only](#as-an-eip-1193-provider
 const ganache = require("ganache");
 
 const options = {};
-const provider = ganache.provider(options);
+const provider = await ganache.provider(options);
 const accounts = await provider.request({ method: "eth_accounts", params: [] });
 ```
 
@@ -171,13 +171,13 @@ To use ganache as a Web3 provider:
 const Web3 = require("web3");
 const ganache = require("ganache");
 
-const web3 = new Web3(ganache.provider());
+const web3 = new Web3(await ganache.provider());
 ```
 
 NOTE: depending on your web3 version, you may need to set a number of confirmation blocks
 
 ```
-const web3 = new Web3(ganache.provider(), null, { transactionConfirmationBlocks: 1 });
+const web3 = new Web3(await ganache.provider(), null, { transactionConfirmationBlocks: 1 });
 ```
 
 #### As an [ethers.js]() provider:
@@ -185,7 +185,7 @@ const web3 = new Web3(ganache.provider(), null, { transactionConfirmationBlocks:
 ```javascript
 const ganache = require("ganache");
 
-const provider = new ethers.providers.Web3Provider(ganache.provider());
+const provider = new ethers.providers.Web3Provider(await ganache.provider());
 ```
 
 ## Documentation

--- a/src/packages/ganache/index.ts
+++ b/src/packages/ganache/index.ts
@@ -1,6 +1,24 @@
 import Ganache from "@ganache/cli";
 
 export default {
+  /**
+   * Creates a Ganache server instance that creates and
+   * serves an underlying Ganache provider. Initialization
+   * doesn't begin until `server.listen(...)` is called.
+   * `server.listen(...)` returns a promise that resolves
+   * when initialization is finished.
+   */
   server: Ganache.server,
+
+  /**
+   * Initializes a Web3 provider for a Ganache instance.
+   * This function starts an asynchronous task, but does not
+   * finish it by the time the function returns. Listen to
+   * `provider.on("connect", () => {...})` or wait for
+   * `await provider.once("connect")` for initialization to
+   * finish. You may start sending requests to the provider
+   * before initialization finishes however; these requests
+   * will start being consumed after initialization finishes.
+   */
   provider: Ganache.provider
 };


### PR DESCRIPTION
This PR was driven by having an issue incorporating Ganache v7 into Ganache UI. If there was an error before the `Server.status` was set to `opening`, but the constructors started async operations (i.e. opening the database), then things would get locked without the ability to be closed properly during `Server.close()`

So this PR does a couple of things:
- Provide more/rearchitect the server `Status` enum to be more accurate and appropriate
- Move all asynchronous code from constructors to a dedicated asynchronous `initialize` functions so that we can guarantee that we can appropriately close things when things fail
- Coincidentally, this has caused `Ganache.provider()` to become asynchronous by nature. It always "was" and the work around was to use an event emitter to say when things were ready. This may get modified to go back to the old way (while still keeping the other benefits added in this PR) to maintain back-compatibility. However that decision is still waiting on feedback from the rest of the team. This PR won't get merged until the final direction has been decided and implemented in this PR. In the meantime, the other parts can be reviewed.