### PR TITLE
Fix Filecoin tests

### DIFF
--- a/src/chains/ethereum/ethereum/npm-shrinkwrap.json
+++ b/src/chains/ethereum/ethereum/npm-shrinkwrap.json
@@ -32,9 +32,9 @@
 			}
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "18.14.0-unofficial.1",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.1.tgz",
-			"integrity": "sha512-gkzWrw/3APSnJHjeq9NPYB9/Kw5hkVWD4c31EuE3yb79BbMefiewJjFMcMQNT66p1LeBKE9rJDrQD9HnHsNPvg==",
+			"version": "18.14.0-unofficial.2",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.2.tgz",
+			"integrity": "sha512-KwO4TOsDBUvBiEwKMpMzFoDfogpgJRpJRiAU9txkk5Fz8dKe9fplrXAd2DjarnbTU86Hxn/VLukgTBUgD6Lo4w==",
 			"dev": true
 		},
 		"@types/bn.js": {

--- a/src/chains/ethereum/ethereum/package.json
+++ b/src/chains/ethereum/ethereum/package.json
@@ -89,6 +89,6 @@
     "solc": "0.7.4",
     "ts-transformer-inline-file": "0.1.1",
     "typedoc": "0.17.8",
-    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.1"
+    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.2"
   }
 }

--- a/src/chains/filecoin/filecoin/npm-shrinkwrap.json
+++ b/src/chains/filecoin/filecoin/npm-shrinkwrap.json
@@ -703,9 +703,9 @@
 			"integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "18.14.0-unofficial.1",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.1.tgz",
-			"integrity": "sha512-gkzWrw/3APSnJHjeq9NPYB9/Kw5hkVWD4c31EuE3yb79BbMefiewJjFMcMQNT66p1LeBKE9rJDrQD9HnHsNPvg==",
+			"version": "18.14.0-unofficial.2",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.2.tgz",
+			"integrity": "sha512-KwO4TOsDBUvBiEwKMpMzFoDfogpgJRpJRiAU9txkk5Fz8dKe9fplrXAd2DjarnbTU86Hxn/VLukgTBUgD6Lo4w==",
 			"dev": true
 		},
 		"@types/abstract-leveldown": {

--- a/src/chains/filecoin/filecoin/package.json
+++ b/src/chains/filecoin/filecoin/package.json
@@ -36,7 +36,7 @@
     "tsc": "ttsc --build",
     "tsc.declarations": "ttsc --build tsconfig.declarations.json",
     "test": "ts-node ../../../../scripts/skip-if-less-than-node-12.ts || nyc --reporter lcov npm run mocha",
-    "mocha": "ts-node ../../../../scripts/skip-if-less-than-node-12.ts || cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true TS_NODE_TRANSPILE_ONLY=true TS_NODE_PROJECT=tsconfig.test.json mocha --timeout 20000 --no-parallel --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "ts-node ../../../../scripts/skip-if-less-than-node-12.ts || cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true TS_NODE_TRANSPILE_ONLY=true TS_NODE_PROJECT=tsconfig.test.json mocha --timeout 60000 --no-parallel --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache-core/issues"

--- a/src/chains/filecoin/filecoin/package.json
+++ b/src/chains/filecoin/filecoin/package.json
@@ -65,7 +65,7 @@
     "@ganache/filecoin-options": "0.1.2",
     "@ganache/options": "0.1.0",
     "@ganache/utils": "0.1.0",
-    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.1",
+    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.2",
     "@types/bn.js": "5.1.0",
     "@types/deep-equal": "1.0.1",
     "@types/levelup": "4.3.0",

--- a/src/chains/filecoin/filecoin/package.json
+++ b/src/chains/filecoin/filecoin/package.json
@@ -36,7 +36,7 @@
     "tsc": "ttsc --build",
     "tsc.declarations": "ttsc --build tsconfig.declarations.json",
     "test": "ts-node ../../../../scripts/skip-if-less-than-node-12.ts || nyc --reporter lcov npm run mocha",
-    "mocha": "ts-node ../../../../scripts/skip-if-less-than-node-12.ts || cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true TS_NODE_TRANSPILE_ONLY=true TS_NODE_PROJECT=tsconfig.test.json mocha --timeout 10000 --no-parallel --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "ts-node ../../../../scripts/skip-if-less-than-node-12.ts || cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true TS_NODE_TRANSPILE_ONLY=true TS_NODE_PROJECT=tsconfig.test.json mocha --timeout 20000 --no-parallel --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache-core/issues"

--- a/src/chains/tezos/tezos/npm-shrinkwrap.json
+++ b/src/chains/tezos/tezos/npm-shrinkwrap.json
@@ -32,9 +32,9 @@
 			}
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "18.14.0-unofficial.1",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.1.tgz",
-			"integrity": "sha512-gkzWrw/3APSnJHjeq9NPYB9/Kw5hkVWD4c31EuE3yb79BbMefiewJjFMcMQNT66p1LeBKE9rJDrQD9HnHsNPvg==",
+			"version": "18.14.0-unofficial.2",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.2.tgz",
+			"integrity": "sha512-KwO4TOsDBUvBiEwKMpMzFoDfogpgJRpJRiAU9txkk5Fz8dKe9fplrXAd2DjarnbTU86Hxn/VLukgTBUgD6Lo4w==",
 			"dev": true
 		},
 		"@types/node": {

--- a/src/chains/tezos/tezos/package.json
+++ b/src/chains/tezos/tezos/package.json
@@ -49,6 +49,6 @@
     "cheerio": "1.0.0-rc.3",
     "local-web-server": "4.2.1",
     "typedoc": "0.17.8",
-    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.1"
+    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.2"
   }
 }

--- a/src/packages/core/npm-shrinkwrap.json
+++ b/src/packages/core/npm-shrinkwrap.json
@@ -37,6 +37,15 @@
 				"@types/node": "*"
 			}
 		},
+		"aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"requires": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			}
+		},
 		"array.prototype.map": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.3.tgz",
@@ -63,6 +72,11 @@
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
 			}
+		},
+		"clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -221,6 +235,11 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
 			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+		},
+		"indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
 		},
 		"inherits": {
 			"version": "2.0.4",

--- a/src/packages/core/npm-shrinkwrap.json
+++ b/src/packages/core/npm-shrinkwrap.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "18.14.0-unofficial.1",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.1.tgz",
-			"integrity": "sha512-gkzWrw/3APSnJHjeq9NPYB9/Kw5hkVWD4c31EuE3yb79BbMefiewJjFMcMQNT66p1LeBKE9rJDrQD9HnHsNPvg=="
+			"version": "18.14.0-unofficial.2",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.2.tgz",
+			"integrity": "sha512-KwO4TOsDBUvBiEwKMpMzFoDfogpgJRpJRiAU9txkk5Fz8dKe9fplrXAd2DjarnbTU86Hxn/VLukgTBUgD6Lo4w=="
 		},
 		"@types/cookiejar": {
 			"version": "2.1.2",

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -51,9 +51,10 @@
     "@ganache/options": "^0.1.0",
     "@ganache/tezos": "^0.1.0",
     "@ganache/utils": "^0.1.0",
-    "promise.allsettled": "1.0.4",
     "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.2",
-    "emittery": "0.8.1"
+    "aggregate-error": "3.1.0",
+    "emittery": "0.8.1",
+    "promise.allsettled": "1.0.4"
   },
   "devDependencies": {
     "@types/promise.allsettled": "1.0.3",

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -52,7 +52,7 @@
     "@ganache/tezos": "^0.1.0",
     "@ganache/utils": "^0.1.0",
     "promise.allsettled": "1.0.4",
-    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.1",
+    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.2",
     "emittery": "0.8.1"
   },
   "devDependencies": {

--- a/src/packages/utils/npm-shrinkwrap.json
+++ b/src/packages/utils/npm-shrinkwrap.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "18.14.0-unofficial.1",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.1.tgz",
-			"integrity": "sha512-gkzWrw/3APSnJHjeq9NPYB9/Kw5hkVWD4c31EuE3yb79BbMefiewJjFMcMQNT66p1LeBKE9rJDrQD9HnHsNPvg==",
+			"version": "18.14.0-unofficial.2",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.2.tgz",
+			"integrity": "sha512-KwO4TOsDBUvBiEwKMpMzFoDfogpgJRpJRiAU9txkk5Fz8dKe9fplrXAd2DjarnbTU86Hxn/VLukgTBUgD6Lo4w==",
 			"dev": true
 		},
 		"@types/seedrandom": {

--- a/src/packages/utils/package.json
+++ b/src/packages/utils/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@types/seedrandom": "2.4.28",
-    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.1"
+    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.2"
   },
   "optionalDependencies": {
     "bigint-buffer": "1.1.5"


### PR DESCRIPTION
This PR fixes tests 2 root issues that were causing multiple tests from failing:
- Change how the result of `allSettled` is handled by using the root thenable rather than wrapping it in another promise. Without this, tests for node<12 were failing
- Use `ubuntu-18.04` to build the Linux images for https://github.com/trufflesuite/uws-js-unofficial (this is the version that the latest `uWebSockets.js` was used to build despite Alex's workflow uses `ubuntu-latest` [so it'll break if/when his `ubuntu-latest` moves to 20.04]). The error was seen in ubuntu 16.04 and 18.04 where GLIBC 2.28 could not be found