### PR TITLE
implement #877 async init changes for the filecoin flavor

### DIFF
--- a/src/chains/filecoin/filecoin/src/api.ts
+++ b/src/chains/filecoin/filecoin/src/api.ts
@@ -50,6 +50,10 @@ export default class FilecoinApi implements types.Api {
     this.#blockchain = blockchain;
   }
 
+  async initialize() {
+    await this.#blockchain.initialize();
+  }
+
   async stop(): Promise<void> {
     return await this.#blockchain.stop();
   }

--- a/src/chains/filecoin/filecoin/src/connector.ts
+++ b/src/chains/filecoin/filecoin/src/connector.ts
@@ -33,15 +33,17 @@ export class Connector
   ) {
     super();
 
-    const provider = (this.#provider = new FilecoinProvider(
+    this.#provider = new FilecoinProvider(
       providerOptions,
       executor
-    ));
+    );
+  }
 
-    provider.on("ready", () => {
-      // tell the consumer (like a `ganache-core` server/connector) everything is ready
-      this.emit("ready");
-    });
+  async initialize() {
+    await this.#provider.initialize();
+    // no need to wait for #provider.once("connect") as the initialize()
+    // promise has already accounted for that after the promise is resolved
+    await this.emit("ready");
   }
 
   parse(message: Buffer) {

--- a/src/chains/filecoin/filecoin/src/database.ts
+++ b/src/chains/filecoin/filecoin/src/database.ts
@@ -47,10 +47,9 @@ export default class Database extends Emittery {
     super();
 
     this.#options = options;
-    this.#initialize();
   }
 
-  #initialize = async () => {
+  initialize = async () => {
     const levelupOptions: any = { valueEncoding: "binary" };
     const store = this.#options.db;
     let db: LevelUp;

--- a/src/chains/filecoin/filecoin/src/provider.ts
+++ b/src/chains/filecoin/filecoin/src/provider.ts
@@ -15,7 +15,7 @@ import cloneDeep from "lodash.clonedeep";
 // Meant to mimic this provider:
 // https://github.com/filecoin-shipyard/js-lotus-client-provider-browser
 export default class FilecoinProvider
-  extends Emittery.Typed<{}, "ready">
+  extends Emittery.Typed<{}, "connect" | "disconnect">
   // Do I actually need this? `types.Provider` doesn't actually define anything behavior
   implements types.Provider<FilecoinApi> {
   #options: FilecoinInternalOptions;
@@ -35,11 +35,13 @@ export default class FilecoinProvider
     this.#executor = executor;
 
     this.blockchain = new Blockchain(providerOptions);
-    this.blockchain.on("ready", () => {
-      this.emit("ready");
-    });
 
     this.#api = new FilecoinApi(this.blockchain);
+  }
+
+  async initialize() {
+    await this.#api.initialize();
+    await this.emit("connect");
   }
 
   /**

--- a/src/chains/filecoin/filecoin/tests/blockchain/blockchain.test.ts
+++ b/src/chains/filecoin/filecoin/tests/blockchain/blockchain.test.ts
@@ -41,8 +41,8 @@ describe("Blockchain", () => {
           }
         })
       );
-      await blockchain.waitForReady();
-      await blockchain2.waitForReady();
+      await blockchain.initialize();
+      await blockchain2.initialize();
     });
 
     after(async () => {
@@ -104,7 +104,7 @@ describe("Blockchain", () => {
       );
 
       try {
-        await blockchain.waitForReady();
+        await blockchain.initialize();
 
         // After 0.5 seconds, we should have at least 3 blocks and no more than 10 blocks
         // Github CI is so unpredictable with their burstable cpus
@@ -135,7 +135,7 @@ describe("Blockchain", () => {
       );
 
       try {
-        await blockchain.waitForReady();
+        await blockchain.initialize();
 
         const ipfs = IpfsHttpClient({
           host: "localhost",
@@ -183,7 +183,7 @@ describe("Blockchain", () => {
         })
       );
 
-      await blockchain.waitForReady();
+      await blockchain.initialize();
 
       const result = await blockchain.ipfs!.add({
         content: "some data"
@@ -274,7 +274,7 @@ describe("Blockchain", () => {
         })
       );
 
-      await blockchain.waitForReady();
+      await blockchain.initialize();
 
       const result = await blockchain.ipfs!.add({
         content: "some data"
@@ -333,7 +333,7 @@ describe("Blockchain", () => {
           }
         })
       );
-      await blockchain.waitForReady();
+      await blockchain.initialize();
       const accounts = await blockchain.accountManager.getControllableAccounts();
 
       assert.strictEqual(accounts[0].address.value, expectedAddress);
@@ -352,7 +352,7 @@ describe("Blockchain", () => {
           }
         })
       );
-      await blockchain.waitForReady();
+      await blockchain.initialize();
       const accounts = await blockchain.accountManager.getControllableAccounts();
 
       assert.notStrictEqual(accounts[0].address.value, expectedAddress);

--- a/src/chains/filecoin/filecoin/tests/blockchain/database.test.ts
+++ b/src/chains/filecoin/filecoin/tests/blockchain/database.test.ts
@@ -35,7 +35,7 @@ describe("Blockchain", () => {
         })
       );
 
-      await blockchain.waitForReady();
+      await blockchain.initialize();
       await blockchain.mineTipset();
       const dir = await readdir(dbPath);
       assert(dir.length > 0);
@@ -78,7 +78,7 @@ describe("Blockchain", () => {
         })
       );
 
-      await blockchain.waitForReady();
+      await blockchain.initialize();
       const latestTipset = blockchain.latestTipset();
       assert.strictEqual(latestTipset.height, 1);
       assert(
@@ -101,7 +101,7 @@ describe("Blockchain", () => {
         })
       );
 
-      await blockchain.waitForReady();
+      await blockchain.initialize();
 
       let gotFile = false;
       for await (const file of blockchain.ipfs.get(ipfsCid)) {

--- a/src/chains/filecoin/filecoin/tests/helpers/getProvider.ts
+++ b/src/chains/filecoin/filecoin/tests/helpers/getProvider.ts
@@ -19,12 +19,8 @@ const getProvider = async (options?: Partial<FilecoinProviderOptions>) => {
     },
     executor
   );
-  await new Promise(resolve => {
-    provider.on("ready", () => {
-      requestCoordinator.resume();
-      resolve(void 0);
-    });
-  });
+  await provider.initialize();
+  requestCoordinator.resume();
   return provider;
 };
 

--- a/src/chains/filecoin/filecoin/tests/helpers/getServer.ts
+++ b/src/chains/filecoin/filecoin/tests/helpers/getServer.ts
@@ -16,7 +16,7 @@ const getServer = async (port: number) => {
       }
     }
   });
-  await new Promise(resolve => server.listen(port, resolve));
+  await server.listen(port);
   return server;
 };
 

--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -183,9 +183,7 @@ export class Server extends Emittery<{ open: undefined; close: undefined }> {
           else throw err;
         }
       })
-    ]).then(() => {
-      return this.emit("open");
-    }).catch(async error => {
+    ]).catch(async error => {
       this.#status = Status.unknown;
       if (callbackIsFunction) callback!(error);
       await this.close();
@@ -197,6 +195,7 @@ export class Server extends Emittery<{ open: undefined; close: undefined }> {
         const promiseResults = await promise;
 
         if (promiseResults[0].status === "fulfilled" && promiseResults[1].status === "fulfilled") {
+          this.emit("open");
           resolve();
         } else {
           let reason = "";


### PR DESCRIPTION
This PR implements the necessary changes from #877 (which was rebased into `filecoin`) for the filecoin flavor so that initialization can happen in an async method rather than the constructor