### PR TITLE
fix: increase max payload size to match geth

### DIFF
--- a/src/chains/ethereum/ethereum/package-lock.json
+++ b/src/chains/ethereum/ethereum/package-lock.json
@@ -535,9 +535,9 @@
       }
     },
     "@trufflesuite/uws-js-unofficial": {
-      "version": "18.14.0-unofficial.9",
-      "resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.9.tgz",
-      "integrity": "sha512-joyG8T+7lSEzLWAy7qF1NmkKi8nM27I3i19xN4j9oVjdgnnRsnboqWJbugyEhouUBUdJvtjr9o3kx3oLD81oxQ==",
+      "version": "18.14.0-unofficial.10",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.10.tgz",
+      "integrity": "sha512-hEG4SWLc6cCvE6pvMjgzsK82Oil9PArqwjZWflQhoevQhN1KAELcdcqqNwh/QBl36GBCjlE7k69fs5UEiApapA==",
       "dev": true,
       "requires": {
         "bufferutil": "4.0.3",

--- a/src/chains/ethereum/ethereum/package.json
+++ b/src/chains/ethereum/ethereum/package.json
@@ -85,7 +85,7 @@
   },
   "devDependencies": {
     "@trufflesuite/typedoc-default-themes": "0.6.1",
-    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.9",
+    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.10",
     "@types/encoding-down": "5.0.0",
     "@types/fs-extra": "9.0.2",
     "@types/keccak": "3.0.1",

--- a/src/chains/filecoin/filecoin/package-lock.json
+++ b/src/chains/filecoin/filecoin/package-lock.json
@@ -830,9 +830,9 @@
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "@trufflesuite/uws-js-unofficial": {
-      "version": "18.14.0-unofficial.9",
-      "resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.9.tgz",
-      "integrity": "sha512-joyG8T+7lSEzLWAy7qF1NmkKi8nM27I3i19xN4j9oVjdgnnRsnboqWJbugyEhouUBUdJvtjr9o3kx3oLD81oxQ==",
+      "version": "18.14.0-unofficial.10",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.10.tgz",
+      "integrity": "sha512-hEG4SWLc6cCvE6pvMjgzsK82Oil9PArqwjZWflQhoevQhN1KAELcdcqqNwh/QBl36GBCjlE7k69fs5UEiApapA==",
       "dev": true,
       "requires": {
         "bufferutil": "4.0.3",

--- a/src/chains/filecoin/filecoin/package.json
+++ b/src/chains/filecoin/filecoin/package.json
@@ -59,7 +59,7 @@
     "@filecoin-shipyard/lotus-client-schema": "2.0.0",
     "@ganache/filecoin-options": "0.1.1-canary.1338",
     "@ganache/utils": "0.1.1-canary.1338",
-    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.9",
+    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.10",
     "@types/bn.js": "5.1.0",
     "@types/deep-equal": "1.0.1",
     "@types/levelup": "4.3.0",

--- a/src/chains/tezos/tezos/package-lock.json
+++ b/src/chains/tezos/tezos/package-lock.json
@@ -32,9 +32,9 @@
       }
     },
     "@trufflesuite/uws-js-unofficial": {
-      "version": "18.14.0-unofficial.9",
-      "resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.9.tgz",
-      "integrity": "sha512-joyG8T+7lSEzLWAy7qF1NmkKi8nM27I3i19xN4j9oVjdgnnRsnboqWJbugyEhouUBUdJvtjr9o3kx3oLD81oxQ==",
+      "version": "18.14.0-unofficial.10",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.10.tgz",
+      "integrity": "sha512-hEG4SWLc6cCvE6pvMjgzsK82Oil9PArqwjZWflQhoevQhN1KAELcdcqqNwh/QBl36GBCjlE7k69fs5UEiApapA==",
       "dev": true,
       "requires": {
         "bufferutil": "4.0.3",

--- a/src/chains/tezos/tezos/package.json
+++ b/src/chains/tezos/tezos/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@trufflesuite/typedoc-default-themes": "0.6.1",
-    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.9",
+    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.10",
     "@types/mocha": "8.2.2",
     "cheerio": "1.0.0-rc.3",
     "cross-env": "7.0.3",

--- a/src/packages/core/package-lock.json
+++ b/src/packages/core/package-lock.json
@@ -421,9 +421,9 @@
       "dev": true
     },
     "@trufflesuite/uws-js-unofficial": {
-      "version": "18.14.0-unofficial.9",
-      "resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.9.tgz",
-      "integrity": "sha512-joyG8T+7lSEzLWAy7qF1NmkKi8nM27I3i19xN4j9oVjdgnnRsnboqWJbugyEhouUBUdJvtjr9o3kx3oLD81oxQ==",
+      "version": "18.14.0-unofficial.10",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.10.tgz",
+      "integrity": "sha512-hEG4SWLc6cCvE6pvMjgzsK82Oil9PArqwjZWflQhoevQhN1KAELcdcqqNwh/QBl36GBCjlE7k69fs5UEiApapA==",
       "requires": {
         "bufferutil": "4.0.3",
         "utf-8-validate": "5.0.5",

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -53,7 +53,7 @@
     "@ganache/options": "0.1.1-canary.1338",
     "@ganache/tezos": "0.1.1-canary.1338",
     "@ganache/utils": "0.1.1-canary.1338",
-    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.9",
+    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.10",
     "aggregate-error": "3.1.0",
     "emittery": "0.8.1",
     "promise.allsettled": "1.0.4"

--- a/src/packages/core/src/servers/ws-server.ts
+++ b/src/packages/core/src/servers/ws-server.ts
@@ -1,4 +1,8 @@
-import { RecognizedString, TemplatedApp, WebSocket } from "@trufflesuite/uws-js-unofficial";
+import {
+  RecognizedString,
+  TemplatedApp,
+  WebSocket
+} from "@trufflesuite/uws-js-unofficial";
 import WebSocketCloseCodes from "./utils/websocket-close-codes";
 import { InternalOptions } from "../options";
 import * as Flavors from "@ganache/flavors";
@@ -25,6 +29,9 @@ export type WebsocketServerOptions = Pick<
   "wsBinary" | "rpcEndpoint"
 >;
 
+// matches geth's limit of 15 MebiBytes: https://github.com/ethereum/go-ethereum/blob/3526f690478482a02a152988f4d31074c176b136/rpc/websocket.go#L40
+export const MAX_PAYLOAD_SIZE = 15 * 1024 * 1024;
+
 export default class WebsocketServer {
   #connections = new Map<WebSocket, Set<() => void>>();
   constructor(
@@ -37,7 +44,8 @@ export default class WebsocketServer {
     const autoBinary = wsBinary === "auto";
     app.ws(options.rpcEndpoint, {
       /* WS Options */
-      maxPayloadLength: 16 * 1024, // 128 Kibibits
+
+      maxPayloadLength: MAX_PAYLOAD_SIZE,
       idleTimeout: 120, // in seconds
 
       // Note that compression is disabled (the default option)

--- a/src/packages/ganache/npm-shrinkwrap.json
+++ b/src/packages/ganache/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
 	"name": "ganache",
-	"version": "7.0.0-canary.1338",
+	"version": "7.0.0-canary.1340",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/packages/utils/package-lock.json
+++ b/src/packages/utils/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@trufflesuite/uws-js-unofficial": {
-      "version": "18.14.0-unofficial.9",
-      "resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.9.tgz",
-      "integrity": "sha512-joyG8T+7lSEzLWAy7qF1NmkKi8nM27I3i19xN4j9oVjdgnnRsnboqWJbugyEhouUBUdJvtjr9o3kx3oLD81oxQ==",
+      "version": "18.14.0-unofficial.10",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.10.tgz",
+      "integrity": "sha512-hEG4SWLc6cCvE6pvMjgzsK82Oil9PArqwjZWflQhoevQhN1KAELcdcqqNwh/QBl36GBCjlE7k69fs5UEiApapA==",
       "dev": true,
       "requires": {
         "bufferutil": "4.0.3",

--- a/src/packages/utils/package.json
+++ b/src/packages/utils/package.json
@@ -51,7 +51,7 @@
     "seedrandom": "3.0.5"
   },
   "devDependencies": {
-    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.9",
+    "@trufflesuite/uws-js-unofficial": "18.14.0-unofficial.10",
     "@types/mocha": "8.2.2",
     "@types/seedrandom": "2.4.28",
     "cross-env": "7.0.3",


### PR DESCRIPTION
The default max payload size for websocket connections was quite small, and @cds-amal found a bug that was hitting our limits, except when run in node 16!

The reason it worked in node 16 is that our uWebsockets.js fork doesn't work with node 16, so instead, it uses a pure-JS fallback. This fallback didn't have any upper max payload size, so it happily accepts large payloads.

The limit introduced in this PR matches that of geth. This PR also updates our uws fork to a version that supports the max payload size option in the JS fallback.