### PR TITLE
fix: add Iuri Matias back to license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/scripts/create.ts
+++ b/scripts/create.ts
@@ -245,7 +245,6 @@ describe("${packageName}", () => {
       const headerdoc = `/*!
   * ${packageName}
   *
-  * @copyright Truffle Blockchain Group
   * @author ${pkg.author}
   * @license ${pkg.license}
 */

--- a/src/chains/ethereum/address/LICENSE
+++ b/src/chains/ethereum/address/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/ethereum/block/LICENSE
+++ b/src/chains/ethereum/block/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/ethereum/ethereum/LICENSE
+++ b/src/chains/ethereum/ethereum/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/ethereum/ethereum/index.ts
+++ b/src/chains/ethereum/ethereum/index.ts
@@ -1,7 +1,6 @@
 /*!
  * @ganache/ethereum
  *
- * @copyright Truffle Blockchain Group
  * @author David Murdoch <david@trufflesuite.com> (https://davidmurdoch.com)
  * @license MIT
  */

--- a/src/chains/ethereum/options/LICENSE
+++ b/src/chains/ethereum/options/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/ethereum/options/index.ts
+++ b/src/chains/ethereum/options/index.ts
@@ -1,7 +1,6 @@
 /*!
  * @ganache/ethereum-options
  *
- * @copyright Truffle Blockchain Group
  * @author David Murdoch <david@trufflesuite.com> (https://davidmurdoch.com)
  * @license MIT
  */

--- a/src/chains/ethereum/transaction/LICENSE
+++ b/src/chains/ethereum/transaction/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/ethereum/transaction/index.ts
+++ b/src/chains/ethereum/transaction/index.ts
@@ -1,7 +1,6 @@
 /*!
  * @ganache/ethereum-transaction
  *
- * @copyright Truffle Blockchain Group
  * @author David Murdoch
  * @license MIT
  */

--- a/src/chains/ethereum/utils/LICENSE
+++ b/src/chains/ethereum/utils/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/ethereum/utils/index.ts
+++ b/src/chains/ethereum/utils/index.ts
@@ -1,7 +1,6 @@
 /*!
  * @ganache/ethereum-utils
  *
- * @copyright Truffle Blockchain Group
  * @author David Murdoch <david@trufflesuite.com> (https://davidmurdoch.com)
  * @license MIT
  */

--- a/src/chains/filecoin/filecoin/index.ts
+++ b/src/chains/filecoin/filecoin/index.ts
@@ -1,7 +1,6 @@
 /*!
  * @ganache/filecoin
  *
- * @copyright Truffle Blockchain Group
  * @author Tim Coulter
  * @license MIT
  */

--- a/src/chains/filecoin/options/LICENSE
+++ b/src/chains/filecoin/options/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/filecoin/options/index.ts
+++ b/src/chains/filecoin/options/index.ts
@@ -1,7 +1,6 @@
 /*!
  * @ganache/filecoin-options
  *
- * @copyright Truffle Blockchain Group
  * @author Tim Coulter
  * @license MIT
  */

--- a/src/chains/tezos/options/LICENSE
+++ b/src/chains/tezos/options/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/tezos/options/index.ts
+++ b/src/chains/tezos/options/index.ts
@@ -1,7 +1,6 @@
 /*!
  * @ganache/tezos-options
  *
- * @copyright Truffle Blockchain Group
  * @author David Murdoch <david@trufflesuite.com> (https://davidmurdoch.com)
  * @license MIT
  */

--- a/src/chains/tezos/tezos/LICENSE
+++ b/src/chains/tezos/tezos/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/cli/LICENSE
+++ b/src/packages/cli/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/colors/index.ts
+++ b/src/packages/colors/index.ts
@@ -1,7 +1,6 @@
 /*!
  * @ganache/colors
  *
- * @copyright Truffle Blockchain Group
  * @author David Murdoch
  * @license MIT
  */

--- a/src/packages/core/LICENSE
+++ b/src/packages/core/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/flavors/LICENSE
+++ b/src/packages/flavors/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/ganache/LICENSE
+++ b/src/packages/ganache/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/options/LICENSE
+++ b/src/packages/options/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/promise-queue/LICENSE
+++ b/src/packages/promise-queue/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/rlp/LICENSE
+++ b/src/packages/rlp/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/utils/LICENSE
+++ b/src/packages/utils/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2020 Truffle Blockchain Group
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 


### PR DESCRIPTION
This also replaces Truffle Blockchain Group with ConsenSys Software Inc in LICENSE files and removes superfluous copyright statements in index.ts files.