### PR TITLE
maint: temporarily make `ganache` not conflict with `ganache-cli`

### DIFF
--- a/src/packages/flavors/index.ts
+++ b/src/packages/flavors/index.ts
@@ -49,6 +49,13 @@ export function GetConnector(
 ): Connector {
   switch (flavor) {
     case DefaultFlavor:
+      // TODO: (Issue #889) Remove warning after `ganache` with `ethereum` is stable
+      console.warn(
+        chalk`\n\n{yellow.bold WARNING:} Using the "{bold ethereum}" flavor via the {bold ganache} package is currently not stable.\n` +
+          chalk`Please use {bold ganache-cli} instead: {hex("${TruffleColors.turquoise}") https://npmjs.com/package/ganache-cli}.\n\n` +
+          chalk`{hex("${TruffleColors.porsche}").bold ${NEED_HELP}}\n` +
+          chalk`{hex("${TruffleColors.turquoise}") ${COMMUNITY_LINK}}\n\n`
+      );
       return new Ethereum.Connector(providerOptions, executor);
     case FilecoinFlavorName:
       try {

--- a/src/packages/ganache/package.json
+++ b/src/packages/ganache/package.json
@@ -10,8 +10,7 @@
   "types": "lib/index.d.ts",
   "source": "index.ts",
   "bin": {
-    "ganache": "dist/cli/ganache.min.js",
-    "ganache-cli": "dist/cli/ganache.min.js"
+    "ganache": "dist/cli/ganache.min.js"
   },
   "directories": {
     "lib": "lib",


### PR DESCRIPTION
This PR makes it so that users can use both `ganache` and `ganache-cli` npm packages as we'll be releasing filecoin without stable ethereum support. The follow up issue to basically revert these changes is #889 