### PR TITLE
feat: Allow contract code and balance overrides

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -29,7 +29,10 @@ import {
 import { TypedData as NotTypedData, signTypedData_v4 } from "eth-sig-util";
 import { EthereumInternalOptions, Hardfork } from "@ganache/ethereum-options";
 import { types, Data, Quantity, PromiEvent, utils } from "@ganache/utils";
-import Blockchain, { TransactionTraceOptions } from "./blockchain";
+import Blockchain, {
+  SimulationOverrides,
+  TransactionTraceOptions
+} from "./blockchain";
 import Wallet from "./wallet";
 import { decode as rlpDecode } from "rlp";
 import { $INLINE_JSON } from "ts-transformer-inline-file";
@@ -1787,10 +1790,11 @@ export default class EthereumApi implements types.Api {
    *
    * @returns the return value of executed contract.
    */
-  @assertArgLength(1, 2)
+  @assertArgLength(1, 3)
   async eth_call(
     transaction: any,
-    blockNumber: string | Buffer | Tag = Tag.LATEST
+    blockNumber: string | Buffer | Tag = Tag.LATEST,
+    overrides: SimulationOverrides = {}
   ) {
     const blockchain = this.#blockchain;
     const blocks = blockchain.blocks;
@@ -1846,7 +1850,11 @@ export default class EthereumApi implements types.Api {
       block
     };
 
-    return blockchain.simulateTransaction(simulatedTransaction, parentBlock);
+    return blockchain.simulateTransaction(
+      simulatedTransaction,
+      parentBlock,
+      overrides
+    );
   }
   //#endregion
 

--- a/src/chains/ethereum/ethereum/tests/api/eth/contracts/Inspector.sol
+++ b/src/chains/ethereum/ethereum/tests/api/eth/contracts/Inspector.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.4;
+pragma experimental ABIEncoderV2;
+
+contract Inspector {
+    function getBalance(address addr)
+        public
+        view
+        returns (uint256)
+    {
+        return addr.balance;
+    }
+
+    function getCode(address addr)
+        public
+        view
+        returns (bytes memory code)
+    {
+        assembly {
+            // retrieve the size of the code, this needs assembly
+            let size := extcodesize(addr)
+            // allocate output byte array - this could also be done without assembly
+            // by using o_code = new bytes(size)
+            code := mload(0x40)
+            // new "memory end" including padding
+            mstore(0x40, add(code, and(add(add(size, 0x20), 0x1f), not(0x1f))))
+            // store length in memory
+            mstore(code, size)
+            // actually retrieve the code, this needs assembly
+            extcodecopy(addr, add(code, 0x20), 0, size)
+        }
+    }
+}

--- a/src/chains/ethereum/ethereum/tests/api/eth/ethCall.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/ethCall.test.ts
@@ -1,0 +1,130 @@
+import assert from "assert";
+import getProvider from "../../helpers/getProvider";
+import compile from "../../helpers/compile";
+import { join } from "path";
+import EthereumProvider from "../../../src/provider";
+import { simpleEncode, rawEncode } from "ethereumjs-abi";
+
+describe("api", () => {
+  describe("eth", () => {
+    describe("sendTransaction", () => {
+      describe("options", () => {
+        const testAddress = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        const contractDir = join(__dirname, "contracts");
+        async function deployContract(
+          provider: EthereumProvider,
+          accounts: string[]
+        ) {
+          const contract = compile(join(contractDir, "Inspector.sol"));
+
+          const from = accounts[0];
+
+          await provider.send("eth_subscribe", ["newHeads"]);
+
+          const transactionHash = await provider.send("eth_sendTransaction", [
+            {
+              from,
+              data: contract.code,
+              gas: 3141592
+            }
+          ]);
+
+          await provider.once("message");
+
+          const receipt = await provider.send("eth_getTransactionReceipt", [
+            transactionHash
+          ]);
+          assert.strictEqual(receipt.blockNumber, "0x1");
+
+          const contractAddress = receipt.contractAddress;
+          return {
+            contract,
+            contractAddress
+          };
+        }
+
+        it("allows override of account code", async () => {
+          const provider = await getProvider({
+            chain: { vmErrorsOnRPCResponse: true }
+          });
+          const accounts = await provider.send("eth_accounts");
+          const { contractAddress } = await deployContract(provider, accounts);
+
+          const data = `0x${simpleEncode(
+            "getCode(address)",
+            testAddress
+          ).toString("hex")}`;
+
+          const result = await provider.send("eth_call", [
+            {
+              from: accounts[0],
+              to: contractAddress,
+              data
+            },
+            "latest",
+            { [testAddress]: { code: "0x123456" } }
+          ]);
+
+          assert.strictEqual(
+            result,
+            "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000031234560000000000000000000000000000000000000000000000000000000000"
+          );
+        });
+
+        it("allows override of account balance", async () => {
+          const provider = await getProvider({
+            chain: { vmErrorsOnRPCResponse: true }
+          });
+          const accounts = await provider.send("eth_accounts");
+          const { contractAddress } = await deployContract(provider, accounts);
+
+          const data = `0x${simpleEncode(
+            "getBalance(address)",
+            testAddress
+          ).toString("hex")}`;
+
+          const result = await provider.send("eth_call", [
+            {
+              from: accounts[0],
+              to: contractAddress,
+              data
+            },
+            "latest",
+            { [testAddress]: { balance: "0x1e240" } }
+          ]);
+
+          assert.strictEqual(
+            result,
+            `0x${rawEncode(["uint256"], [123456]).toString("hex")}`
+          );
+        });
+
+        it("does not persist overrides", async () => {
+          const provider = await getProvider({
+            chain: { vmErrorsOnRPCResponse: true }
+          });
+          const accounts = await provider.send("eth_accounts");
+          const { contractAddress } = await deployContract(provider, accounts);
+
+          const data = `0x${simpleEncode(
+            "getCode(address)",
+            testAddress
+          ).toString("hex")}`;
+
+          const result = await provider.send("eth_call", [
+            {
+              from: accounts[0],
+              to: contractAddress,
+              data
+            },
+            "latest"
+          ]);
+
+          const rawEmptyBytesEncoded =
+            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000";
+          assert.strictEqual(result, rawEmptyBytesEncoded);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Wanted to gather some early feedback on this WIP PR. https://github.com/trufflesuite/ganache-core/issues/554

We'd love to have override support, similar to geth, in ganache. https://geth.ethereum.org/docs/rpc/ns-eth

The feature in geth is fantastic as it allows us to query a contract without requiring it to be deployed onto the chain. It also allows us to use this query contract on an archive node (i.e before it could conceivably be deployed). It also allows us to replace token contracts with dummy contracts and override balances/allowances for simulation and testing. 

Would love to hear your thoughts on whether this will be a PR you'd accept and any hints on the approach taken.