### PR TITLE
feat: london

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,8 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-          with:
-            token: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:
@@ -50,7 +50,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+          with:
+            repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
           with:
-            repo-token: ${{ secrets.GITHUB_TOKEN }}
+            token: ${{ secrets.GITHUB_TOKEN }}
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+          with:
+            repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v1
         with:
           node-version: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-          with:
-            token: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v1
         with:
           node-version: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
           with:
-            repo-token: ${{ secrets.GITHUB_TOKEN }}
+            token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v1
         with:
           node-version: 14

--- a/docs/assets/js/ganache/ganache.min.js.LICENSE.txt
+++ b/docs/assets/js/ganache/ganache.min.js.LICENSE.txt
@@ -41,6 +41,13 @@
  */
 
 /*!
+ * @ganache/secp256k1
+ *
+ * @author David Murdoch
+ * @license MIT
+ */
+
+/*!
  * The buffer module from node.js, for the browser.
  *
  * @author   Feross Aboukhadijeh <feross@feross.org> <http://feross.org>

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,7 +42,7 @@
       <span class="hljs-function"> <span class="hljs-title">bzz_hive</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">any</span>[]&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L217" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L218" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -88,7 +88,7 @@
       <span class="hljs-function"> <span class="hljs-title">bzz_info</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">any</span>[]&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L230" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L231" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -134,7 +134,7 @@
       <span class="hljs-function"> <span class="hljs-title">db_getHex</span>(<span class="hljs-params">dbName: <span class="hljs-built_in">string</span>, key: <span class="hljs-built_in">string</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L202" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L203" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -193,7 +193,7 @@
       <span class="hljs-function"> <span class="hljs-title">db_getString</span>(<span class="hljs-params">dbName: <span class="hljs-built_in">string</span>, key: <span class="hljs-built_in">string</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L169" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L170" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -252,7 +252,7 @@
       <span class="hljs-function"> <span class="hljs-title">db_putHex</span>(<span class="hljs-params">dbName: <span class="hljs-built_in">string</span>, key: <span class="hljs-built_in">string</span>, data: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L186" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L187" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -313,7 +313,7 @@
       <span class="hljs-function"> <span class="hljs-title">db_putString</span>(<span class="hljs-params">dbName: <span class="hljs-built_in">string</span>, key: <span class="hljs-built_in">string</span>, value: <span class="hljs-built_in">string</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L153" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L154" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -374,7 +374,7 @@
       <span class="hljs-function"> <span class="hljs-title">debug_storageRangeAt</span>(<span class="hljs-params">blockHash: DATA, transactionIndex: <span class="hljs-built_in">number</span>, contractAddress: DATA, startKey: DATA, maxResult: <span class="hljs-built_in">number</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">StorageRangeResult</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2539" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2576" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -467,7 +467,7 @@ returns a next key which is the keccak-256 hash of the next key in storage for c
       <span class="hljs-function"> <span class="hljs-title">debug_traceTransaction</span>(<span class="hljs-params">transactionHash: DATA, options?: TransactionTraceOptions</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">TraceTransactionResult</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2489" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2526" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -565,7 +565,7 @@ The possible options are:</p>
       <span class="hljs-function"> <span class="hljs-title">eth_accounts</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>[]&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1307" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1328" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -612,7 +612,7 @@ The possible options are:</p>
       <span class="hljs-function"> <span class="hljs-title">eth_blockNumber</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1321" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1342" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -659,7 +659,7 @@ The possible options are:</p>
       <span class="hljs-function"> <span class="hljs-title">eth_call</span>(<span class="hljs-params">transaction: <span class="hljs-built_in">any</span>, blockNumber: QUANTITY | TAG</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">DATA</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2378" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2413" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -743,7 +743,7 @@ The possible options are:</p>
       <span class="hljs-function"> <span class="hljs-title">eth_chainId</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1338" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1359" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -802,7 +802,7 @@ replay-protected transaction signing as introduced by EIP-155.</p>
       <span class="hljs-function"> <span class="hljs-title">eth_coinbase</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">Address</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L820" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L831" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -849,7 +849,7 @@ replay-protected transaction signing as introduced by EIP-155.</p>
       <span class="hljs-function"> <span class="hljs-title">eth_estimateGas</span>(<span class="hljs-params">transaction: <span class="hljs-built_in">any</span>, blockNumber: QUANTITY | TAG</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L729" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L738" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -925,7 +925,7 @@ including EVM mechanics and node performance.</p>
       <span class="hljs-function"> <span class="hljs-title">eth_gasPrice</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1293" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1314" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -972,7 +972,7 @@ including EVM mechanics and node performance.</p>
       <span class="hljs-function"> <span class="hljs-title">eth_getBalance</span>(<span class="hljs-params">address: DATA, blockNumber: QUANTITY | TAG</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1358" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1379" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -1032,10 +1032,10 @@ including EVM mechanics and node performance.</p>
   <div>
     <a name="eth_getBlockByHash"></a>
     <h3 class="signature">
-      <span class="hljs-function"> <span class="hljs-title">eth_getBlockByHash</span>(<span class="hljs-params">hash: DATA, transactions: <span class="hljs-built_in">boolean</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">any</span>&gt;</span>
+      <span class="hljs-function"> <span class="hljs-title">eth_getBlockByHash</span>(<span class="hljs-params">hash: DATA, transactions: <span class="hljs-built_in">boolean</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L916" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L929" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -1068,7 +1068,7 @@ transactions.</li>
           returns
         </div>
         <div class="return_type">
-          <code class="language-typescript"><span class="hljs-function"><span class="hljs-title">Promise</span>&lt;<span class="hljs-title">any</span>&gt;</span>
+          <code class="language-typescript"><span class="hljs-function"><span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
 </code><p>: The block, <code>null</code> if the block doesn&#39;t exist.</p>
 <ul>
 <li><code>hash</code>: <code>DATA</code>, 32 Bytes - Hash of the block. <code>null</code> when pending.</li>
@@ -1131,10 +1131,10 @@ transactions.</li>
   <div>
     <a name="eth_getBlockByNumber"></a>
     <h3 class="signature">
-      <span class="hljs-function"> <span class="hljs-title">eth_getBlockByNumber</span>(<span class="hljs-params"><span class="hljs-built_in">number</span>: QUANTITY | TAG, transactions: <span class="hljs-built_in">boolean</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">any</span>&gt;</span>
+      <span class="hljs-function"> <span class="hljs-title">eth_getBlockByNumber</span>(<span class="hljs-params"><span class="hljs-built_in">number</span>: QUANTITY | TAG, transactions: <span class="hljs-built_in">boolean</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L860" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L871" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -1168,7 +1168,7 @@ transactions.</li>
           returns
         </div>
         <div class="return_type">
-          <code class="language-typescript"><span class="hljs-function"><span class="hljs-title">Promise</span>&lt;<span class="hljs-title">any</span>&gt;</span>
+          <code class="language-typescript"><span class="hljs-function"><span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
 </code><p>: The block, <code>null</code> if the block doesn&#39;t exist.</p>
 <ul>
 <li><code>hash</code>: <code>DATA</code>, 32 Bytes - Hash of the block. <code>null</code> when pending.</li>
@@ -1218,7 +1218,7 @@ transactions.</li>
       <span class="hljs-function"> <span class="hljs-title">eth_getBlockTransactionCountByHash</span>(<span class="hljs-params">hash: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L972" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L985" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -1292,7 +1292,7 @@ transactions.</li>
       <span class="hljs-function"> <span class="hljs-title">eth_getBlockTransactionCountByNumber</span>(<span class="hljs-params">blockNumber: QUANTITY | TAG</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L935" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L948" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -1350,7 +1350,7 @@ transactions.</li>
       <span class="hljs-function"> <span class="hljs-title">eth_getCode</span>(<span class="hljs-params">address: DATA, blockNumber: QUANTITY | TAG</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">DATA</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1397" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1418" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -1426,7 +1426,7 @@ transactions.</li>
       <span class="hljs-function"> <span class="hljs-title">eth_getCompilers</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>[]&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L994" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1007" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -1473,7 +1473,7 @@ transactions.</li>
       <span class="hljs-function"> <span class="hljs-title">eth_getFilterChanges</span>(<span class="hljs-params">filterId: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">DATA</span>[]&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2182" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2217" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -1574,7 +1574,7 @@ on the filter type, which occurred since last poll.</p>
       <span class="hljs-function"> <span class="hljs-title">eth_getFilterLogs</span>(<span class="hljs-params">filterId: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>[]&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2252" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2287" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -1656,7 +1656,7 @@ on the filter type, which occurred since last poll.</p>
       <span class="hljs-function"> <span class="hljs-title">eth_getLogs</span>(<span class="hljs-params">filter: FilterArgs</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>[]&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2309" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2344" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -1751,7 +1751,7 @@ then neither <code>fromBlock</code> or <code>toBlock</code> are allowed.</li>
       <span class="hljs-function"> <span class="hljs-title">eth_getStorageAt</span>(<span class="hljs-params">address: DATA, position: QUANTITY, blockNumber: QUANTITY | TAG</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">DATA</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1432" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1453" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -1827,10 +1827,10 @@ then neither <code>fromBlock</code> or <code>toBlock</code> are allowed.</li>
   <div>
     <a name="eth_getTransactionByBlockHashAndIndex"></a>
     <h3 class="signature">
-      <span class="hljs-function"> <span class="hljs-title">eth_getTransactionByBlockHashAndIndex</span>(<span class="hljs-params">hash: DATA, index: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">any</span>&gt;</span>
+      <span class="hljs-function"> <span class="hljs-title">eth_getTransactionByBlockHashAndIndex</span>(<span class="hljs-params">hash: DATA, index: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1032" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1045" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -1862,7 +1862,7 @@ then neither <code>fromBlock</code> or <code>toBlock</code> are allowed.</li>
           returns
         </div>
         <div class="return_type">
-          <code class="language-typescript"><span class="hljs-function"><span class="hljs-title">Promise</span>&lt;<span class="hljs-title">any</span>&gt;</span>
+          <code class="language-typescript"><span class="hljs-function"><span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
 </code><p>: The transaction object or <code>null</code> if no transaction was found.</p>
 <ul>
 <li><code>hash</code>: <code>DATA</code>, 32 Bytes - The transaction hash.</li>
@@ -1909,10 +1909,10 @@ then neither <code>fromBlock</code> or <code>toBlock</code> are allowed.</li>
   <div>
     <a name="eth_getTransactionByBlockNumberAndIndex"></a>
     <h3 class="signature">
-      <span class="hljs-function"> <span class="hljs-title">eth_getTransactionByBlockNumberAndIndex</span>(<span class="hljs-params"><span class="hljs-built_in">number</span>: QUANTITY | TAG, index: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">any</span>&gt;</span>
+      <span class="hljs-function"> <span class="hljs-title">eth_getTransactionByBlockNumberAndIndex</span>(<span class="hljs-params"><span class="hljs-built_in">number</span>: QUANTITY | TAG, index: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1075" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1091" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -1944,7 +1944,7 @@ then neither <code>fromBlock</code> or <code>toBlock</code> are allowed.</li>
           returns
         </div>
         <div class="return_type">
-          <code class="language-typescript"><span class="hljs-function"><span class="hljs-title">Promise</span>&lt;<span class="hljs-title">any</span>&gt;</span>
+          <code class="language-typescript"><span class="hljs-function"><span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
 </code><p>: The transaction object or <code>null</code> if no transaction was found.</p>
 <ul>
 <li><code>hash</code>: <code>DATA</code>, 32 Bytes - The transaction hash.</li>
@@ -1994,7 +1994,7 @@ then neither <code>fromBlock</code> or <code>toBlock</code> are allowed.</li>
       <span class="hljs-function"> <span class="hljs-title">eth_getTransactionByHash</span>(<span class="hljs-params">transactionHash: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1505" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1526" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2073,7 +2073,7 @@ then neither <code>fromBlock</code> or <code>toBlock</code> are allowed.</li>
       <span class="hljs-function"> <span class="hljs-title">eth_getTransactionCount</span>(<span class="hljs-params">address: DATA, blockNumber: QUANTITY | TAG</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2332" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2367" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2136,10 +2136,10 @@ or &quot;pending&quot;.</li>
   <div>
     <a name="eth_getTransactionReceipt"></a>
     <h3 class="signature">
-      <span class="hljs-function"> <span class="hljs-title">eth_getTransactionReceipt</span>(<span class="hljs-params">transactionHash: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
+      <span class="hljs-function"> <span class="hljs-title">eth_getTransactionReceipt</span>(<span class="hljs-params">transactionHash: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">TransactionReceiptJSON</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1542" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1563" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2170,7 +2170,7 @@ or &quot;pending&quot;.</li>
           returns
         </div>
         <div class="return_type">
-          <code class="language-typescript"><span class="hljs-function"><span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
+          <code class="language-typescript"><span class="hljs-function"><span class="hljs-title">Promise</span>&lt;<span class="hljs-title">TransactionReceiptJSON</span>&gt;</span>
 </code><p>: Returns the receipt of a transaction by transaction hash.</p>
 
         </div>
@@ -2200,10 +2200,10 @@ or &quot;pending&quot;.</li>
   <div>
     <a name="eth_getUncleByBlockHashAndIndex"></a>
     <h3 class="signature">
-      <span class="hljs-function"> <span class="hljs-title">eth_getUncleByBlockHashAndIndex</span>(<span class="hljs-params">hash: DATA, index: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">any</span>&gt;</span>
+      <span class="hljs-function"> <span class="hljs-title">eth_getUncleByBlockHashAndIndex</span>(<span class="hljs-params">hash: DATA, index: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1150" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1171" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2235,7 +2235,7 @@ or &quot;pending&quot;.</li>
           returns
         </div>
         <div class="return_type">
-          <code class="language-typescript"><span class="hljs-function"><span class="hljs-title">Promise</span>&lt;<span class="hljs-title">any</span>&gt;</span>
+          <code class="language-typescript"><span class="hljs-function"><span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
 </code><p>: A block object or <code>null</code> when no block is found.</p>
 <ul>
 <li><code>hash</code>: <code>DATA</code>, 32 Bytes - Hash of the block. <code>null</code> when pending.</li>
@@ -2283,10 +2283,10 @@ or &quot;pending&quot;.</li>
   <div>
     <a name="eth_getUncleByBlockNumberAndIndex"></a>
     <h3 class="signature">
-      <span class="hljs-function"> <span class="hljs-title">eth_getUncleByBlockNumberAndIndex</span>(<span class="hljs-params">blockNumber: QUANTITY | TAG, uncleIndex: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">any</span>&gt;</span>
+      <span class="hljs-function"> <span class="hljs-title">eth_getUncleByBlockNumberAndIndex</span>(<span class="hljs-params">blockNumber: QUANTITY | TAG, uncleIndex: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1189" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1210" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2318,7 +2318,7 @@ or &quot;pending&quot;.</li>
           returns
         </div>
         <div class="return_type">
-          <code class="language-typescript"><span class="hljs-function"><span class="hljs-title">Promise</span>&lt;<span class="hljs-title">any</span>&gt;</span>
+          <code class="language-typescript"><span class="hljs-function"><span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
 </code><p>: A block object or <code>null</code> when no block is found.</p>
 <ul>
 <li><code>hash</code>: <code>DATA</code>, 32 Bytes - Hash of the block. <code>null</code> when pending.</li>
@@ -2368,7 +2368,7 @@ or &quot;pending&quot;.</li>
       <span class="hljs-function"> <span class="hljs-title">eth_getUncleCountByBlockHash</span>(<span class="hljs-params">hash: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1095" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1116" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2427,7 +2427,7 @@ or &quot;pending&quot;.</li>
       <span class="hljs-function"> <span class="hljs-title">eth_getUncleCountByBlockNumber</span>(<span class="hljs-params">blockNumber: QUANTITY | TAG</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1110" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1131" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2485,7 +2485,7 @@ or &quot;pending&quot;.</li>
       <span class="hljs-function"> <span class="hljs-title">eth_getWork</span>(<span class="hljs-params">filterId: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;[] | [<span class="hljs-title">string</span>, <span class="hljs-title">string</span>, <span class="hljs-title">string</span>]&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1210" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1231" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2545,7 +2545,7 @@ or &quot;pending&quot;.</li>
       <span class="hljs-function"> <span class="hljs-title">eth_hashrate</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1279" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1300" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2592,7 +2592,7 @@ or &quot;pending&quot;.</li>
       <span class="hljs-function"> <span class="hljs-title">eth_mining</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1264" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1285" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2639,7 +2639,7 @@ or &quot;pending&quot;.</li>
       <span class="hljs-function"> <span class="hljs-title">eth_newBlockFilter</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2018" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2053" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2687,7 +2687,7 @@ if the state has changed, call <code>eth_getFilterChanges</code>.</p>
       <span class="hljs-function"> <span class="hljs-title">eth_newFilter</span>(<span class="hljs-params">filter?: RangeFilterArgs</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2104" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2139" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2775,7 +2775,7 @@ be an array of <code>DATA</code> with &quot;or&quot; options.</li>
       <span class="hljs-function"> <span class="hljs-title">eth_newPendingTransactionFilter</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2045" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2080" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2823,7 +2823,7 @@ arrive. To check if the state has changed, call <code>eth_getFilterChanges</code
       <span class="hljs-function"> <span class="hljs-title">eth_protocolVersion</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">DATA</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L785" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L796" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2870,7 +2870,7 @@ arrive. To check if the state has changed, call <code>eth_getFilterChanges</code
       <span class="hljs-function"> <span class="hljs-title">eth_sendRawTransaction</span>(<span class="hljs-params">transaction: <span class="hljs-built_in">string</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">DATA</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1704" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1738" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2927,10 +2927,10 @@ arrive. To check if the state has changed, call <code>eth_getFilterChanges</code
   <div>
     <a name="eth_sendTransaction"></a>
     <h3 class="signature">
-      <span class="hljs-function"> <span class="hljs-title">eth_sendTransaction</span>(<span class="hljs-params">transaction: RpcTransaction</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">DATA</span>&gt;</span>
+      <span class="hljs-function"> <span class="hljs-title">eth_sendTransaction</span>(<span class="hljs-params">transaction: TypedRpcTransaction</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">DATA</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1606" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1632" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -2955,7 +2955,7 @@ arrive. To check if the state has changed, call <code>eth_getFilterChanges</code
           arguments
         </div>
         <ul>
-          <li><code class="language-typescript"><span class="hljs-function"><span class="hljs-params">transaction: RpcTransaction</span></span>
+          <li><code class="language-typescript"><span class="hljs-function"><span class="hljs-params">transaction: TypedRpcTransaction</span></span>
 </code>
 : The transaction call object as seen in source.</li>
         </ul>
@@ -3000,7 +3000,7 @@ arrive. To check if the state has changed, call <code>eth_getFilterChanges</code
       <span class="hljs-function"> <span class="hljs-title">eth_sign</span>(<span class="hljs-params">address: DATA, message: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1739" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1771" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -3069,10 +3069,10 @@ that the <code>v</code> parameter includes the chain id as specified in <a href=
   <div>
     <a name="eth_signTransaction"></a>
     <h3 class="signature">
-      <span class="hljs-function"> <span class="hljs-title">eth_signTransaction</span>(<span class="hljs-params">transaction: RpcTransaction</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>&gt;</span>
+      <span class="hljs-function"> <span class="hljs-title">eth_signTransaction</span>(<span class="hljs-params">transaction: TypedRpcTransaction</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1667" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1701" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -3097,7 +3097,7 @@ that the <code>v</code> parameter includes the chain id as specified in <a href=
           arguments
         </div>
         <ul>
-          <li><code class="language-typescript"><span class="hljs-function"><span class="hljs-params">transaction: RpcTransaction</span></span>
+          <li><code class="language-typescript"><span class="hljs-function"><span class="hljs-params">transaction: TypedRpcTransaction</span></span>
 </code>
 : The transaction call object as seen in source.</li>
         </ul>
@@ -3140,7 +3140,7 @@ that the <code>v</code> parameter includes the chain id as specified in <a href=
       <span class="hljs-function"> <span class="hljs-title">eth_signTypedData</span>(<span class="hljs-params">address: DATA, typedData: TypedData</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1809" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1841" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -3253,7 +3253,7 @@ that the <code>v</code> parameter includes the chain id as specified in <a href=
       <span class="hljs-function"> <span class="hljs-title">eth_submitHashrate</span>(<span class="hljs-params">hashRate: DATA, clientID: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1250" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1271" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -3315,7 +3315,7 @@ that the <code>v</code> parameter includes the chain id as specified in <a href=
       <span class="hljs-function"> <span class="hljs-title">eth_submitWork</span>(<span class="hljs-params">nonce: DATA, powHash: DATA, digest: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1231" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1252" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -3380,7 +3380,7 @@ that the <code>v</code> parameter includes the chain id as specified in <a href=
       <span class="hljs-function"> <span class="hljs-title">eth_subscribe</span>(<span class="hljs-params">subscriptionName: SubscriptionName</span>): <span class="hljs-title">PromiEvent</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1853" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1885" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -3440,7 +3440,7 @@ subscription ID will be sent to a client.</p>
       <span class="hljs-function"> <span class="hljs-title">eth_syncing</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L806" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L817" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -3493,7 +3493,7 @@ subscription ID will be sent to a client.</p>
       <span class="hljs-function"> <span class="hljs-title">eth_uninstallFilter</span>(<span class="hljs-params">filterId: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2208" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2243" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -3554,7 +3554,7 @@ no longer needed.</p>
       <span class="hljs-function"> <span class="hljs-title">eth_unsubscribe</span>(<span class="hljs-params">subscriptionId: SubscriptionId</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L1994" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2029" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -3614,7 +3614,7 @@ if the subscription was successfully cancelled.</p>
       <span class="hljs-function"> <span class="hljs-title">evm_increaseTime</span>(<span class="hljs-params">seconds: <span class="hljs-built_in">number</span> | QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">number</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L344" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L353" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -3673,7 +3673,7 @@ if the subscription was successfully cancelled.</p>
       <span class="hljs-function"> <span class="hljs-title">evm_lockUnknownAccount</span>(<span class="hljs-params">address: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L511" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L520" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -3736,7 +3736,7 @@ locked.</p>
       <span class="hljs-function"> <span class="hljs-title">evm_mine</span>(<span class="hljs-params">timestamp: <span class="hljs-built_in">number</span></span>): <span class="hljs-title">Promise</span>&lt;&quot;0<span class="hljs-title">x0</span>&quot;&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L257" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L258" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -3802,7 +3802,7 @@ operation. This behavior is subject to change!
       <span class="hljs-function"> <span class="hljs-title">evm_revert</span>(<span class="hljs-params">snapshotId: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L426" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L435" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -3886,7 +3886,7 @@ assert(isReverted);
       <span class="hljs-function"> <span class="hljs-title">evm_setAccountNonce</span>(<span class="hljs-params">address: DATA, nonce: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L312" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L321" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -3950,7 +3950,7 @@ before returning.</p>
       <span class="hljs-function"> <span class="hljs-title">evm_setTime</span>(<span class="hljs-params">time: <span class="hljs-built_in">number</span> | QUANTITY | <span class="hljs-built_in">Date</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">number</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L371" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L380" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4014,7 +4014,7 @@ an invalid state.</p>
       <span class="hljs-function"> <span class="hljs-title">evm_snapshot</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L467" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L476" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4087,7 +4087,7 @@ assert(isReverted);
       <span class="hljs-function"> <span class="hljs-title">evm_unlockUnknownAccount</span>(<span class="hljs-params">address: DATA, duration: <span class="hljs-built_in">number</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L490" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L499" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4153,7 +4153,7 @@ unlocked.</p>
       <span class="hljs-function"> <span class="hljs-title">miner_setEtherbase</span>(<span class="hljs-params">address: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L598" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L607" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4211,7 +4211,7 @@ unlocked.</p>
       <span class="hljs-function"> <span class="hljs-title">miner_setExtra</span>(<span class="hljs-params">extra: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L613" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L622" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4268,7 +4268,7 @@ unlocked.</p>
       <span class="hljs-function"> <span class="hljs-title">miner_setGasPrice</span>(<span class="hljs-params"><span class="hljs-built_in">number</span>: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L582" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L591" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4327,7 +4327,7 @@ Transactions that are below this limit are excluded from the mining process.</p>
       <span class="hljs-function"> <span class="hljs-title">miner_start</span>(<span class="hljs-params">threads: <span class="hljs-built_in">number</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L540" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L549" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4390,7 +4390,7 @@ Transactions that are below this limit are excluded from the mining process.</p>
       <span class="hljs-function"> <span class="hljs-title">miner_stop</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L565" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L574" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4440,7 +4440,7 @@ Transactions that are below this limit are excluded from the mining process.</p>
       <span class="hljs-function"> <span class="hljs-title">net_listening</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L679" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L688" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4486,7 +4486,7 @@ Transactions that are below this limit are excluded from the mining process.</p>
       <span class="hljs-function"> <span class="hljs-title">net_peerCount</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">QUANTITY</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L692" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L701" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4532,7 +4532,7 @@ Transactions that are below this limit are excluded from the mining process.</p>
       <span class="hljs-function"> <span class="hljs-title">net_version</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L666" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L675" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4579,7 +4579,7 @@ Quantity/Data encoded.</p>
       <span class="hljs-function"> <span class="hljs-title">personal_importRawKey</span>(<span class="hljs-params">rawKey: DATA, passphrase: <span class="hljs-built_in">string</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">Address</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2621" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2658" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4642,7 +4642,7 @@ Quantity/Data encoded.</p>
       <span class="hljs-function"> <span class="hljs-title">personal_listAccounts</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>[]&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2568" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2605" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4689,7 +4689,7 @@ added.</p>
       <span class="hljs-function"> <span class="hljs-title">personal_lockAccount</span>(<span class="hljs-params">address: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2652" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2689" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4748,7 +4748,7 @@ added.</p>
       <span class="hljs-function"> <span class="hljs-title">personal_newAccount</span>(<span class="hljs-params">passphrase: <span class="hljs-built_in">string</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">Address</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2586" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2623" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4808,7 +4808,7 @@ account.</p>
       <span class="hljs-function"> <span class="hljs-title">personal_sendTransaction</span>(<span class="hljs-params">transaction: <span class="hljs-built_in">any</span>, passphrase: <span class="hljs-built_in">string</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">DATA</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2725" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2762" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4884,10 +4884,10 @@ and cannot be used in other RPC calls.</p>
   <div>
     <a name="personal_signTransaction"></a>
     <h3 class="signature">
-      <span class="hljs-function"> <span class="hljs-title">personal_signTransaction</span>(<span class="hljs-params">transaction: RpcTransaction, passphrase: <span class="hljs-built_in">string</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>&gt;</span>
+      <span class="hljs-function"> <span class="hljs-title">personal_signTransaction</span>(<span class="hljs-params">transaction: TypedRpcTransaction, passphrase: <span class="hljs-built_in">string</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2778" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2815" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -4917,7 +4917,7 @@ The account is not unlocked globally in the node and cannot be used in other RPC
           arguments
         </div>
         <ul>
-          <li><code class="language-typescript"><span class="hljs-function"><span class="hljs-params">transaction: RpcTransaction</span></span>
+          <li><code class="language-typescript"><span class="hljs-function"><span class="hljs-params">transaction: TypedRpcTransaction</span></span>
 </code>
 : The transaction call object as seen in source.</li><li><code class="language-typescript"><span class="hljs-function"><span class="hljs-params">passphrase: <span class="hljs-built_in">string</span></span></span>
 </code>
@@ -4965,7 +4965,7 @@ The account is not unlocked globally in the node and cannot be used in other RPC
       <span class="hljs-function"> <span class="hljs-title">personal_unlockAccount</span>(<span class="hljs-params">address: DATA, passphrase: <span class="hljs-built_in">string</span>, duration: <span class="hljs-built_in">number</span></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2681" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2718" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -5036,7 +5036,7 @@ should remain unlocked for. Set to 0 to disable automatic locking.</li>
       <span class="hljs-function"> <span class="hljs-title">rpc_modules</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">object</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2812" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2849" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -5082,7 +5082,7 @@ should remain unlocked for. Set to 0 to disable automatic locking.</li>
       <span class="hljs-function"> <span class="hljs-title">shh_addToGroup</span>(<span class="hljs-params">address: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2869" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2906" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -5139,7 +5139,7 @@ should remain unlocked for. Set to 0 to disable automatic locking.</li>
       <span class="hljs-function"> <span class="hljs-title">shh_getFilterChanges</span>(<span class="hljs-params">id: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">any</span>[]&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2917" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2954" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -5196,7 +5196,7 @@ should remain unlocked for. Set to 0 to disable automatic locking.</li>
       <span class="hljs-function"> <span class="hljs-title">shh_getMessages</span>(<span class="hljs-params">id: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2932" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2969" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -5253,7 +5253,7 @@ should remain unlocked for. Set to 0 to disable automatic locking.</li>
       <span class="hljs-function"> <span class="hljs-title">shh_hasIdentity</span>(<span class="hljs-params">address: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2844" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2881" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -5310,7 +5310,7 @@ should remain unlocked for. Set to 0 to disable automatic locking.</li>
       <span class="hljs-function"> <span class="hljs-title">shh_newFilter</span>(<span class="hljs-params">to: DATA, topics: DATA[]</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2886" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2923" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -5370,7 +5370,7 @@ should remain unlocked for. Set to 0 to disable automatic locking.</li>
       <span class="hljs-function"> <span class="hljs-title">shh_newGroup</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2854" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2891" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -5405,7 +5405,7 @@ should remain unlocked for. Set to 0 to disable automatic locking.</li>
       <span class="hljs-function"> <span class="hljs-title">shh_newIdentity</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2829" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2866" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -5451,7 +5451,7 @@ should remain unlocked for. Set to 0 to disable automatic locking.</li>
       <span class="hljs-function"> <span class="hljs-title">shh_post</span>(<span class="hljs-params">postData: WhisperPostObject</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2947" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2984" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -5508,7 +5508,7 @@ should remain unlocked for. Set to 0 to disable automatic locking.</li>
       <span class="hljs-function"> <span class="hljs-title">shh_uninstallFilter</span>(<span class="hljs-params">id: QUANTITY</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">boolean</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2902" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2939" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -5566,7 +5566,7 @@ Additionally filters timeout when they aren&#39;t requested with <code>shh_getFi
       <span class="hljs-function"> <span class="hljs-title">shh_version</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2961" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L2998" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -5612,7 +5612,7 @@ Additionally filters timeout when they aren&#39;t requested with <code>shh_getFi
       <span class="hljs-function"> <span class="hljs-title">web3_clientVersion</span>(<span class="hljs-params"></span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">string</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L634" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L643" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       
@@ -5658,7 +5658,7 @@ Additionally filters timeout when they aren&#39;t requested with <code>shh_getFi
       <span class="hljs-function"> <span class="hljs-title">web3_sha3</span>(<span class="hljs-params">data: DATA</span>): <span class="hljs-title">Promise</span>&lt;<span class="hljs-title">DATA</span>&gt;</span>
     </h3>
     <div class="content small">
-      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L650" target="_blank" rel="noopener">source</a>
+      <a href="https://github.com/trufflesuite/ganache/blob/next/src/chains/ethereum/ethereum/src/api.ts#L659" target="_blank" rel="noopener">source</a>
     </div>
     <div class="content">
       

--- a/docs/typedoc/api.json
+++ b/docs/typedoc/api.json
@@ -12,7 +12,7 @@
 			"flags": {
 				"isExported": true
 			},
-			"originalName": "/home/runner/work/ganache/ganache/src/chains/ethereum/ethereum/src/api.ts",
+			"originalName": "/home/david/work/ganache-core/src/chains/ethereum/ethereum/src/api.ts",
 			"children": [
 				{
 					"id": 2,
@@ -96,7 +96,7 @@
 									"sources": [
 										{
 											"fileName": "chains/ethereum/ethereum/src/api.ts",
-											"line": 112,
+											"line": 113,
 											"character": 27
 										}
 									]
@@ -181,7 +181,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 119,
+									"line": 120,
 									"character": 27
 								}
 							]
@@ -199,7 +199,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 118,
+									"line": 119,
 									"character": 22
 								}
 							],
@@ -221,7 +221,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 115,
+									"line": 116,
 									"character": 19
 								}
 							],
@@ -359,7 +359,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 114,
+									"line": 115,
 									"character": 17
 								}
 							],
@@ -382,7 +382,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 117,
+									"line": 118,
 									"character": 19
 								}
 							],
@@ -404,7 +404,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 116,
+									"line": 117,
 									"character": 25
 								}
 							],
@@ -460,7 +460,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 119,
+									"line": 120,
 									"character": 18
 								}
 							],
@@ -526,7 +526,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 217,
+									"line": 218,
 									"character": 16
 								}
 							]
@@ -588,7 +588,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 230,
+									"line": 231,
 									"character": 16
 								}
 							]
@@ -681,7 +681,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 202,
+									"line": 203,
 									"character": 17
 								}
 							]
@@ -774,7 +774,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 169,
+									"line": 170,
 									"character": 20
 								}
 							]
@@ -883,7 +883,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 186,
+									"line": 187,
 									"character": 17
 								}
 							]
@@ -992,13 +992,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 153,
+									"line": 154,
 									"character": 20
 								}
 							]
 						},
 						{
-							"id": 309,
+							"id": 623,
 							"name": "debug_storageRangeAt",
 							"kind": 2048,
 							"kindString": "Method",
@@ -1007,7 +1007,7 @@
 							},
 							"signatures": [
 								{
-									"id": 310,
+									"id": 624,
 									"name": "debug_storageRangeAt",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -1026,7 +1026,7 @@
 									},
 									"parameters": [
 										{
-											"id": 311,
+											"id": 625,
 											"name": "blockHash",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1042,7 +1042,7 @@
 											}
 										},
 										{
-											"id": 312,
+											"id": 626,
 											"name": "transactionIndex",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1058,7 +1058,7 @@
 											}
 										},
 										{
-											"id": 313,
+											"id": 627,
 											"name": "contractAddress",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1074,7 +1074,7 @@
 											}
 										},
 										{
-											"id": 314,
+											"id": 628,
 											"name": "startKey",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1090,7 +1090,7 @@
 											}
 										},
 										{
-											"id": 315,
+											"id": 629,
 											"name": "maxResult",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1121,13 +1121,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2539,
+									"line": 2576,
 									"character": 28
 								}
 							]
 						},
 						{
-							"id": 305,
+							"id": 619,
 							"name": "debug_traceTransaction",
 							"kind": 2048,
 							"kindString": "Method",
@@ -1136,7 +1136,7 @@
 							},
 							"signatures": [
 								{
-									"id": 306,
+									"id": 620,
 									"name": "debug_traceTransaction",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -1156,7 +1156,7 @@
 									},
 									"parameters": [
 										{
-											"id": 307,
+											"id": 621,
 											"name": "transactionHash",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1172,7 +1172,7 @@
 											}
 										},
 										{
-											"id": 308,
+											"id": 622,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1204,13 +1204,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2489,
+									"line": 2526,
 									"character": 30
 								}
 							]
 						},
 						{
-							"id": 169,
+							"id": 505,
 							"name": "eth_accounts",
 							"kind": 2048,
 							"kindString": "Method",
@@ -1231,7 +1231,7 @@
 							],
 							"signatures": [
 								{
-									"id": 170,
+									"id": 506,
 									"name": "eth_accounts",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -1266,13 +1266,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1307,
+									"line": 1328,
 									"character": 20
 								}
 							]
 						},
 						{
-							"id": 171,
+							"id": 507,
 							"name": "eth_blockNumber",
 							"kind": 2048,
 							"kindString": "Method",
@@ -1293,7 +1293,7 @@
 							],
 							"signatures": [
 								{
-									"id": 172,
+									"id": 508,
 									"name": "eth_blockNumber",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -1325,13 +1325,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1321,
+									"line": 1342,
 									"character": 23
 								}
 							]
 						},
 						{
-							"id": 301,
+							"id": 615,
 							"name": "eth_call",
 							"kind": 2048,
 							"kindString": "Method",
@@ -1353,7 +1353,7 @@
 							],
 							"signatures": [
 								{
-									"id": 302,
+									"id": 616,
 									"name": "eth_call",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -1373,7 +1373,7 @@
 									},
 									"parameters": [
 										{
-											"id": 303,
+											"id": 617,
 											"name": "transaction",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1389,7 +1389,7 @@
 											}
 										},
 										{
-											"id": 304,
+											"id": 618,
 											"name": "blockNumber",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1430,13 +1430,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2378,
+									"line": 2413,
 									"character": 16
 								}
 							]
 						},
 						{
-							"id": 173,
+							"id": 509,
 							"name": "eth_chainId",
 							"kind": 2048,
 							"kindString": "Method",
@@ -1457,7 +1457,7 @@
 							],
 							"signatures": [
 								{
-									"id": 174,
+									"id": 510,
 									"name": "eth_chainId",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -1493,7 +1493,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1338,
+									"line": 1359,
 									"character": 19
 								}
 							]
@@ -1552,7 +1552,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 820,
+									"line": 831,
 									"character": 20
 								}
 							]
@@ -1657,13 +1657,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 729,
+									"line": 738,
 									"character": 23
 								}
 							]
 						},
 						{
-							"id": 167,
+							"id": 503,
 							"name": "eth_gasPrice",
 							"kind": 2048,
 							"kindString": "Method",
@@ -1684,7 +1684,7 @@
 							],
 							"signatures": [
 								{
-									"id": 168,
+									"id": 504,
 									"name": "eth_gasPrice",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -1716,13 +1716,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1293,
+									"line": 1314,
 									"character": 20
 								}
 							]
 						},
 						{
-							"id": 175,
+							"id": 511,
 							"name": "eth_getBalance",
 							"kind": 2048,
 							"kindString": "Method",
@@ -1744,7 +1744,7 @@
 							],
 							"signatures": [
 								{
-									"id": 176,
+									"id": 512,
 									"name": "eth_getBalance",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -1763,7 +1763,7 @@
 									},
 									"parameters": [
 										{
-											"id": 177,
+											"id": 513,
 											"name": "address",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1779,7 +1779,7 @@
 											}
 										},
 										{
-											"id": 178,
+											"id": 514,
 											"name": "blockNumber",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1820,13 +1820,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1358,
+									"line": 1379,
 									"character": 22
 								}
 							]
 						},
 						{
-							"id": 117,
+							"id": 193,
 							"name": "eth_getBlockByHash",
 							"kind": 2048,
 							"kindString": "Method",
@@ -1848,7 +1848,7 @@
 							],
 							"signatures": [
 								{
-									"id": 118,
+									"id": 194,
 									"name": "eth_getBlockByHash",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -1867,7 +1867,7 @@
 									},
 									"parameters": [
 										{
-											"id": 119,
+											"id": 195,
 											"name": "hash",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1883,7 +1883,7 @@
 											}
 										},
 										{
-											"id": 120,
+											"id": 196,
 											"name": "transactions",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -1904,8 +1904,1617 @@
 										"type": "reference",
 										"typeArguments": [
 											{
-												"type": "intrinsic",
-												"name": "any"
+												"type": "reflection",
+												"declaration": {
+													"id": 197,
+													"name": "__type",
+													"kind": 65536,
+													"kindString": "Type literal",
+													"flags": {
+														"isExported": true
+													},
+													"children": [
+														{
+															"id": 271,
+															"name": "baseFeePerGas",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true,
+																"isOptional": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 42,
+																	"character": 21
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 262,
+															"name": "difficulty",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 33,
+																	"character": 18
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 268,
+															"name": "extraData",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 39,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 265,
+															"name": "gasLimit",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 36,
+																	"character": 16
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 266,
+															"name": "gasUsed",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 37,
+																	"character": 15
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 272,
+															"name": "hash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 43,
+																	"character": 12
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 261,
+															"name": "logsBloom",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 32,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 257,
+															"name": "miner",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 28,
+																	"character": 13
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 269,
+															"name": "mixHash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 40,
+																	"character": 15
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 270,
+															"name": "nonce",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 41,
+																	"character": 13
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 264,
+															"name": "number",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 35,
+																	"character": 14
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 255,
+															"name": "parentHash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 26,
+																	"character": 18
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 260,
+															"name": "receiptsRoot",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 31,
+																	"character": 20
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 256,
+															"name": "sha3Uncles",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 27,
+																	"character": 18
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 198,
+															"name": "size",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 23,
+																	"character": 12
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 258,
+															"name": "stateRoot",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 29,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 267,
+															"name": "timestamp",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 38,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 263,
+															"name": "totalDifficulty",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 34,
+																	"character": 23
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 199,
+															"name": "transactions",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 24,
+																	"character": 20
+																}
+															],
+															"type": {
+																"type": "array",
+																"elementType": {
+																	"type": "union",
+																	"types": [
+																		{
+																			"type": "reference",
+																			"name": "Data"
+																		},
+																		{
+																			"type": "reflection",
+																			"declaration": {
+																				"id": 200,
+																				"name": "__type",
+																				"kind": 65536,
+																				"kindString": "Type literal",
+																				"flags": {
+																					"isExported": true
+																				},
+																				"children": [
+																					{
+																						"id": 204,
+																						"name": "blockHash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 15,
+																								"character": 13
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 205,
+																						"name": "blockNumber",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 16,
+																								"character": 15
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 207,
+																						"name": "from",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 18,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 210,
+																						"name": "gas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 21,
+																								"character": 7
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 211,
+																						"name": "gasPrice",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 22,
+																								"character": 12
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 201,
+																						"name": "hash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 12,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 212,
+																						"name": "input",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 23,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 203,
+																						"name": "nonce",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 14,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 214,
+																						"name": "r",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 25,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 215,
+																						"name": "s",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 26,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 208,
+																						"name": "to",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 19,
+																								"character": 6
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Address"
+																						}
+																					},
+																					{
+																						"id": 206,
+																						"name": "transactionIndex",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 17,
+																								"character": 20
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 202,
+																						"name": "type",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true,
+																							"isOptional": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 13,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 213,
+																						"name": "v",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 24,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 209,
+																						"name": "value",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 20,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					}
+																				],
+																				"groups": [
+																					{
+																						"title": "Variables",
+																						"kind": 32,
+																						"children": [
+																							204,
+																							205,
+																							207,
+																							210,
+																							211,
+																							201,
+																							212,
+																							203,
+																							214,
+																							215,
+																							208,
+																							206,
+																							202,
+																							213,
+																							209
+																						]
+																					}
+																				]
+																			}
+																		},
+																		{
+																			"type": "reflection",
+																			"declaration": {
+																				"id": 216,
+																				"name": "__type",
+																				"kind": 65536,
+																				"kindString": "Type literal",
+																				"flags": {
+																					"isExported": true
+																				},
+																				"children": [
+																					{
+																						"id": 230,
+																						"name": "accessList",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 42,
+																								"character": 14
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "AccessList"
+																						}
+																					},
+																					{
+																						"id": 221,
+																						"name": "blockHash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 33,
+																								"character": 13
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 222,
+																						"name": "blockNumber",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 34,
+																								"character": 15
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 219,
+																						"name": "chainId",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 31,
+																								"character": 11
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 224,
+																						"name": "from",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 36,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 227,
+																						"name": "gas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 39,
+																								"character": 7
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 228,
+																						"name": "gasPrice",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 40,
+																								"character": 12
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 217,
+																						"name": "hash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 29,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 229,
+																						"name": "input",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 41,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 220,
+																						"name": "nonce",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 32,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 232,
+																						"name": "r",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 44,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 233,
+																						"name": "s",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 45,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 225,
+																						"name": "to",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 37,
+																								"character": 6
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Address"
+																						}
+																					},
+																					{
+																						"id": 223,
+																						"name": "transactionIndex",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 35,
+																								"character": 20
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 218,
+																						"name": "type",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 30,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 231,
+																						"name": "v",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 43,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 226,
+																						"name": "value",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 38,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					}
+																				],
+																				"groups": [
+																					{
+																						"title": "Variables",
+																						"kind": 32,
+																						"children": [
+																							230,
+																							221,
+																							222,
+																							219,
+																							224,
+																							227,
+																							228,
+																							217,
+																							229,
+																							220,
+																							232,
+																							233,
+																							225,
+																							223,
+																							218,
+																							231,
+																							226
+																						]
+																					}
+																				]
+																			}
+																		},
+																		{
+																			"type": "reflection",
+																			"declaration": {
+																				"id": 234,
+																				"name": "__type",
+																				"kind": 65536,
+																				"kindString": "Type literal",
+																				"flags": {
+																					"isExported": true
+																				},
+																				"children": [
+																					{
+																						"id": 250,
+																						"name": "accessList",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 63,
+																								"character": 14
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "AccessList"
+																						}
+																					},
+																					{
+																						"id": 239,
+																						"name": "blockHash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 52,
+																								"character": 13
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 240,
+																						"name": "blockNumber",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 53,
+																								"character": 15
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 237,
+																						"name": "chainId",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 50,
+																								"character": 11
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 242,
+																						"name": "from",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 55,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 248,
+																						"name": "gas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 61,
+																								"character": 7
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 247,
+																						"name": "gasPrice",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 60,
+																								"character": 12
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 235,
+																						"name": "hash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 48,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 249,
+																						"name": "input",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 62,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 246,
+																						"name": "maxFeePerGas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 59,
+																								"character": 16
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 245,
+																						"name": "maxPriorityFeePerGas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 58,
+																								"character": 24
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 238,
+																						"name": "nonce",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 51,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 252,
+																						"name": "r",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 65,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 253,
+																						"name": "s",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 66,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 243,
+																						"name": "to",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 56,
+																								"character": 6
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Address"
+																						}
+																					},
+																					{
+																						"id": 241,
+																						"name": "transactionIndex",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 54,
+																								"character": 20
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 236,
+																						"name": "type",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 49,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 251,
+																						"name": "v",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 64,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 244,
+																						"name": "value",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 57,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					}
+																				],
+																				"groups": [
+																					{
+																						"title": "Variables",
+																						"kind": 32,
+																						"children": [
+																							250,
+																							239,
+																							240,
+																							237,
+																							242,
+																							248,
+																							247,
+																							235,
+																							249,
+																							246,
+																							245,
+																							238,
+																							252,
+																							253,
+																							243,
+																							241,
+																							236,
+																							251,
+																							244
+																						]
+																					}
+																				]
+																			}
+																		}
+																	]
+																}
+															}
+														},
+														{
+															"id": 259,
+															"name": "transactionsRoot",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 30,
+																	"character": 24
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 254,
+															"name": "uncles",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 25,
+																	"character": 14
+																}
+															],
+															"type": {
+																"type": "array",
+																"elementType": {
+																	"type": "intrinsic",
+																	"name": "string"
+																}
+															}
+														}
+													],
+													"groups": [
+														{
+															"title": "Variables",
+															"kind": 32,
+															"children": [
+																271,
+																262,
+																268,
+																265,
+																266,
+																272,
+																261,
+																257,
+																269,
+																270,
+																264,
+																255,
+																260,
+																256,
+																198,
+																258,
+																267,
+																263,
+																199,
+																259,
+																254
+															]
+														}
+													]
+												}
 											}
 										],
 										"name": "Promise"
@@ -1915,7 +3524,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 916,
+									"line": 929,
 									"character": 26
 								}
 							]
@@ -2008,8 +3617,1617 @@
 										"type": "reference",
 										"typeArguments": [
 											{
-												"type": "intrinsic",
-												"name": "any"
+												"type": "reflection",
+												"declaration": {
+													"id": 117,
+													"name": "__type",
+													"kind": 65536,
+													"kindString": "Type literal",
+													"flags": {
+														"isExported": true
+													},
+													"children": [
+														{
+															"id": 191,
+															"name": "baseFeePerGas",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true,
+																"isOptional": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 42,
+																	"character": 21
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 182,
+															"name": "difficulty",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 33,
+																	"character": 18
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 188,
+															"name": "extraData",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 39,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 185,
+															"name": "gasLimit",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 36,
+																	"character": 16
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 186,
+															"name": "gasUsed",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 37,
+																	"character": 15
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 192,
+															"name": "hash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 43,
+																	"character": 12
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 181,
+															"name": "logsBloom",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 32,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 177,
+															"name": "miner",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 28,
+																	"character": 13
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 189,
+															"name": "mixHash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 40,
+																	"character": 15
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 190,
+															"name": "nonce",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 41,
+																	"character": 13
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 184,
+															"name": "number",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 35,
+																	"character": 14
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 175,
+															"name": "parentHash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 26,
+																	"character": 18
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 180,
+															"name": "receiptsRoot",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 31,
+																	"character": 20
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 176,
+															"name": "sha3Uncles",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 27,
+																	"character": 18
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 118,
+															"name": "size",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 23,
+																	"character": 12
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 178,
+															"name": "stateRoot",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 29,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 187,
+															"name": "timestamp",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 38,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 183,
+															"name": "totalDifficulty",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 34,
+																	"character": 23
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 119,
+															"name": "transactions",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 24,
+																	"character": 20
+																}
+															],
+															"type": {
+																"type": "array",
+																"elementType": {
+																	"type": "union",
+																	"types": [
+																		{
+																			"type": "reference",
+																			"name": "Data"
+																		},
+																		{
+																			"type": "reflection",
+																			"declaration": {
+																				"id": 120,
+																				"name": "__type",
+																				"kind": 65536,
+																				"kindString": "Type literal",
+																				"flags": {
+																					"isExported": true
+																				},
+																				"children": [
+																					{
+																						"id": 124,
+																						"name": "blockHash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 15,
+																								"character": 13
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 125,
+																						"name": "blockNumber",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 16,
+																								"character": 15
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 127,
+																						"name": "from",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 18,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 130,
+																						"name": "gas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 21,
+																								"character": 7
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 131,
+																						"name": "gasPrice",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 22,
+																								"character": 12
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 121,
+																						"name": "hash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 12,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 132,
+																						"name": "input",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 23,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 123,
+																						"name": "nonce",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 14,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 134,
+																						"name": "r",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 25,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 135,
+																						"name": "s",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 26,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 128,
+																						"name": "to",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 19,
+																								"character": 6
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Address"
+																						}
+																					},
+																					{
+																						"id": 126,
+																						"name": "transactionIndex",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 17,
+																								"character": 20
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 122,
+																						"name": "type",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true,
+																							"isOptional": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 13,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 133,
+																						"name": "v",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 24,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 129,
+																						"name": "value",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 20,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					}
+																				],
+																				"groups": [
+																					{
+																						"title": "Variables",
+																						"kind": 32,
+																						"children": [
+																							124,
+																							125,
+																							127,
+																							130,
+																							131,
+																							121,
+																							132,
+																							123,
+																							134,
+																							135,
+																							128,
+																							126,
+																							122,
+																							133,
+																							129
+																						]
+																					}
+																				]
+																			}
+																		},
+																		{
+																			"type": "reflection",
+																			"declaration": {
+																				"id": 136,
+																				"name": "__type",
+																				"kind": 65536,
+																				"kindString": "Type literal",
+																				"flags": {
+																					"isExported": true
+																				},
+																				"children": [
+																					{
+																						"id": 150,
+																						"name": "accessList",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 42,
+																								"character": 14
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "AccessList"
+																						}
+																					},
+																					{
+																						"id": 141,
+																						"name": "blockHash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 33,
+																								"character": 13
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 142,
+																						"name": "blockNumber",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 34,
+																								"character": 15
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 139,
+																						"name": "chainId",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 31,
+																								"character": 11
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 144,
+																						"name": "from",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 36,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 147,
+																						"name": "gas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 39,
+																								"character": 7
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 148,
+																						"name": "gasPrice",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 40,
+																								"character": 12
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 137,
+																						"name": "hash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 29,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 149,
+																						"name": "input",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 41,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 140,
+																						"name": "nonce",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 32,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 152,
+																						"name": "r",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 44,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 153,
+																						"name": "s",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 45,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 145,
+																						"name": "to",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 37,
+																								"character": 6
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Address"
+																						}
+																					},
+																					{
+																						"id": 143,
+																						"name": "transactionIndex",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 35,
+																								"character": 20
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 138,
+																						"name": "type",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 30,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 151,
+																						"name": "v",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 43,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 146,
+																						"name": "value",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 38,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					}
+																				],
+																				"groups": [
+																					{
+																						"title": "Variables",
+																						"kind": 32,
+																						"children": [
+																							150,
+																							141,
+																							142,
+																							139,
+																							144,
+																							147,
+																							148,
+																							137,
+																							149,
+																							140,
+																							152,
+																							153,
+																							145,
+																							143,
+																							138,
+																							151,
+																							146
+																						]
+																					}
+																				]
+																			}
+																		},
+																		{
+																			"type": "reflection",
+																			"declaration": {
+																				"id": 154,
+																				"name": "__type",
+																				"kind": 65536,
+																				"kindString": "Type literal",
+																				"flags": {
+																					"isExported": true
+																				},
+																				"children": [
+																					{
+																						"id": 170,
+																						"name": "accessList",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 63,
+																								"character": 14
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "AccessList"
+																						}
+																					},
+																					{
+																						"id": 159,
+																						"name": "blockHash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 52,
+																								"character": 13
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 160,
+																						"name": "blockNumber",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 53,
+																								"character": 15
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 157,
+																						"name": "chainId",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 50,
+																								"character": 11
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 162,
+																						"name": "from",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 55,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 168,
+																						"name": "gas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 61,
+																								"character": 7
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 167,
+																						"name": "gasPrice",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 60,
+																								"character": 12
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 155,
+																						"name": "hash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 48,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 169,
+																						"name": "input",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 62,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 166,
+																						"name": "maxFeePerGas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 59,
+																								"character": 16
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 165,
+																						"name": "maxPriorityFeePerGas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 58,
+																								"character": 24
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 158,
+																						"name": "nonce",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 51,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 172,
+																						"name": "r",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 65,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 173,
+																						"name": "s",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 66,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 163,
+																						"name": "to",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 56,
+																								"character": 6
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Address"
+																						}
+																					},
+																					{
+																						"id": 161,
+																						"name": "transactionIndex",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 54,
+																								"character": 20
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 156,
+																						"name": "type",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 49,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 171,
+																						"name": "v",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 64,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 164,
+																						"name": "value",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 57,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					}
+																				],
+																				"groups": [
+																					{
+																						"title": "Variables",
+																						"kind": 32,
+																						"children": [
+																							170,
+																							159,
+																							160,
+																							157,
+																							162,
+																							168,
+																							167,
+																							155,
+																							169,
+																							166,
+																							165,
+																							158,
+																							172,
+																							173,
+																							163,
+																							161,
+																							156,
+																							171,
+																							164
+																						]
+																					}
+																				]
+																			}
+																		}
+																	]
+																}
+															}
+														},
+														{
+															"id": 179,
+															"name": "transactionsRoot",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 30,
+																	"character": 24
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 174,
+															"name": "uncles",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 25,
+																	"character": 14
+																}
+															],
+															"type": {
+																"type": "array",
+																"elementType": {
+																	"type": "intrinsic",
+																	"name": "string"
+																}
+															}
+														}
+													],
+													"groups": [
+														{
+															"title": "Variables",
+															"kind": 32,
+															"children": [
+																191,
+																182,
+																188,
+																185,
+																186,
+																192,
+																181,
+																177,
+																189,
+																190,
+																184,
+																175,
+																180,
+																176,
+																118,
+																178,
+																187,
+																183,
+																119,
+																179,
+																174
+															]
+														}
+													]
+												}
 											}
 										],
 										"name": "Promise"
@@ -2019,13 +5237,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 860,
+									"line": 871,
 									"character": 28
 								}
 							]
 						},
 						{
-							"id": 124,
+							"id": 276,
 							"name": "eth_getBlockTransactionCountByHash",
 							"kind": 2048,
 							"kindString": "Method",
@@ -2046,7 +5264,7 @@
 							],
 							"signatures": [
 								{
-									"id": 125,
+									"id": 277,
 									"name": "eth_getBlockTransactionCountByHash",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -2065,7 +5283,7 @@
 									},
 									"parameters": [
 										{
-											"id": 126,
+											"id": 278,
 											"name": "hash",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -2096,13 +5314,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 972,
+									"line": 985,
 									"character": 42
 								}
 							]
 						},
 						{
-							"id": 121,
+							"id": 273,
 							"name": "eth_getBlockTransactionCountByNumber",
 							"kind": 2048,
 							"kindString": "Method",
@@ -2123,7 +5341,7 @@
 							],
 							"signatures": [
 								{
-									"id": 122,
+									"id": 274,
 									"name": "eth_getBlockTransactionCountByNumber",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -2142,7 +5360,7 @@
 									},
 									"parameters": [
 										{
-											"id": 123,
+											"id": 275,
 											"name": "blockNumber",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -2179,13 +5397,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 935,
+									"line": 948,
 									"character": 44
 								}
 							]
 						},
 						{
-							"id": 179,
+							"id": 515,
 							"name": "eth_getCode",
 							"kind": 2048,
 							"kindString": "Method",
@@ -2207,7 +5425,7 @@
 							],
 							"signatures": [
 								{
-									"id": 180,
+									"id": 516,
 									"name": "eth_getCode",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -2226,7 +5444,7 @@
 									},
 									"parameters": [
 										{
-											"id": 181,
+											"id": 517,
 											"name": "address",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -2242,7 +5460,7 @@
 											}
 										},
 										{
-											"id": 182,
+											"id": 518,
 											"name": "blockNumber",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -2283,13 +5501,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1397,
+									"line": 1418,
 									"character": 19
 								}
 							]
 						},
 						{
-							"id": 127,
+							"id": 279,
 							"name": "eth_getCompilers",
 							"kind": 2048,
 							"kindString": "Method",
@@ -2310,7 +5528,7 @@
 							],
 							"signatures": [
 								{
-									"id": 128,
+									"id": 280,
 									"name": "eth_getCompilers",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -2345,13 +5563,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 994,
+									"line": 1007,
 									"character": 24
 								}
 							]
 						},
 						{
-							"id": 265,
+							"id": 579,
 							"name": "eth_getFilterChanges",
 							"kind": 2048,
 							"kindString": "Method",
@@ -2372,7 +5590,7 @@
 							],
 							"signatures": [
 								{
-									"id": 266,
+									"id": 580,
 									"name": "eth_getFilterChanges",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -2391,7 +5609,7 @@
 									},
 									"parameters": [
 										{
-											"id": 267,
+											"id": 581,
 											"name": "filterId",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -2425,13 +5643,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2182,
+									"line": 2217,
 									"character": 28
 								}
 							]
 						},
 						{
-							"id": 271,
+							"id": 585,
 							"name": "eth_getFilterLogs",
 							"kind": 2048,
 							"kindString": "Method",
@@ -2452,7 +5670,7 @@
 							],
 							"signatures": [
 								{
-									"id": 272,
+									"id": 586,
 									"name": "eth_getFilterLogs",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -2471,7 +5689,7 @@
 									},
 									"parameters": [
 										{
-											"id": 273,
+											"id": 587,
 											"name": "filterId",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -2495,7 +5713,7 @@
 												"elementType": {
 													"type": "reflection",
 													"declaration": {
-														"id": 274,
+														"id": 588,
 														"name": "__type",
 														"kind": 65536,
 														"kindString": "Type literal",
@@ -2504,7 +5722,7 @@
 														},
 														"children": [
 															{
-																"id": 275,
+																"id": 589,
 																"name": "address",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2524,7 +5742,7 @@
 																}
 															},
 															{
-																"id": 276,
+																"id": 590,
 																"name": "blockHash",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2544,7 +5762,7 @@
 																}
 															},
 															{
-																"id": 277,
+																"id": 591,
 																"name": "blockNumber",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2564,7 +5782,7 @@
 																}
 															},
 															{
-																"id": 278,
+																"id": 592,
 																"name": "data",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2596,7 +5814,7 @@
 																}
 															},
 															{
-																"id": 279,
+																"id": 593,
 																"name": "logIndex",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2616,7 +5834,7 @@
 																}
 															},
 															{
-																"id": 280,
+																"id": 594,
 																"name": "removed",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2636,7 +5854,7 @@
 																}
 															},
 															{
-																"id": 281,
+																"id": 595,
 																"name": "topics",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2668,7 +5886,7 @@
 																}
 															},
 															{
-																"id": 282,
+																"id": 596,
 																"name": "transactionHash",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2688,7 +5906,7 @@
 																}
 															},
 															{
-																"id": 283,
+																"id": 597,
 																"name": "transactionIndex",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2713,15 +5931,15 @@
 																"title": "Variables",
 																"kind": 32,
 																"children": [
-																	275,
-																	276,
-																	277,
-																	278,
-																	279,
-																	280,
-																	281,
-																	282,
-																	283
+																	589,
+																	590,
+																	591,
+																	592,
+																	593,
+																	594,
+																	595,
+																	596,
+																	597
 																]
 															}
 														]
@@ -2736,13 +5954,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2252,
+									"line": 2287,
 									"character": 25
 								}
 							]
 						},
 						{
-							"id": 284,
+							"id": 598,
 							"name": "eth_getLogs",
 							"kind": 2048,
 							"kindString": "Method",
@@ -2763,7 +5981,7 @@
 							],
 							"signatures": [
 								{
-									"id": 285,
+									"id": 599,
 									"name": "eth_getLogs",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -2783,7 +6001,7 @@
 									},
 									"parameters": [
 										{
-											"id": 286,
+											"id": 600,
 											"name": "filter",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -2807,7 +6025,7 @@
 												"elementType": {
 													"type": "reflection",
 													"declaration": {
-														"id": 287,
+														"id": 601,
 														"name": "__type",
 														"kind": 65536,
 														"kindString": "Type literal",
@@ -2816,7 +6034,7 @@
 														},
 														"children": [
 															{
-																"id": 288,
+																"id": 602,
 																"name": "address",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2836,7 +6054,7 @@
 																}
 															},
 															{
-																"id": 289,
+																"id": 603,
 																"name": "blockHash",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2856,7 +6074,7 @@
 																}
 															},
 															{
-																"id": 290,
+																"id": 604,
 																"name": "blockNumber",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2876,7 +6094,7 @@
 																}
 															},
 															{
-																"id": 291,
+																"id": 605,
 																"name": "data",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2908,7 +6126,7 @@
 																}
 															},
 															{
-																"id": 292,
+																"id": 606,
 																"name": "logIndex",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2928,7 +6146,7 @@
 																}
 															},
 															{
-																"id": 293,
+																"id": 607,
 																"name": "removed",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2948,7 +6166,7 @@
 																}
 															},
 															{
-																"id": 294,
+																"id": 608,
 																"name": "topics",
 																"kind": 32,
 																"kindString": "Variable",
@@ -2980,7 +6198,7 @@
 																}
 															},
 															{
-																"id": 295,
+																"id": 609,
 																"name": "transactionHash",
 																"kind": 32,
 																"kindString": "Variable",
@@ -3000,7 +6218,7 @@
 																}
 															},
 															{
-																"id": 296,
+																"id": 610,
 																"name": "transactionIndex",
 																"kind": 32,
 																"kindString": "Variable",
@@ -3025,15 +6243,15 @@
 																"title": "Variables",
 																"kind": 32,
 																"children": [
-																	288,
-																	289,
-																	290,
-																	291,
-																	292,
-																	293,
-																	294,
-																	295,
-																	296
+																	602,
+																	603,
+																	604,
+																	605,
+																	606,
+																	607,
+																	608,
+																	609,
+																	610
 																]
 															}
 														]
@@ -3048,13 +6266,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2309,
+									"line": 2344,
 									"character": 19
 								}
 							]
 						},
 						{
-							"id": 183,
+							"id": 519,
 							"name": "eth_getStorageAt",
 							"kind": 2048,
 							"kindString": "Method",
@@ -3076,7 +6294,7 @@
 							],
 							"signatures": [
 								{
-									"id": 184,
+									"id": 520,
 									"name": "eth_getStorageAt",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -3095,7 +6313,7 @@
 									},
 									"parameters": [
 										{
-											"id": 185,
+											"id": 521,
 											"name": "address",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3111,7 +6329,7 @@
 											}
 										},
 										{
-											"id": 186,
+											"id": 522,
 											"name": "position",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3127,7 +6345,7 @@
 											}
 										},
 										{
-											"id": 187,
+											"id": 523,
 											"name": "blockNumber",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3168,13 +6386,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1432,
+									"line": 1453,
 									"character": 24
 								}
 							]
 						},
 						{
-							"id": 129,
+							"id": 281,
 							"name": "eth_getTransactionByBlockHashAndIndex",
 							"kind": 2048,
 							"kindString": "Method",
@@ -3195,7 +6413,7 @@
 							],
 							"signatures": [
 								{
-									"id": 130,
+									"id": 282,
 									"name": "eth_getTransactionByBlockHashAndIndex",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -3214,7 +6432,7 @@
 									},
 									"parameters": [
 										{
-											"id": 131,
+											"id": 283,
 											"name": "hash",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3230,7 +6448,7 @@
 											}
 										},
 										{
-											"id": 132,
+											"id": 284,
 											"name": "index",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3250,8 +6468,342 @@
 										"type": "reference",
 										"typeArguments": [
 											{
-												"type": "intrinsic",
-												"name": "any"
+												"type": "reflection",
+												"declaration": {
+													"id": 285,
+													"name": "__type",
+													"kind": 65536,
+													"kindString": "Type literal",
+													"flags": {
+														"isExported": true
+													},
+													"children": [
+														{
+															"id": 289,
+															"name": "blockHash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 15,
+																	"character": 13
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 290,
+															"name": "blockNumber",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 16,
+																	"character": 15
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 292,
+															"name": "from",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 18,
+																	"character": 8
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 295,
+															"name": "gas",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 21,
+																	"character": 7
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 296,
+															"name": "gasPrice",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 22,
+																	"character": 12
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 286,
+															"name": "hash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 12,
+																	"character": 8
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 297,
+															"name": "input",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 23,
+																	"character": 9
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 288,
+															"name": "nonce",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 14,
+																	"character": 9
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 299,
+															"name": "r",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 25,
+																	"character": 5
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 300,
+															"name": "s",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 26,
+																	"character": 5
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 293,
+															"name": "to",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 19,
+																	"character": 6
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Address"
+															}
+														},
+														{
+															"id": 291,
+															"name": "transactionIndex",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 17,
+																	"character": 20
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 287,
+															"name": "type",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true,
+																"isOptional": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 13,
+																	"character": 8
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 298,
+															"name": "v",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 24,
+																	"character": 5
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 294,
+															"name": "value",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 20,
+																	"character": 9
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														}
+													],
+													"groups": [
+														{
+															"title": "Variables",
+															"kind": 32,
+															"children": [
+																289,
+																290,
+																292,
+																295,
+																296,
+																286,
+																297,
+																288,
+																299,
+																300,
+																293,
+																291,
+																287,
+																298,
+																294
+															]
+														}
+													]
+												}
 											}
 										],
 										"name": "Promise"
@@ -3261,13 +6813,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1032,
+									"line": 1045,
 									"character": 45
 								}
 							]
 						},
 						{
-							"id": 133,
+							"id": 301,
 							"name": "eth_getTransactionByBlockNumberAndIndex",
 							"kind": 2048,
 							"kindString": "Method",
@@ -3288,7 +6840,7 @@
 							],
 							"signatures": [
 								{
-									"id": 134,
+									"id": 302,
 									"name": "eth_getTransactionByBlockNumberAndIndex",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -3307,7 +6859,7 @@
 									},
 									"parameters": [
 										{
-											"id": 135,
+											"id": 303,
 											"name": "number",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3332,7 +6884,7 @@
 											}
 										},
 										{
-											"id": 136,
+											"id": 304,
 											"name": "index",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3352,8 +6904,342 @@
 										"type": "reference",
 										"typeArguments": [
 											{
-												"type": "intrinsic",
-												"name": "any"
+												"type": "reflection",
+												"declaration": {
+													"id": 305,
+													"name": "__type",
+													"kind": 65536,
+													"kindString": "Type literal",
+													"flags": {
+														"isExported": true
+													},
+													"children": [
+														{
+															"id": 309,
+															"name": "blockHash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 15,
+																	"character": 13
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 310,
+															"name": "blockNumber",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 16,
+																	"character": 15
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 312,
+															"name": "from",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 18,
+																	"character": 8
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 315,
+															"name": "gas",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 21,
+																	"character": 7
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 316,
+															"name": "gasPrice",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 22,
+																	"character": 12
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 306,
+															"name": "hash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 12,
+																	"character": 8
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 317,
+															"name": "input",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 23,
+																	"character": 9
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 308,
+															"name": "nonce",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 14,
+																	"character": 9
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 319,
+															"name": "r",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 25,
+																	"character": 5
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 320,
+															"name": "s",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 26,
+																	"character": 5
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 313,
+															"name": "to",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 19,
+																	"character": 6
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Address"
+															}
+														},
+														{
+															"id": 311,
+															"name": "transactionIndex",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 17,
+																	"character": 20
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 307,
+															"name": "type",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true,
+																"isOptional": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 13,
+																	"character": 8
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 318,
+															"name": "v",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 24,
+																	"character": 5
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 314,
+															"name": "value",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 20,
+																	"character": 9
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														}
+													],
+													"groups": [
+														{
+															"title": "Variables",
+															"kind": 32,
+															"children": [
+																309,
+																310,
+																312,
+																315,
+																316,
+																306,
+																317,
+																308,
+																319,
+																320,
+																313,
+																311,
+																307,
+																318,
+																314
+															]
+														}
+													]
+												}
 											}
 										],
 										"name": "Promise"
@@ -3363,13 +7249,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1075,
+									"line": 1091,
 									"character": 47
 								}
 							]
 						},
 						{
-							"id": 188,
+							"id": 524,
 							"name": "eth_getTransactionByHash",
 							"kind": 2048,
 							"kindString": "Method",
@@ -3390,7 +7276,7 @@
 							],
 							"signatures": [
 								{
-									"id": 189,
+									"id": 525,
 									"name": "eth_getTransactionByHash",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -3409,7 +7295,7 @@
 									},
 									"parameters": [
 										{
-											"id": 190,
+											"id": 526,
 											"name": "transactionHash",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3431,7 +7317,7 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 191,
+													"id": 527,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
@@ -3440,7 +7326,7 @@
 													},
 													"children": [
 														{
-															"id": 194,
+															"id": 531,
 															"name": "blockHash",
 															"kind": 32,
 															"kindString": "Variable",
@@ -3449,18 +7335,18 @@
 															},
 															"sources": [
 																{
-																	"fileName": "chains/ethereum/transaction/typings/src/runtime-transaction.d.ts",
-																	"line": 184,
-																	"character": 17
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 15,
+																	"character": 13
 																}
 															],
 															"type": {
-																"type": "intrinsic",
-																"name": "any"
+																"type": "reference",
+																"name": "Data"
 															}
 														},
 														{
-															"id": 195,
+															"id": 532,
 															"name": "blockNumber",
 															"kind": 32,
 															"kindString": "Variable",
@@ -3469,18 +7355,18 @@
 															},
 															"sources": [
 																{
-																	"fileName": "chains/ethereum/transaction/typings/src/runtime-transaction.d.ts",
-																	"line": 185,
-																	"character": 19
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 16,
+																	"character": 15
 																}
 															],
 															"type": {
-																"type": "intrinsic",
-																"name": "any"
+																"type": "reference",
+																"name": "Quantity"
 															}
 														},
 														{
-															"id": 197,
+															"id": 534,
 															"name": "from",
 															"kind": 32,
 															"kindString": "Variable",
@@ -3489,9 +7375,9 @@
 															},
 															"sources": [
 																{
-																	"fileName": "chains/ethereum/transaction/typings/src/runtime-transaction.d.ts",
-																	"line": 187,
-																	"character": 12
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 18,
+																	"character": 8
 																}
 															],
 															"type": {
@@ -3500,7 +7386,7 @@
 															}
 														},
 														{
-															"id": 200,
+															"id": 537,
 															"name": "gas",
 															"kind": 32,
 															"kindString": "Variable",
@@ -3509,9 +7395,9 @@
 															},
 															"sources": [
 																{
-																	"fileName": "chains/ethereum/transaction/typings/src/runtime-transaction.d.ts",
-																	"line": 190,
-																	"character": 11
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 21,
+																	"character": 7
 																}
 															],
 															"type": {
@@ -3520,7 +7406,7 @@
 															}
 														},
 														{
-															"id": 201,
+															"id": 538,
 															"name": "gasPrice",
 															"kind": 32,
 															"kindString": "Variable",
@@ -3529,9 +7415,9 @@
 															},
 															"sources": [
 																{
-																	"fileName": "chains/ethereum/transaction/typings/src/runtime-transaction.d.ts",
-																	"line": 191,
-																	"character": 16
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 22,
+																	"character": 12
 																}
 															],
 															"type": {
@@ -3540,7 +7426,7 @@
 															}
 														},
 														{
-															"id": 192,
+															"id": 528,
 															"name": "hash",
 															"kind": 32,
 															"kindString": "Variable",
@@ -3549,9 +7435,9 @@
 															},
 															"sources": [
 																{
-																	"fileName": "chains/ethereum/transaction/typings/src/runtime-transaction.d.ts",
-																	"line": 182,
-																	"character": 12
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 12,
+																	"character": 8
 																}
 															],
 															"type": {
@@ -3560,7 +7446,7 @@
 															}
 														},
 														{
-															"id": 202,
+															"id": 539,
 															"name": "input",
 															"kind": 32,
 															"kindString": "Variable",
@@ -3569,9 +7455,9 @@
 															},
 															"sources": [
 																{
-																	"fileName": "chains/ethereum/transaction/typings/src/runtime-transaction.d.ts",
-																	"line": 192,
-																	"character": 13
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 23,
+																	"character": 9
 																}
 															],
 															"type": {
@@ -3580,7 +7466,7 @@
 															}
 														},
 														{
-															"id": 193,
+															"id": 530,
 															"name": "nonce",
 															"kind": 32,
 															"kindString": "Variable",
@@ -3589,9 +7475,9 @@
 															},
 															"sources": [
 																{
-																	"fileName": "chains/ethereum/transaction/typings/src/runtime-transaction.d.ts",
-																	"line": 183,
-																	"character": 13
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 14,
+																	"character": 9
 																}
 															],
 															"type": {
@@ -3600,7 +7486,7 @@
 															}
 														},
 														{
-															"id": 204,
+															"id": 541,
 															"name": "r",
 															"kind": 32,
 															"kindString": "Variable",
@@ -3609,9 +7495,9 @@
 															},
 															"sources": [
 																{
-																	"fileName": "chains/ethereum/transaction/typings/src/runtime-transaction.d.ts",
-																	"line": 194,
-																	"character": 9
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 25,
+																	"character": 5
 																}
 															],
 															"type": {
@@ -3620,7 +7506,7 @@
 															}
 														},
 														{
-															"id": 205,
+															"id": 542,
 															"name": "s",
 															"kind": 32,
 															"kindString": "Variable",
@@ -3629,9 +7515,9 @@
 															},
 															"sources": [
 																{
-																	"fileName": "chains/ethereum/transaction/typings/src/runtime-transaction.d.ts",
-																	"line": 195,
-																	"character": 9
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 26,
+																	"character": 5
 																}
 															],
 															"type": {
@@ -3640,7 +7526,7 @@
 															}
 														},
 														{
-															"id": 198,
+															"id": 535,
 															"name": "to",
 															"kind": 32,
 															"kindString": "Variable",
@@ -3649,9 +7535,9 @@
 															},
 															"sources": [
 																{
-																	"fileName": "chains/ethereum/transaction/typings/src/runtime-transaction.d.ts",
-																	"line": 188,
-																	"character": 10
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 19,
+																	"character": 6
 																}
 															],
 															"type": {
@@ -3660,7 +7546,7 @@
 															}
 														},
 														{
-															"id": 196,
+															"id": 533,
 															"name": "transactionIndex",
 															"kind": 32,
 															"kindString": "Variable",
@@ -3669,29 +7555,9 @@
 															},
 															"sources": [
 																{
-																	"fileName": "chains/ethereum/transaction/typings/src/runtime-transaction.d.ts",
-																	"line": 186,
-																	"character": 24
-																}
-															],
-															"type": {
-																"type": "intrinsic",
-																"name": "any"
-															}
-														},
-														{
-															"id": 203,
-															"name": "v",
-															"kind": 32,
-															"kindString": "Variable",
-															"flags": {
-																"isExported": true
-															},
-															"sources": [
-																{
-																	"fileName": "chains/ethereum/transaction/typings/src/runtime-transaction.d.ts",
-																	"line": 193,
-																	"character": 9
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 17,
+																	"character": 20
 																}
 															],
 															"type": {
@@ -3700,7 +7566,48 @@
 															}
 														},
 														{
-															"id": 199,
+															"id": 529,
+															"name": "type",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true,
+																"isOptional": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 13,
+																	"character": 8
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 540,
+															"name": "v",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 24,
+																	"character": 5
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 536,
 															"name": "value",
 															"kind": 32,
 															"kindString": "Variable",
@@ -3709,9 +7616,9 @@
 															},
 															"sources": [
 																{
-																	"fileName": "chains/ethereum/transaction/typings/src/runtime-transaction.d.ts",
-																	"line": 189,
-																	"character": 13
+																	"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																	"line": 20,
+																	"character": 9
 																}
 															],
 															"type": {
@@ -3725,20 +7632,21 @@
 															"title": "Variables",
 															"kind": 32,
 															"children": [
-																194,
-																195,
-																197,
-																200,
-																201,
-																192,
-																202,
-																193,
-																204,
-																205,
-																198,
-																196,
-																203,
-																199
+																531,
+																532,
+																534,
+																537,
+																538,
+																528,
+																539,
+																530,
+																541,
+																542,
+																535,
+																533,
+																529,
+																540,
+																536
 															]
 														}
 													]
@@ -3752,13 +7660,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1505,
+									"line": 1526,
 									"character": 32
 								}
 							]
 						},
 						{
-							"id": 297,
+							"id": 611,
 							"name": "eth_getTransactionCount",
 							"kind": 2048,
 							"kindString": "Method",
@@ -3780,7 +7688,7 @@
 							],
 							"signatures": [
 								{
-									"id": 298,
+									"id": 612,
 									"name": "eth_getTransactionCount",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -3799,7 +7707,7 @@
 									},
 									"parameters": [
 										{
-											"id": 299,
+											"id": 613,
 											"name": "address",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3815,7 +7723,7 @@
 											}
 										},
 										{
-											"id": 300,
+											"id": 614,
 											"name": "blockNumber",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3856,13 +7764,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2332,
+									"line": 2367,
 									"character": 31
 								}
 							]
 						},
 						{
-							"id": 206,
+							"id": 543,
 							"name": "eth_getTransactionReceipt",
 							"kind": 2048,
 							"kindString": "Method",
@@ -3883,7 +7791,7 @@
 							],
 							"signatures": [
 								{
-									"id": 207,
+									"id": 544,
 									"name": "eth_getTransactionReceipt",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -3903,7 +7811,7 @@
 									},
 									"parameters": [
 										{
-											"id": 208,
+											"id": 545,
 											"name": "transactionHash",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -3923,519 +7831,8 @@
 										"type": "reference",
 										"typeArguments": [
 											{
-												"type": "reflection",
-												"declaration": {
-													"id": 209,
-													"name": "__type",
-													"kind": 65536,
-													"kindString": "Type literal",
-													"flags": {
-														"isExported": true
-													},
-													"children": [
-														{
-															"id": 213,
-															"name": "blockHash",
-															"kind": 32,
-															"kindString": "Variable",
-															"flags": {
-																"isExported": true
-															},
-															"sources": [
-																{
-																	"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																	"line": 31,
-																	"character": 17
-																}
-															],
-															"type": {
-																"type": "reference",
-																"name": "Data"
-															}
-														},
-														{
-															"id": 212,
-															"name": "blockNumber",
-															"kind": 32,
-															"kindString": "Variable",
-															"flags": {
-																"isExported": true
-															},
-															"sources": [
-																{
-																	"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																	"line": 30,
-																	"character": 19
-																}
-															],
-															"type": {
-																"type": "reference",
-																"name": "Quantity"
-															}
-														},
-														{
-															"id": 218,
-															"name": "contractAddress",
-															"kind": 32,
-															"kindString": "Variable",
-															"flags": {
-																"isExported": true
-															},
-															"sources": [
-																{
-																	"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																	"line": 36,
-																	"character": 23
-																}
-															],
-															"type": {
-																"type": "reference",
-																"name": "Data"
-															}
-														},
-														{
-															"id": 216,
-															"name": "cumulativeGasUsed",
-															"kind": 32,
-															"kindString": "Variable",
-															"flags": {
-																"isExported": true
-															},
-															"sources": [
-																{
-																	"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																	"line": 34,
-																	"character": 25
-																}
-															],
-															"type": {
-																"type": "reference",
-																"name": "Quantity"
-															}
-														},
-														{
-															"id": 214,
-															"name": "from",
-															"kind": 32,
-															"kindString": "Variable",
-															"flags": {
-																"isExported": true
-															},
-															"sources": [
-																{
-																	"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																	"line": 32,
-																	"character": 12
-																}
-															],
-															"type": {
-																"type": "reference",
-																"name": "Data"
-															}
-														},
-														{
-															"id": 217,
-															"name": "gasUsed",
-															"kind": 32,
-															"kindString": "Variable",
-															"flags": {
-																"isExported": true
-															},
-															"sources": [
-																{
-																	"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																	"line": 35,
-																	"character": 15
-																}
-															],
-															"type": {
-																"type": "reference",
-																"name": "Quantity"
-															}
-														},
-														{
-															"id": 219,
-															"name": "logs",
-															"kind": 32,
-															"kindString": "Variable",
-															"flags": {
-																"isExported": true
-															},
-															"sources": [
-																{
-																	"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																	"line": 37,
-																	"character": 12
-																}
-															],
-															"type": {
-																"type": "array",
-																"elementType": {
-																	"type": "reflection",
-																	"declaration": {
-																		"id": 220,
-																		"name": "__type",
-																		"kind": 65536,
-																		"kindString": "Type literal",
-																		"flags": {
-																			"isExported": true
-																		},
-																		"children": [
-																			{
-																				"id": 221,
-																				"name": "address",
-																				"kind": 32,
-																				"kindString": "Variable",
-																				"flags": {
-																					"isExported": true
-																				},
-																				"sources": [
-																					{
-																						"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																						"line": 38,
-																						"character": 19
-																					}
-																				],
-																				"type": {
-																					"type": "reference",
-																					"name": "Address"
-																				}
-																			},
-																			{
-																				"id": 222,
-																				"name": "blockHash",
-																				"kind": 32,
-																				"kindString": "Variable",
-																				"flags": {
-																					"isExported": true
-																				},
-																				"sources": [
-																					{
-																						"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																						"line": 39,
-																						"character": 21
-																					}
-																				],
-																				"type": {
-																					"type": "reference",
-																					"name": "Data"
-																				}
-																			},
-																			{
-																				"id": 223,
-																				"name": "blockNumber",
-																				"kind": 32,
-																				"kindString": "Variable",
-																				"flags": {
-																					"isExported": true
-																				},
-																				"sources": [
-																					{
-																						"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																						"line": 40,
-																						"character": 23
-																					}
-																				],
-																				"type": {
-																					"type": "reference",
-																					"name": "Quantity"
-																				}
-																			},
-																			{
-																				"id": 224,
-																				"name": "data",
-																				"kind": 32,
-																				"kindString": "Variable",
-																				"flags": {
-																					"isExported": true
-																				},
-																				"sources": [
-																					{
-																						"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																						"line": 41,
-																						"character": 16
-																					}
-																				],
-																				"type": {
-																					"type": "union",
-																					"types": [
-																						{
-																							"type": "reference",
-																							"name": "Data"
-																						},
-																						{
-																							"type": "array",
-																							"elementType": {
-																								"type": "reference",
-																								"name": "Data"
-																							}
-																						}
-																					]
-																				}
-																			},
-																			{
-																				"id": 225,
-																				"name": "logIndex",
-																				"kind": 32,
-																				"kindString": "Variable",
-																				"flags": {
-																					"isExported": true
-																				},
-																				"sources": [
-																					{
-																						"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																						"line": 42,
-																						"character": 20
-																					}
-																				],
-																				"type": {
-																					"type": "reference",
-																					"name": "Quantity"
-																				}
-																			},
-																			{
-																				"id": 226,
-																				"name": "removed",
-																				"kind": 32,
-																				"kindString": "Variable",
-																				"flags": {
-																					"isExported": true
-																				},
-																				"sources": [
-																					{
-																						"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																						"line": 43,
-																						"character": 19
-																					}
-																				],
-																				"type": {
-																					"type": "intrinsic",
-																					"name": "boolean"
-																				}
-																			},
-																			{
-																				"id": 227,
-																				"name": "topics",
-																				"kind": 32,
-																				"kindString": "Variable",
-																				"flags": {
-																					"isExported": true
-																				},
-																				"sources": [
-																					{
-																						"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																						"line": 44,
-																						"character": 18
-																					}
-																				],
-																				"type": {
-																					"type": "union",
-																					"types": [
-																						{
-																							"type": "reference",
-																							"name": "Data"
-																						},
-																						{
-																							"type": "array",
-																							"elementType": {
-																								"type": "reference",
-																								"name": "Data"
-																							}
-																						}
-																					]
-																				}
-																			},
-																			{
-																				"id": 228,
-																				"name": "transactionHash",
-																				"kind": 32,
-																				"kindString": "Variable",
-																				"flags": {
-																					"isExported": true
-																				},
-																				"sources": [
-																					{
-																						"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																						"line": 45,
-																						"character": 27
-																					}
-																				],
-																				"type": {
-																					"type": "reference",
-																					"name": "Data"
-																				}
-																			},
-																			{
-																				"id": 229,
-																				"name": "transactionIndex",
-																				"kind": 32,
-																				"kindString": "Variable",
-																				"flags": {
-																					"isExported": true
-																				},
-																				"sources": [
-																					{
-																						"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																						"line": 46,
-																						"character": 28
-																					}
-																				],
-																				"type": {
-																					"type": "reference",
-																					"name": "Quantity"
-																				}
-																			}
-																		],
-																		"groups": [
-																			{
-																				"title": "Variables",
-																				"kind": 32,
-																				"children": [
-																					221,
-																					222,
-																					223,
-																					224,
-																					225,
-																					226,
-																					227,
-																					228,
-																					229
-																				]
-																			}
-																		],
-																		"sources": [
-																			{
-																				"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																				"line": 37,
-																				"character": 13
-																			}
-																		]
-																	}
-																}
-															}
-														},
-														{
-															"id": 230,
-															"name": "logsBloom",
-															"kind": 32,
-															"kindString": "Variable",
-															"flags": {
-																"isExported": true
-															},
-															"sources": [
-																{
-																	"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																	"line": 48,
-																	"character": 17
-																}
-															],
-															"type": {
-																"type": "reference",
-																"name": "Data"
-															}
-														},
-														{
-															"id": 231,
-															"name": "status",
-															"kind": 32,
-															"kindString": "Variable",
-															"flags": {
-																"isExported": true
-															},
-															"sources": [
-																{
-																	"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																	"line": 49,
-																	"character": 14
-																}
-															],
-															"type": {
-																"type": "reference",
-																"name": "Quantity"
-															}
-														},
-														{
-															"id": 215,
-															"name": "to",
-															"kind": 32,
-															"kindString": "Variable",
-															"flags": {
-																"isExported": true
-															},
-															"sources": [
-																{
-																	"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																	"line": 33,
-																	"character": 10
-																}
-															],
-															"type": {
-																"type": "reference",
-																"name": "Address"
-															}
-														},
-														{
-															"id": 210,
-															"name": "transactionHash",
-															"kind": 32,
-															"kindString": "Variable",
-															"flags": {
-																"isExported": true
-															},
-															"sources": [
-																{
-																	"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																	"line": 28,
-																	"character": 23
-																}
-															],
-															"type": {
-																"type": "reference",
-																"name": "Data"
-															}
-														},
-														{
-															"id": 211,
-															"name": "transactionIndex",
-															"kind": 32,
-															"kindString": "Variable",
-															"flags": {
-																"isExported": true
-															},
-															"sources": [
-																{
-																	"fileName": "chains/ethereum/transaction/typings/src/transaction-receipt.d.ts",
-																	"line": 29,
-																	"character": 24
-																}
-															],
-															"type": {
-																"type": "reference",
-																"name": "Quantity"
-															}
-														}
-													],
-													"groups": [
-														{
-															"title": "Variables",
-															"kind": 32,
-															"children": [
-																213,
-																212,
-																218,
-																216,
-																214,
-																217,
-																219,
-																230,
-																231,
-																215,
-																210,
-																211
-															]
-														}
-													]
-												}
+												"type": "reference",
+												"name": "TransactionReceiptJSON"
 											}
 										],
 										"name": "Promise"
@@ -4445,13 +7842,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1542,
+									"line": 1563,
 									"character": 33
 								}
 							]
 						},
 						{
-							"id": 143,
+							"id": 327,
 							"name": "eth_getUncleByBlockHashAndIndex",
 							"kind": 2048,
 							"kindString": "Method",
@@ -4472,7 +7869,7 @@
 							],
 							"signatures": [
 								{
-									"id": 144,
+									"id": 328,
 									"name": "eth_getUncleByBlockHashAndIndex",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -4491,7 +7888,7 @@
 									},
 									"parameters": [
 										{
-											"id": 145,
+											"id": 329,
 											"name": "hash",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -4507,7 +7904,7 @@
 											}
 										},
 										{
-											"id": 146,
+											"id": 330,
 											"name": "index",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -4527,8 +7924,1617 @@
 										"type": "reference",
 										"typeArguments": [
 											{
-												"type": "intrinsic",
-												"name": "any"
+												"type": "reflection",
+												"declaration": {
+													"id": 331,
+													"name": "__type",
+													"kind": 65536,
+													"kindString": "Type literal",
+													"flags": {
+														"isExported": true
+													},
+													"children": [
+														{
+															"id": 405,
+															"name": "baseFeePerGas",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true,
+																"isOptional": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 42,
+																	"character": 21
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 396,
+															"name": "difficulty",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 33,
+																	"character": 18
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 402,
+															"name": "extraData",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 39,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 399,
+															"name": "gasLimit",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 36,
+																	"character": 16
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 400,
+															"name": "gasUsed",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 37,
+																	"character": 15
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 406,
+															"name": "hash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 43,
+																	"character": 12
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 395,
+															"name": "logsBloom",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 32,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 391,
+															"name": "miner",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 28,
+																	"character": 13
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 403,
+															"name": "mixHash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 40,
+																	"character": 15
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 404,
+															"name": "nonce",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 41,
+																	"character": 13
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 398,
+															"name": "number",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 35,
+																	"character": 14
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 389,
+															"name": "parentHash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 26,
+																	"character": 18
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 394,
+															"name": "receiptsRoot",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 31,
+																	"character": 20
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 390,
+															"name": "sha3Uncles",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 27,
+																	"character": 18
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 332,
+															"name": "size",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 23,
+																	"character": 12
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 392,
+															"name": "stateRoot",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 29,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 401,
+															"name": "timestamp",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 38,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 397,
+															"name": "totalDifficulty",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 34,
+																	"character": 23
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 333,
+															"name": "transactions",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 24,
+																	"character": 20
+																}
+															],
+															"type": {
+																"type": "array",
+																"elementType": {
+																	"type": "union",
+																	"types": [
+																		{
+																			"type": "reference",
+																			"name": "Data"
+																		},
+																		{
+																			"type": "reflection",
+																			"declaration": {
+																				"id": 334,
+																				"name": "__type",
+																				"kind": 65536,
+																				"kindString": "Type literal",
+																				"flags": {
+																					"isExported": true
+																				},
+																				"children": [
+																					{
+																						"id": 338,
+																						"name": "blockHash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 15,
+																								"character": 13
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 339,
+																						"name": "blockNumber",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 16,
+																								"character": 15
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 341,
+																						"name": "from",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 18,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 344,
+																						"name": "gas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 21,
+																								"character": 7
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 345,
+																						"name": "gasPrice",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 22,
+																								"character": 12
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 335,
+																						"name": "hash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 12,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 346,
+																						"name": "input",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 23,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 337,
+																						"name": "nonce",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 14,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 348,
+																						"name": "r",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 25,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 349,
+																						"name": "s",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 26,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 342,
+																						"name": "to",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 19,
+																								"character": 6
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Address"
+																						}
+																					},
+																					{
+																						"id": 340,
+																						"name": "transactionIndex",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 17,
+																								"character": 20
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 336,
+																						"name": "type",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true,
+																							"isOptional": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 13,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 347,
+																						"name": "v",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 24,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 343,
+																						"name": "value",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 20,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					}
+																				],
+																				"groups": [
+																					{
+																						"title": "Variables",
+																						"kind": 32,
+																						"children": [
+																							338,
+																							339,
+																							341,
+																							344,
+																							345,
+																							335,
+																							346,
+																							337,
+																							348,
+																							349,
+																							342,
+																							340,
+																							336,
+																							347,
+																							343
+																						]
+																					}
+																				]
+																			}
+																		},
+																		{
+																			"type": "reflection",
+																			"declaration": {
+																				"id": 350,
+																				"name": "__type",
+																				"kind": 65536,
+																				"kindString": "Type literal",
+																				"flags": {
+																					"isExported": true
+																				},
+																				"children": [
+																					{
+																						"id": 364,
+																						"name": "accessList",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 42,
+																								"character": 14
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "AccessList"
+																						}
+																					},
+																					{
+																						"id": 355,
+																						"name": "blockHash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 33,
+																								"character": 13
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 356,
+																						"name": "blockNumber",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 34,
+																								"character": 15
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 353,
+																						"name": "chainId",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 31,
+																								"character": 11
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 358,
+																						"name": "from",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 36,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 361,
+																						"name": "gas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 39,
+																								"character": 7
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 362,
+																						"name": "gasPrice",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 40,
+																								"character": 12
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 351,
+																						"name": "hash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 29,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 363,
+																						"name": "input",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 41,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 354,
+																						"name": "nonce",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 32,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 366,
+																						"name": "r",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 44,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 367,
+																						"name": "s",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 45,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 359,
+																						"name": "to",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 37,
+																								"character": 6
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Address"
+																						}
+																					},
+																					{
+																						"id": 357,
+																						"name": "transactionIndex",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 35,
+																								"character": 20
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 352,
+																						"name": "type",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 30,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 365,
+																						"name": "v",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 43,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 360,
+																						"name": "value",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 38,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					}
+																				],
+																				"groups": [
+																					{
+																						"title": "Variables",
+																						"kind": 32,
+																						"children": [
+																							364,
+																							355,
+																							356,
+																							353,
+																							358,
+																							361,
+																							362,
+																							351,
+																							363,
+																							354,
+																							366,
+																							367,
+																							359,
+																							357,
+																							352,
+																							365,
+																							360
+																						]
+																					}
+																				]
+																			}
+																		},
+																		{
+																			"type": "reflection",
+																			"declaration": {
+																				"id": 368,
+																				"name": "__type",
+																				"kind": 65536,
+																				"kindString": "Type literal",
+																				"flags": {
+																					"isExported": true
+																				},
+																				"children": [
+																					{
+																						"id": 384,
+																						"name": "accessList",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 63,
+																								"character": 14
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "AccessList"
+																						}
+																					},
+																					{
+																						"id": 373,
+																						"name": "blockHash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 52,
+																								"character": 13
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 374,
+																						"name": "blockNumber",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 53,
+																								"character": 15
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 371,
+																						"name": "chainId",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 50,
+																								"character": 11
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 376,
+																						"name": "from",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 55,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 382,
+																						"name": "gas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 61,
+																								"character": 7
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 381,
+																						"name": "gasPrice",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 60,
+																								"character": 12
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 369,
+																						"name": "hash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 48,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 383,
+																						"name": "input",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 62,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 380,
+																						"name": "maxFeePerGas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 59,
+																								"character": 16
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 379,
+																						"name": "maxPriorityFeePerGas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 58,
+																								"character": 24
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 372,
+																						"name": "nonce",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 51,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 386,
+																						"name": "r",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 65,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 387,
+																						"name": "s",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 66,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 377,
+																						"name": "to",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 56,
+																								"character": 6
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Address"
+																						}
+																					},
+																					{
+																						"id": 375,
+																						"name": "transactionIndex",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 54,
+																								"character": 20
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 370,
+																						"name": "type",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 49,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 385,
+																						"name": "v",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 64,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 378,
+																						"name": "value",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 57,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					}
+																				],
+																				"groups": [
+																					{
+																						"title": "Variables",
+																						"kind": 32,
+																						"children": [
+																							384,
+																							373,
+																							374,
+																							371,
+																							376,
+																							382,
+																							381,
+																							369,
+																							383,
+																							380,
+																							379,
+																							372,
+																							386,
+																							387,
+																							377,
+																							375,
+																							370,
+																							385,
+																							378
+																						]
+																					}
+																				]
+																			}
+																		}
+																	]
+																}
+															}
+														},
+														{
+															"id": 393,
+															"name": "transactionsRoot",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 30,
+																	"character": 24
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 388,
+															"name": "uncles",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 25,
+																	"character": 14
+																}
+															],
+															"type": {
+																"type": "array",
+																"elementType": {
+																	"type": "intrinsic",
+																	"name": "string"
+																}
+															}
+														}
+													],
+													"groups": [
+														{
+															"title": "Variables",
+															"kind": 32,
+															"children": [
+																405,
+																396,
+																402,
+																399,
+																400,
+																406,
+																395,
+																391,
+																403,
+																404,
+																398,
+																389,
+																394,
+																390,
+																332,
+																392,
+																401,
+																397,
+																333,
+																393,
+																388
+															]
+														}
+													]
+												}
 											}
 										],
 										"name": "Promise"
@@ -4538,13 +9544,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1150,
+									"line": 1171,
 									"character": 39
 								}
 							]
 						},
 						{
-							"id": 147,
+							"id": 407,
 							"name": "eth_getUncleByBlockNumberAndIndex",
 							"kind": 2048,
 							"kindString": "Method",
@@ -4565,7 +9571,7 @@
 							],
 							"signatures": [
 								{
-									"id": 148,
+									"id": 408,
 									"name": "eth_getUncleByBlockNumberAndIndex",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -4584,7 +9590,7 @@
 									},
 									"parameters": [
 										{
-											"id": 149,
+											"id": 409,
 											"name": "blockNumber",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -4609,7 +9615,7 @@
 											}
 										},
 										{
-											"id": 150,
+											"id": 410,
 											"name": "uncleIndex",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -4629,8 +9635,1617 @@
 										"type": "reference",
 										"typeArguments": [
 											{
-												"type": "intrinsic",
-												"name": "any"
+												"type": "reflection",
+												"declaration": {
+													"id": 411,
+													"name": "__type",
+													"kind": 65536,
+													"kindString": "Type literal",
+													"flags": {
+														"isExported": true
+													},
+													"children": [
+														{
+															"id": 485,
+															"name": "baseFeePerGas",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true,
+																"isOptional": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 42,
+																	"character": 21
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 476,
+															"name": "difficulty",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 33,
+																	"character": 18
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 482,
+															"name": "extraData",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 39,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 479,
+															"name": "gasLimit",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 36,
+																	"character": 16
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 480,
+															"name": "gasUsed",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 37,
+																	"character": 15
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 486,
+															"name": "hash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 43,
+																	"character": 12
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 475,
+															"name": "logsBloom",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 32,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 471,
+															"name": "miner",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 28,
+																	"character": 13
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 483,
+															"name": "mixHash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 40,
+																	"character": 15
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 484,
+															"name": "nonce",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 41,
+																	"character": 13
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 478,
+															"name": "number",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 35,
+																	"character": 14
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 469,
+															"name": "parentHash",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 26,
+																	"character": 18
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 474,
+															"name": "receiptsRoot",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 31,
+																	"character": 20
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 470,
+															"name": "sha3Uncles",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 27,
+																	"character": 18
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 412,
+															"name": "size",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 23,
+																	"character": 12
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 472,
+															"name": "stateRoot",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 29,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 481,
+															"name": "timestamp",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 38,
+																	"character": 17
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 477,
+															"name": "totalDifficulty",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 34,
+																	"character": 23
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Quantity"
+															}
+														},
+														{
+															"id": 413,
+															"name": "transactions",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 24,
+																	"character": 20
+																}
+															],
+															"type": {
+																"type": "array",
+																"elementType": {
+																	"type": "union",
+																	"types": [
+																		{
+																			"type": "reference",
+																			"name": "Data"
+																		},
+																		{
+																			"type": "reflection",
+																			"declaration": {
+																				"id": 414,
+																				"name": "__type",
+																				"kind": 65536,
+																				"kindString": "Type literal",
+																				"flags": {
+																					"isExported": true
+																				},
+																				"children": [
+																					{
+																						"id": 418,
+																						"name": "blockHash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 15,
+																								"character": 13
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 419,
+																						"name": "blockNumber",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 16,
+																								"character": 15
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 421,
+																						"name": "from",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 18,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 424,
+																						"name": "gas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 21,
+																								"character": 7
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 425,
+																						"name": "gasPrice",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 22,
+																								"character": 12
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 415,
+																						"name": "hash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 12,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 426,
+																						"name": "input",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 23,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 417,
+																						"name": "nonce",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 14,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 428,
+																						"name": "r",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 25,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 429,
+																						"name": "s",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 26,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 422,
+																						"name": "to",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 19,
+																								"character": 6
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Address"
+																						}
+																					},
+																					{
+																						"id": 420,
+																						"name": "transactionIndex",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 17,
+																								"character": 20
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 416,
+																						"name": "type",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true,
+																							"isOptional": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 13,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 427,
+																						"name": "v",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 24,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 423,
+																						"name": "value",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 20,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					}
+																				],
+																				"groups": [
+																					{
+																						"title": "Variables",
+																						"kind": 32,
+																						"children": [
+																							418,
+																							419,
+																							421,
+																							424,
+																							425,
+																							415,
+																							426,
+																							417,
+																							428,
+																							429,
+																							422,
+																							420,
+																							416,
+																							427,
+																							423
+																						]
+																					}
+																				]
+																			}
+																		},
+																		{
+																			"type": "reflection",
+																			"declaration": {
+																				"id": 430,
+																				"name": "__type",
+																				"kind": 65536,
+																				"kindString": "Type literal",
+																				"flags": {
+																					"isExported": true
+																				},
+																				"children": [
+																					{
+																						"id": 444,
+																						"name": "accessList",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 42,
+																								"character": 14
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "AccessList"
+																						}
+																					},
+																					{
+																						"id": 435,
+																						"name": "blockHash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 33,
+																								"character": 13
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 436,
+																						"name": "blockNumber",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 34,
+																								"character": 15
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 433,
+																						"name": "chainId",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 31,
+																								"character": 11
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 438,
+																						"name": "from",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 36,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 441,
+																						"name": "gas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 39,
+																								"character": 7
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 442,
+																						"name": "gasPrice",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 40,
+																								"character": 12
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 431,
+																						"name": "hash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 29,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 443,
+																						"name": "input",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 41,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 434,
+																						"name": "nonce",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 32,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 446,
+																						"name": "r",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 44,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 447,
+																						"name": "s",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 45,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 439,
+																						"name": "to",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 37,
+																								"character": 6
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Address"
+																						}
+																					},
+																					{
+																						"id": 437,
+																						"name": "transactionIndex",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 35,
+																								"character": 20
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 432,
+																						"name": "type",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 30,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 445,
+																						"name": "v",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 43,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 440,
+																						"name": "value",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 38,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					}
+																				],
+																				"groups": [
+																					{
+																						"title": "Variables",
+																						"kind": 32,
+																						"children": [
+																							444,
+																							435,
+																							436,
+																							433,
+																							438,
+																							441,
+																							442,
+																							431,
+																							443,
+																							434,
+																							446,
+																							447,
+																							439,
+																							437,
+																							432,
+																							445,
+																							440
+																						]
+																					}
+																				]
+																			}
+																		},
+																		{
+																			"type": "reflection",
+																			"declaration": {
+																				"id": 448,
+																				"name": "__type",
+																				"kind": 65536,
+																				"kindString": "Type literal",
+																				"flags": {
+																					"isExported": true
+																				},
+																				"children": [
+																					{
+																						"id": 464,
+																						"name": "accessList",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 63,
+																								"character": 14
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "AccessList"
+																						}
+																					},
+																					{
+																						"id": 453,
+																						"name": "blockHash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 52,
+																								"character": 13
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 454,
+																						"name": "blockNumber",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 53,
+																								"character": 15
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 451,
+																						"name": "chainId",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 50,
+																								"character": 11
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 456,
+																						"name": "from",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 55,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 462,
+																						"name": "gas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 61,
+																								"character": 7
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 461,
+																						"name": "gasPrice",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 60,
+																								"character": 12
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 449,
+																						"name": "hash",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 48,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 463,
+																						"name": "input",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 62,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Data"
+																						}
+																					},
+																					{
+																						"id": 460,
+																						"name": "maxFeePerGas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 59,
+																								"character": 16
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 459,
+																						"name": "maxPriorityFeePerGas",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 58,
+																								"character": 24
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 452,
+																						"name": "nonce",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 51,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 466,
+																						"name": "r",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 65,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 467,
+																						"name": "s",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 66,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 457,
+																						"name": "to",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 56,
+																								"character": 6
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Address"
+																						}
+																					},
+																					{
+																						"id": 455,
+																						"name": "transactionIndex",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 54,
+																								"character": 20
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 450,
+																						"name": "type",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 49,
+																								"character": 8
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 465,
+																						"name": "v",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 64,
+																								"character": 5
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					},
+																					{
+																						"id": 458,
+																						"name": "value",
+																						"kind": 32,
+																						"kindString": "Variable",
+																						"flags": {
+																							"isExported": true
+																						},
+																						"sources": [
+																							{
+																								"fileName": "chains/ethereum/transaction/typings/src/transaction-types.d.ts",
+																								"line": 57,
+																								"character": 9
+																							}
+																						],
+																						"type": {
+																							"type": "reference",
+																							"name": "Quantity"
+																						}
+																					}
+																				],
+																				"groups": [
+																					{
+																						"title": "Variables",
+																						"kind": 32,
+																						"children": [
+																							464,
+																							453,
+																							454,
+																							451,
+																							456,
+																							462,
+																							461,
+																							449,
+																							463,
+																							460,
+																							459,
+																							452,
+																							466,
+																							467,
+																							457,
+																							455,
+																							450,
+																							465,
+																							458
+																						]
+																					}
+																				]
+																			}
+																		}
+																	]
+																}
+															}
+														},
+														{
+															"id": 473,
+															"name": "transactionsRoot",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 30,
+																	"character": 24
+																}
+															],
+															"type": {
+																"type": "reference",
+																"name": "Data"
+															}
+														},
+														{
+															"id": 468,
+															"name": "uncles",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
+																	"line": 25,
+																	"character": 14
+																}
+															],
+															"type": {
+																"type": "array",
+																"elementType": {
+																	"type": "intrinsic",
+																	"name": "string"
+																}
+															}
+														}
+													],
+													"groups": [
+														{
+															"title": "Variables",
+															"kind": 32,
+															"children": [
+																485,
+																476,
+																482,
+																479,
+																480,
+																486,
+																475,
+																471,
+																483,
+																484,
+																478,
+																469,
+																474,
+																470,
+																412,
+																472,
+																481,
+																477,
+																413,
+																473,
+																468
+															]
+														}
+													]
+												}
 											}
 										],
 										"name": "Promise"
@@ -4640,13 +11255,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1189,
+									"line": 1210,
 									"character": 41
 								}
 							]
 						},
 						{
-							"id": 137,
+							"id": 321,
 							"name": "eth_getUncleCountByBlockHash",
 							"kind": 2048,
 							"kindString": "Method",
@@ -4667,7 +11282,7 @@
 							],
 							"signatures": [
 								{
-									"id": 138,
+									"id": 322,
 									"name": "eth_getUncleCountByBlockHash",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -4686,7 +11301,7 @@
 									},
 									"parameters": [
 										{
-											"id": 139,
+											"id": 323,
 											"name": "hash",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -4717,13 +11332,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1095,
+									"line": 1116,
 									"character": 36
 								}
 							]
 						},
 						{
-							"id": 140,
+							"id": 324,
 							"name": "eth_getUncleCountByBlockNumber",
 							"kind": 2048,
 							"kindString": "Method",
@@ -4744,7 +11359,7 @@
 							],
 							"signatures": [
 								{
-									"id": 141,
+									"id": 325,
 									"name": "eth_getUncleCountByBlockNumber",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -4763,7 +11378,7 @@
 									},
 									"parameters": [
 										{
-											"id": 142,
+											"id": 326,
 											"name": "blockNumber",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -4803,13 +11418,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1110,
+									"line": 1131,
 									"character": 38
 								}
 							]
 						},
 						{
-							"id": 151,
+							"id": 487,
 							"name": "eth_getWork",
 							"kind": 2048,
 							"kindString": "Method",
@@ -4830,7 +11445,7 @@
 							],
 							"signatures": [
 								{
-									"id": 152,
+									"id": 488,
 									"name": "eth_getWork",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -4849,7 +11464,7 @@
 									},
 									"parameters": [
 										{
-											"id": 153,
+											"id": 489,
 											"name": "filterId",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -4901,13 +11516,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1210,
+									"line": 1231,
 									"character": 19
 								}
 							]
 						},
 						{
-							"id": 165,
+							"id": 501,
 							"name": "eth_hashrate",
 							"kind": 2048,
 							"kindString": "Method",
@@ -4928,7 +11543,7 @@
 							],
 							"signatures": [
 								{
-									"id": 166,
+									"id": 502,
 									"name": "eth_hashrate",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -4960,13 +11575,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1279,
+									"line": 1300,
 									"character": 20
 								}
 							]
 						},
 						{
-							"id": 163,
+							"id": 499,
 							"name": "eth_mining",
 							"kind": 2048,
 							"kindString": "Method",
@@ -4987,7 +11602,7 @@
 							],
 							"signatures": [
 								{
-									"id": 164,
+									"id": 500,
 									"name": "eth_mining",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -5019,13 +11634,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1264,
+									"line": 1285,
 									"character": 18
 								}
 							]
 						},
 						{
-							"id": 258,
+							"id": 572,
 							"name": "eth_newBlockFilter",
 							"kind": 2048,
 							"kindString": "Method",
@@ -5046,7 +11661,7 @@
 							],
 							"signatures": [
 								{
-									"id": 259,
+									"id": 573,
 									"name": "eth_newBlockFilter",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -5078,13 +11693,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2018,
+									"line": 2053,
 									"character": 26
 								}
 							]
 						},
 						{
-							"id": 262,
+							"id": 576,
 							"name": "eth_newFilter",
 							"kind": 2048,
 							"kindString": "Method",
@@ -5106,7 +11721,7 @@
 							],
 							"signatures": [
 								{
-									"id": 263,
+									"id": 577,
 									"name": "eth_newFilter",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -5126,7 +11741,7 @@
 									},
 									"parameters": [
 										{
-											"id": 264,
+											"id": 578,
 											"name": "filter",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -5158,13 +11773,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2104,
+									"line": 2139,
 									"character": 21
 								}
 							]
 						},
 						{
-							"id": 260,
+							"id": 574,
 							"name": "eth_newPendingTransactionFilter",
 							"kind": 2048,
 							"kindString": "Method",
@@ -5185,7 +11800,7 @@
 							],
 							"signatures": [
 								{
-									"id": 261,
+									"id": 575,
 									"name": "eth_newPendingTransactionFilter",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -5217,7 +11832,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2045,
+									"line": 2080,
 									"character": 39
 								}
 							]
@@ -5276,13 +11891,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 785,
+									"line": 796,
 									"character": 27
 								}
 							]
 						},
 						{
-							"id": 238,
+							"id": 552,
 							"name": "eth_sendRawTransaction",
 							"kind": 2048,
 							"kindString": "Method",
@@ -5303,7 +11918,7 @@
 							],
 							"signatures": [
 								{
-									"id": 239,
+									"id": 553,
 									"name": "eth_sendRawTransaction",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -5322,7 +11937,7 @@
 									},
 									"parameters": [
 										{
-											"id": 240,
+											"id": 554,
 											"name": "transaction",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -5353,13 +11968,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1704,
+									"line": 1738,
 									"character": 30
 								}
 							]
 						},
 						{
-							"id": 232,
+							"id": 546,
 							"name": "eth_sendTransaction",
 							"kind": 2048,
 							"kindString": "Method",
@@ -5380,7 +11995,7 @@
 							],
 							"signatures": [
 								{
-									"id": 233,
+									"id": 547,
 									"name": "eth_sendTransaction",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -5400,7 +12015,7 @@
 									},
 									"parameters": [
 										{
-											"id": 234,
+											"id": 548,
 											"name": "transaction",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -5412,7 +12027,7 @@
 											},
 											"type": {
 												"type": "reference",
-												"name": "RpcTransaction"
+												"name": "TypedRpcTransaction"
 											}
 										}
 									],
@@ -5431,13 +12046,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1606,
+									"line": 1632,
 									"character": 27
 								}
 							]
 						},
 						{
-							"id": 241,
+							"id": 555,
 							"name": "eth_sign",
 							"kind": 2048,
 							"kindString": "Method",
@@ -5458,7 +12073,7 @@
 							],
 							"signatures": [
 								{
-									"id": 242,
+									"id": 556,
 									"name": "eth_sign",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -5478,7 +12093,7 @@
 									},
 									"parameters": [
 										{
-											"id": 243,
+											"id": 557,
 											"name": "address",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -5494,7 +12109,7 @@
 											}
 										},
 										{
-											"id": 244,
+											"id": 558,
 											"name": "message",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -5525,13 +12140,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1739,
+									"line": 1771,
 									"character": 16
 								}
 							]
 						},
 						{
-							"id": 235,
+							"id": 549,
 							"name": "eth_signTransaction",
 							"kind": 2048,
 							"kindString": "Method",
@@ -5552,7 +12167,7 @@
 							],
 							"signatures": [
 								{
-									"id": 236,
+									"id": 550,
 									"name": "eth_signTransaction",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -5572,7 +12187,7 @@
 									},
 									"parameters": [
 										{
-											"id": 237,
+											"id": 551,
 											"name": "transaction",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -5584,7 +12199,7 @@
 											},
 											"type": {
 												"type": "reference",
-												"name": "RpcTransaction"
+												"name": "TypedRpcTransaction"
 											}
 										}
 									],
@@ -5603,13 +12218,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1667,
+									"line": 1701,
 									"character": 27
 								}
 							]
 						},
 						{
-							"id": 245,
+							"id": 559,
 							"name": "eth_signTypedData",
 							"kind": 2048,
 							"kindString": "Method",
@@ -5630,7 +12245,7 @@
 							],
 							"signatures": [
 								{
-									"id": 246,
+									"id": 560,
 									"name": "eth_signTypedData",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -5652,7 +12267,7 @@
 									},
 									"parameters": [
 										{
-											"id": 247,
+											"id": 561,
 											"name": "address",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -5668,7 +12283,7 @@
 											}
 										},
 										{
-											"id": 248,
+											"id": 562,
 											"name": "typedData",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -5680,7 +12295,7 @@
 											},
 											"type": {
 												"type": "reference",
-												"id": 389,
+												"id": 703,
 												"name": "TypedData"
 											}
 										}
@@ -5700,13 +12315,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1809,
+									"line": 1841,
 									"character": 25
 								}
 							]
 						},
 						{
-							"id": 159,
+							"id": 495,
 							"name": "eth_submitHashrate",
 							"kind": 2048,
 							"kindString": "Method",
@@ -5727,7 +12342,7 @@
 							],
 							"signatures": [
 								{
-									"id": 160,
+									"id": 496,
 									"name": "eth_submitHashrate",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -5746,7 +12361,7 @@
 									},
 									"parameters": [
 										{
-											"id": 161,
+											"id": 497,
 											"name": "hashRate",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -5762,7 +12377,7 @@
 											}
 										},
 										{
-											"id": 162,
+											"id": 498,
 											"name": "clientID",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -5793,13 +12408,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1250,
+									"line": 1271,
 									"character": 26
 								}
 							]
 						},
 						{
-							"id": 154,
+							"id": 490,
 							"name": "eth_submitWork",
 							"kind": 2048,
 							"kindString": "Method",
@@ -5820,7 +12435,7 @@
 							],
 							"signatures": [
 								{
-									"id": 155,
+									"id": 491,
 									"name": "eth_submitWork",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -5839,7 +12454,7 @@
 									},
 									"parameters": [
 										{
-											"id": 156,
+											"id": 492,
 											"name": "nonce",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -5855,7 +12470,7 @@
 											}
 										},
 										{
-											"id": 157,
+											"id": 493,
 											"name": "powHash",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -5871,7 +12486,7 @@
 											}
 										},
 										{
-											"id": 158,
+											"id": 494,
 											"name": "digest",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -5902,13 +12517,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1231,
+									"line": 1252,
 									"character": 22
 								}
 							]
 						},
 						{
-							"id": 249,
+							"id": 563,
 							"name": "eth_subscribe",
 							"kind": 2048,
 							"kindString": "Method",
@@ -5930,7 +12545,7 @@
 							],
 							"signatures": [
 								{
-									"id": 250,
+									"id": 564,
 									"name": "eth_subscribe",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -5949,7 +12564,7 @@
 									},
 									"parameters": [
 										{
-											"id": 251,
+											"id": 565,
 											"name": "subscriptionName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -5977,7 +12592,7 @@
 									}
 								},
 								{
-									"id": 252,
+									"id": 566,
 									"name": "eth_subscribe",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -5990,7 +12605,7 @@
 									},
 									"parameters": [
 										{
-											"id": 253,
+											"id": 567,
 											"name": "subscriptionName",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -6014,7 +12629,7 @@
 											}
 										},
 										{
-											"id": 254,
+											"id": 568,
 											"name": "options",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -6045,17 +12660,17 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1853,
+									"line": 1885,
 									"character": 15
 								},
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1866,
+									"line": 1898,
 									"character": 15
 								},
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1871,
+									"line": 1903,
 									"character": 15
 								}
 							]
@@ -6114,13 +12729,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 806,
+									"line": 817,
 									"character": 19
 								}
 							]
 						},
 						{
-							"id": 268,
+							"id": 582,
 							"name": "eth_uninstallFilter",
 							"kind": 2048,
 							"kindString": "Method",
@@ -6141,7 +12756,7 @@
 							],
 							"signatures": [
 								{
-									"id": 269,
+									"id": 583,
 									"name": "eth_uninstallFilter",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -6160,7 +12775,7 @@
 									},
 									"parameters": [
 										{
-											"id": 270,
+											"id": 584,
 											"name": "filterId",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -6191,13 +12806,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2208,
+									"line": 2243,
 									"character": 27
 								}
 							]
 						},
 						{
-							"id": 255,
+							"id": 569,
 							"name": "eth_unsubscribe",
 							"kind": 2048,
 							"kindString": "Method",
@@ -6218,7 +12833,7 @@
 							],
 							"signatures": [
 								{
-									"id": 256,
+									"id": 570,
 									"name": "eth_unsubscribe",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -6237,7 +12852,7 @@
 									},
 									"parameters": [
 										{
-											"id": 257,
+											"id": 571,
 											"name": "subscriptionId",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -6268,7 +12883,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 1994,
+									"line": 2029,
 									"character": 23
 								}
 							]
@@ -6354,7 +12969,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 344,
+									"line": 353,
 									"character": 24
 								}
 							]
@@ -6420,7 +13035,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 511,
+									"line": 520,
 									"character": 30
 								}
 							]
@@ -6535,7 +13150,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/ethereum/src/api.ts",
-																	"line": 260,
+																	"line": 261,
 																	"character": 10
 																}
 															],
@@ -6556,7 +13171,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/ethereum/src/api.ts",
-																	"line": 259,
+																	"line": 260,
 																	"character": 13
 																}
 															],
@@ -6579,7 +13194,7 @@
 													"sources": [
 														{
 															"fileName": "chains/ethereum/ethereum/src/api.ts",
-															"line": 258,
+															"line": 259,
 															"character": 25
 														}
 													]
@@ -6602,17 +13217,17 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 257,
-									"character": 16
-								},
-								{
-									"fileName": "chains/ethereum/ethereum/src/api.ts",
 									"line": 258,
 									"character": 16
 								},
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 263,
+									"line": 259,
+									"character": 16
+								},
+								{
+									"fileName": "chains/ethereum/ethereum/src/api.ts",
+									"line": 264,
 									"character": 16
 								}
 							]
@@ -6689,7 +13304,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 426,
+									"line": 435,
 									"character": 18
 								}
 							]
@@ -6783,7 +13398,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 312,
+									"line": 321,
 									"character": 27
 								}
 							]
@@ -6875,7 +13490,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 371,
+									"line": 380,
 									"character": 19
 								}
 							]
@@ -6922,7 +13537,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 467,
+									"line": 476,
 									"character": 20
 								}
 							]
@@ -7005,7 +13620,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 490,
+									"line": 499,
 									"character": 32
 								}
 							]
@@ -7082,7 +13697,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 598,
+									"line": 607,
 									"character": 26
 								}
 							]
@@ -7159,7 +13774,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 613,
+									"line": 622,
 									"character": 22
 								}
 							]
@@ -7236,7 +13851,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 582,
+									"line": 591,
 									"character": 25
 								}
 							]
@@ -7316,7 +13931,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 540,
+									"line": 549,
 									"character": 19
 								}
 							]
@@ -7375,7 +13990,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 565,
+									"line": 574,
 									"character": 18
 								}
 							]
@@ -7434,7 +14049,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 679,
+									"line": 688,
 									"character": 21
 								}
 							]
@@ -7493,7 +14108,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 692,
+									"line": 701,
 									"character": 21
 								}
 							]
@@ -7552,13 +14167,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 666,
+									"line": 675,
 									"character": 19
 								}
 							]
 						},
 						{
-							"id": 321,
+							"id": 635,
 							"name": "personal_importRawKey",
 							"kind": 2048,
 							"kindString": "Method",
@@ -7579,7 +14194,7 @@
 							],
 							"signatures": [
 								{
-									"id": 322,
+									"id": 636,
 									"name": "personal_importRawKey",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -7598,7 +14213,7 @@
 									},
 									"parameters": [
 										{
-											"id": 323,
+											"id": 637,
 											"name": "rawKey",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -7614,7 +14229,7 @@
 											}
 										},
 										{
-											"id": 324,
+											"id": 638,
 											"name": "passphrase",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -7645,13 +14260,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2621,
+									"line": 2658,
 									"character": 29
 								}
 							]
 						},
 						{
-							"id": 316,
+							"id": 630,
 							"name": "personal_listAccounts",
 							"kind": 2048,
 							"kindString": "Method",
@@ -7672,7 +14287,7 @@
 							],
 							"signatures": [
 								{
-									"id": 317,
+									"id": 631,
 									"name": "personal_listAccounts",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -7707,13 +14322,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2568,
+									"line": 2605,
 									"character": 29
 								}
 							]
 						},
 						{
-							"id": 325,
+							"id": 639,
 							"name": "personal_lockAccount",
 							"kind": 2048,
 							"kindString": "Method",
@@ -7734,7 +14349,7 @@
 							],
 							"signatures": [
 								{
-									"id": 326,
+									"id": 640,
 									"name": "personal_lockAccount",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -7753,7 +14368,7 @@
 									},
 									"parameters": [
 										{
-											"id": 327,
+											"id": 641,
 											"name": "address",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -7784,13 +14399,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2652,
+									"line": 2689,
 									"character": 28
 								}
 							]
 						},
 						{
-							"id": 318,
+							"id": 632,
 							"name": "personal_newAccount",
 							"kind": 2048,
 							"kindString": "Method",
@@ -7811,7 +14426,7 @@
 							],
 							"signatures": [
 								{
-									"id": 319,
+									"id": 633,
 									"name": "personal_newAccount",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -7830,7 +14445,7 @@
 									},
 									"parameters": [
 										{
-											"id": 320,
+											"id": 634,
 											"name": "passphrase",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -7861,13 +14476,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2586,
+									"line": 2623,
 									"character": 27
 								}
 							]
 						},
 						{
-							"id": 333,
+							"id": 647,
 							"name": "personal_sendTransaction",
 							"kind": 2048,
 							"kindString": "Method",
@@ -7888,7 +14503,7 @@
 							],
 							"signatures": [
 								{
-									"id": 334,
+									"id": 648,
 									"name": "personal_sendTransaction",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -7908,7 +14523,7 @@
 									},
 									"parameters": [
 										{
-											"id": 335,
+											"id": 649,
 											"name": "transaction",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -7921,7 +14536,7 @@
 											}
 										},
 										{
-											"id": 336,
+											"id": 650,
 											"name": "passphrase",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -7952,13 +14567,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2725,
+									"line": 2762,
 									"character": 32
 								}
 							]
 						},
 						{
-							"id": 337,
+							"id": 651,
 							"name": "personal_signTransaction",
 							"kind": 2048,
 							"kindString": "Method",
@@ -7979,7 +14594,7 @@
 							],
 							"signatures": [
 								{
-									"id": 338,
+									"id": 652,
 									"name": "personal_signTransaction",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -7999,7 +14614,7 @@
 									},
 									"parameters": [
 										{
-											"id": 339,
+											"id": 653,
 											"name": "transaction",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -8011,11 +14626,11 @@
 											},
 											"type": {
 												"type": "reference",
-												"name": "RpcTransaction"
+												"name": "TypedRpcTransaction"
 											}
 										},
 										{
-											"id": 340,
+											"id": 654,
 											"name": "passphrase",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -8043,13 +14658,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2778,
+									"line": 2815,
 									"character": 32
 								}
 							]
 						},
 						{
-							"id": 328,
+							"id": 642,
 							"name": "personal_unlockAccount",
 							"kind": 2048,
 							"kindString": "Method",
@@ -8071,7 +14686,7 @@
 							],
 							"signatures": [
 								{
-									"id": 329,
+									"id": 643,
 									"name": "personal_unlockAccount",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -8091,7 +14706,7 @@
 									},
 									"parameters": [
 										{
-											"id": 330,
+											"id": 644,
 											"name": "address",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -8107,7 +14722,7 @@
 											}
 										},
 										{
-											"id": 331,
+											"id": 645,
 											"name": "passphrase",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -8123,7 +14738,7 @@
 											}
 										},
 										{
-											"id": 332,
+											"id": 646,
 											"name": "duration",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -8155,13 +14770,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2681,
+									"line": 2718,
 									"character": 30
 								}
 							]
 						},
 						{
-							"id": 341,
+							"id": 655,
 							"name": "rpc_modules",
 							"kind": 2048,
 							"kindString": "Method",
@@ -8182,7 +14797,7 @@
 							],
 							"signatures": [
 								{
-									"id": 342,
+									"id": 656,
 									"name": "rpc_modules",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -8205,7 +14820,7 @@
 											{
 												"type": "reflection",
 												"declaration": {
-													"id": 343,
+													"id": 657,
 													"name": "__type",
 													"kind": 65536,
 													"kindString": "Type literal",
@@ -8214,50 +14829,8 @@
 													},
 													"children": [
 														{
-															"id": 344,
+															"id": 658,
 															"name": "eth",
-															"kind": 32,
-															"kindString": "Variable",
-															"flags": {
-																"isExported": true
-															},
-															"sources": [
-																{
-																	"fileName": "chains/ethereum/ethereum/src/api.ts",
-																	"line": 62,
-																	"character": 5
-																}
-															],
-															"type": {
-																"type": "stringLiteral",
-																"value": "1.0"
-															},
-															"defaultValue": "\"1.0\""
-														},
-														{
-															"id": 348,
-															"name": "evm",
-															"kind": 32,
-															"kindString": "Variable",
-															"flags": {
-																"isExported": true
-															},
-															"sources": [
-																{
-																	"fileName": "chains/ethereum/ethereum/src/api.ts",
-																	"line": 66,
-																	"character": 5
-																}
-															],
-															"type": {
-																"type": "stringLiteral",
-																"value": "1.0"
-															},
-															"defaultValue": "\"1.0\""
-														},
-														{
-															"id": 345,
-															"name": "net",
 															"kind": 32,
 															"kindString": "Variable",
 															"flags": {
@@ -8277,8 +14850,8 @@
 															"defaultValue": "\"1.0\""
 														},
 														{
-															"id": 349,
-															"name": "personal",
+															"id": 662,
+															"name": "evm",
 															"kind": 32,
 															"kindString": "Variable",
 															"flags": {
@@ -8288,7 +14861,7 @@
 																{
 																	"fileName": "chains/ethereum/ethereum/src/api.ts",
 																	"line": 67,
-																	"character": 10
+																	"character": 5
 																}
 															],
 															"type": {
@@ -8298,8 +14871,8 @@
 															"defaultValue": "\"1.0\""
 														},
 														{
-															"id": 346,
-															"name": "rpc",
+															"id": 659,
+															"name": "net",
 															"kind": 32,
 															"kindString": "Variable",
 															"flags": {
@@ -8319,8 +14892,29 @@
 															"defaultValue": "\"1.0\""
 														},
 														{
-															"id": 347,
-															"name": "web3",
+															"id": 663,
+															"name": "personal",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/ethereum/src/api.ts",
+																	"line": 68,
+																	"character": 10
+																}
+															],
+															"type": {
+																"type": "stringLiteral",
+																"value": "1.0"
+															},
+															"defaultValue": "\"1.0\""
+														},
+														{
+															"id": 660,
+															"name": "rpc",
 															"kind": 32,
 															"kindString": "Variable",
 															"flags": {
@@ -8330,6 +14924,27 @@
 																{
 																	"fileName": "chains/ethereum/ethereum/src/api.ts",
 																	"line": 65,
+																	"character": 5
+																}
+															],
+															"type": {
+																"type": "stringLiteral",
+																"value": "1.0"
+															},
+															"defaultValue": "\"1.0\""
+														},
+														{
+															"id": 661,
+															"name": "web3",
+															"kind": 32,
+															"kindString": "Variable",
+															"flags": {
+																"isExported": true
+															},
+															"sources": [
+																{
+																	"fileName": "chains/ethereum/ethereum/src/api.ts",
+																	"line": 66,
 																	"character": 6
 																}
 															],
@@ -8345,12 +14960,12 @@
 															"title": "Variables",
 															"kind": 32,
 															"children": [
-																344,
-																348,
-																345,
-																349,
-																346,
-																347
+																658,
+																662,
+																659,
+																663,
+																660,
+																661
 															]
 														}
 													]
@@ -8364,13 +14979,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2812,
+									"line": 2849,
 									"character": 19
 								}
 							]
 						},
 						{
-							"id": 357,
+							"id": 671,
 							"name": "shh_addToGroup",
 							"kind": 2048,
 							"kindString": "Method",
@@ -8391,7 +15006,7 @@
 							],
 							"signatures": [
 								{
-									"id": 358,
+									"id": 672,
 									"name": "shh_addToGroup",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -8410,7 +15025,7 @@
 									},
 									"parameters": [
 										{
-											"id": 359,
+											"id": 673,
 											"name": "address",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -8441,13 +15056,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2869,
+									"line": 2906,
 									"character": 22
 								}
 							]
 						},
 						{
-							"id": 367,
+							"id": 681,
 							"name": "shh_getFilterChanges",
 							"kind": 2048,
 							"kindString": "Method",
@@ -8468,7 +15083,7 @@
 							],
 							"signatures": [
 								{
-									"id": 368,
+									"id": 682,
 									"name": "shh_getFilterChanges",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -8487,7 +15102,7 @@
 									},
 									"parameters": [
 										{
-											"id": 369,
+											"id": 683,
 											"name": "id",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -8521,13 +15136,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2917,
+									"line": 2954,
 									"character": 28
 								}
 							]
 						},
 						{
-							"id": 370,
+							"id": 684,
 							"name": "shh_getMessages",
 							"kind": 2048,
 							"kindString": "Method",
@@ -8548,7 +15163,7 @@
 							],
 							"signatures": [
 								{
-									"id": 371,
+									"id": 685,
 									"name": "shh_getMessages",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -8567,7 +15182,7 @@
 									},
 									"parameters": [
 										{
-											"id": 372,
+											"id": 686,
 											"name": "id",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -8598,13 +15213,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2932,
+									"line": 2969,
 									"character": 23
 								}
 							]
 						},
 						{
-							"id": 352,
+							"id": 666,
 							"name": "shh_hasIdentity",
 							"kind": 2048,
 							"kindString": "Method",
@@ -8625,7 +15240,7 @@
 							],
 							"signatures": [
 								{
-									"id": 353,
+									"id": 667,
 									"name": "shh_hasIdentity",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -8644,7 +15259,7 @@
 									},
 									"parameters": [
 										{
-											"id": 354,
+											"id": 668,
 											"name": "address",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -8675,13 +15290,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2844,
+									"line": 2881,
 									"character": 23
 								}
 							]
 						},
 						{
-							"id": 360,
+							"id": 674,
 							"name": "shh_newFilter",
 							"kind": 2048,
 							"kindString": "Method",
@@ -8702,7 +15317,7 @@
 							],
 							"signatures": [
 								{
-									"id": 361,
+									"id": 675,
 									"name": "shh_newFilter",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -8721,7 +15336,7 @@
 									},
 									"parameters": [
 										{
-											"id": 362,
+											"id": 676,
 											"name": "to",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -8737,7 +15352,7 @@
 											}
 										},
 										{
-											"id": 363,
+											"id": 677,
 											"name": "topics",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -8771,13 +15386,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2886,
+									"line": 2923,
 									"character": 21
 								}
 							]
 						},
 						{
-							"id": 355,
+							"id": 669,
 							"name": "shh_newGroup",
 							"kind": 2048,
 							"kindString": "Method",
@@ -8798,7 +15413,7 @@
 							],
 							"signatures": [
 								{
-									"id": 356,
+									"id": 670,
 									"name": "shh_newGroup",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -8824,13 +15439,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2854,
+									"line": 2891,
 									"character": 20
 								}
 							]
 						},
 						{
-							"id": 350,
+							"id": 664,
 							"name": "shh_newIdentity",
 							"kind": 2048,
 							"kindString": "Method",
@@ -8851,7 +15466,7 @@
 							],
 							"signatures": [
 								{
-									"id": 351,
+									"id": 665,
 									"name": "shh_newIdentity",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -8883,13 +15498,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2829,
+									"line": 2866,
 									"character": 23
 								}
 							]
 						},
 						{
-							"id": 373,
+							"id": 687,
 							"name": "shh_post",
 							"kind": 2048,
 							"kindString": "Method",
@@ -8910,7 +15525,7 @@
 							],
 							"signatures": [
 								{
-									"id": 374,
+									"id": 688,
 									"name": "shh_post",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -8929,7 +15544,7 @@
 									},
 									"parameters": [
 										{
-											"id": 375,
+											"id": 689,
 											"name": "postData",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -8958,13 +15573,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2947,
+									"line": 2984,
 									"character": 16
 								}
 							]
 						},
 						{
-							"id": 364,
+							"id": 678,
 							"name": "shh_uninstallFilter",
 							"kind": 2048,
 							"kindString": "Method",
@@ -8985,7 +15600,7 @@
 							],
 							"signatures": [
 								{
-									"id": 365,
+									"id": 679,
 									"name": "shh_uninstallFilter",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -9004,7 +15619,7 @@
 									},
 									"parameters": [
 										{
-											"id": 366,
+											"id": 680,
 											"name": "id",
 											"kind": 32768,
 											"kindString": "Parameter",
@@ -9035,13 +15650,13 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2902,
+									"line": 2939,
 									"character": 27
 								}
 							]
 						},
 						{
-							"id": 376,
+							"id": 690,
 							"name": "shh_version",
 							"kind": 2048,
 							"kindString": "Method",
@@ -9062,7 +15677,7 @@
 							],
 							"signatures": [
 								{
-									"id": 377,
+									"id": 691,
 									"name": "shh_version",
 									"kind": 4096,
 									"kindString": "Call signature",
@@ -9094,7 +15709,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 2961,
+									"line": 2998,
 									"character": 19
 								}
 							]
@@ -9153,7 +15768,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 634,
+									"line": 643,
 									"character": 26
 								}
 							]
@@ -9230,7 +15845,7 @@
 							"sources": [
 								{
 									"fileName": "chains/ethereum/ethereum/src/api.ts",
-									"line": 650,
+									"line": 659,
 									"character": 17
 								}
 							]
@@ -9266,53 +15881,53 @@
 								31,
 								35,
 								26,
-								309,
-								305,
-								169,
-								171,
-								301,
-								173,
+								623,
+								619,
+								505,
+								507,
+								615,
+								509,
 								111,
 								103,
-								167,
-								175,
-								117,
+								503,
+								511,
+								193,
 								113,
-								124,
-								121,
-								179,
-								127,
-								265,
-								271,
-								284,
-								183,
-								129,
-								133,
-								188,
-								297,
-								206,
-								143,
-								147,
-								137,
-								140,
-								151,
-								165,
-								163,
-								258,
-								262,
-								260,
+								276,
+								273,
+								515,
+								279,
+								579,
+								585,
+								598,
+								519,
+								281,
+								301,
+								524,
+								611,
+								543,
+								327,
+								407,
+								321,
+								324,
+								487,
+								501,
+								499,
+								572,
+								576,
+								574,
 								107,
-								238,
-								232,
-								241,
-								235,
-								245,
-								159,
-								154,
-								249,
+								552,
+								546,
+								555,
+								549,
+								559,
+								495,
+								490,
+								563,
 								109,
-								268,
-								255,
+								582,
+								569,
 								60,
 								75,
 								48,
@@ -9329,24 +15944,24 @@
 								99,
 								101,
 								97,
-								321,
-								316,
-								325,
-								318,
-								333,
-								337,
-								328,
-								341,
-								357,
-								367,
-								370,
-								352,
-								360,
-								355,
-								350,
-								373,
-								364,
-								376,
+								635,
+								630,
+								639,
+								632,
+								647,
+								651,
+								642,
+								655,
+								671,
+								681,
+								684,
+								666,
+								674,
+								669,
+								664,
+								687,
+								678,
+								690,
 								92,
 								94
 							]
@@ -9355,7 +15970,7 @@
 					"sources": [
 						{
 							"fileName": "chains/ethereum/ethereum/src/api.ts",
-							"line": 111,
+							"line": 112,
 							"character": 32
 						}
 					],
@@ -9367,7 +15982,7 @@
 					]
 				},
 				{
-					"id": 389,
+					"id": 703,
 					"name": "TypedData",
 					"kind": 4194304,
 					"kindString": "Type alias",
@@ -9375,7 +15990,7 @@
 					"sources": [
 						{
 							"fileName": "chains/ethereum/ethereum/src/api.ts",
-							"line": 72,
+							"line": 73,
 							"character": 14
 						}
 					],
@@ -9418,7 +16033,7 @@
 					}
 				},
 				{
-					"id": 379,
+					"id": 693,
 					"name": "CLIENT_VERSION",
 					"kind": 32,
 					"kindString": "Variable",
@@ -9428,7 +16043,7 @@
 					"sources": [
 						{
 							"fileName": "chains/ethereum/ethereum/src/api.ts",
-							"line": 59,
+							"line": 60,
 							"character": 20
 						}
 					],
@@ -9439,7 +16054,7 @@
 					"defaultValue": "`Ganache/v${version}/EthereumJS TestRPC/v${version}/ethereum-js`"
 				},
 				{
-					"id": 380,
+					"id": 694,
 					"name": "PROTOCOL_VERSION",
 					"kind": 32,
 					"kindString": "Variable",
@@ -9449,7 +16064,7 @@
 					"sources": [
 						{
 							"fileName": "chains/ethereum/ethereum/src/api.ts",
-							"line": 60,
+							"line": 61,
 							"character": 22
 						}
 					],
@@ -9460,7 +16075,7 @@
 					"defaultValue": "Data.from(\"0x3f\")"
 				},
 				{
-					"id": 381,
+					"id": 695,
 					"name": "RPC_MODULES",
 					"kind": 32,
 					"kindString": "Variable",
@@ -9470,60 +16085,22 @@
 					"sources": [
 						{
 							"fileName": "chains/ethereum/ethereum/src/api.ts",
-							"line": 61,
+							"line": 62,
 							"character": 17
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 382,
+							"id": 696,
 							"name": "__type",
 							"kind": 65536,
 							"kindString": "Type literal",
 							"flags": {},
 							"children": [
 								{
-									"id": 383,
+									"id": 697,
 									"name": "eth",
-									"kind": 32,
-									"kindString": "Variable",
-									"flags": {},
-									"sources": [
-										{
-											"fileName": "chains/ethereum/ethereum/src/api.ts",
-											"line": 62,
-											"character": 5
-										}
-									],
-									"type": {
-										"type": "stringLiteral",
-										"value": "1.0"
-									},
-									"defaultValue": "\"1.0\""
-								},
-								{
-									"id": 387,
-									"name": "evm",
-									"kind": 32,
-									"kindString": "Variable",
-									"flags": {},
-									"sources": [
-										{
-											"fileName": "chains/ethereum/ethereum/src/api.ts",
-											"line": 66,
-											"character": 5
-										}
-									],
-									"type": {
-										"type": "stringLiteral",
-										"value": "1.0"
-									},
-									"defaultValue": "\"1.0\""
-								},
-								{
-									"id": 384,
-									"name": "net",
 									"kind": 32,
 									"kindString": "Variable",
 									"flags": {},
@@ -9541,8 +16118,8 @@
 									"defaultValue": "\"1.0\""
 								},
 								{
-									"id": 388,
-									"name": "personal",
+									"id": 701,
+									"name": "evm",
 									"kind": 32,
 									"kindString": "Variable",
 									"flags": {},
@@ -9550,7 +16127,7 @@
 										{
 											"fileName": "chains/ethereum/ethereum/src/api.ts",
 											"line": 67,
-											"character": 10
+											"character": 5
 										}
 									],
 									"type": {
@@ -9560,8 +16137,8 @@
 									"defaultValue": "\"1.0\""
 								},
 								{
-									"id": 385,
-									"name": "rpc",
+									"id": 698,
+									"name": "net",
 									"kind": 32,
 									"kindString": "Variable",
 									"flags": {},
@@ -9579,8 +16156,27 @@
 									"defaultValue": "\"1.0\""
 								},
 								{
-									"id": 386,
-									"name": "web3",
+									"id": 702,
+									"name": "personal",
+									"kind": 32,
+									"kindString": "Variable",
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "chains/ethereum/ethereum/src/api.ts",
+											"line": 68,
+											"character": 10
+										}
+									],
+									"type": {
+										"type": "stringLiteral",
+										"value": "1.0"
+									},
+									"defaultValue": "\"1.0\""
+								},
+								{
+									"id": 699,
+									"name": "rpc",
 									"kind": 32,
 									"kindString": "Variable",
 									"flags": {},
@@ -9588,6 +16184,25 @@
 										{
 											"fileName": "chains/ethereum/ethereum/src/api.ts",
 											"line": 65,
+											"character": 5
+										}
+									],
+									"type": {
+										"type": "stringLiteral",
+										"value": "1.0"
+									},
+									"defaultValue": "\"1.0\""
+								},
+								{
+									"id": 700,
+									"name": "web3",
+									"kind": 32,
+									"kindString": "Variable",
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "chains/ethereum/ethereum/src/api.ts",
+											"line": 66,
 											"character": 6
 										}
 									],
@@ -9603,12 +16218,12 @@
 									"title": "Variables",
 									"kind": 32,
 									"children": [
-										383,
-										387,
-										384,
-										388,
-										385,
-										386
+										697,
+										701,
+										698,
+										702,
+										699,
+										700
 									]
 								}
 							]
@@ -9617,7 +16232,7 @@
 					"defaultValue": "{\n  eth: \"1.0\",\n  net: \"1.0\",\n  rpc: \"1.0\",\n  web3: \"1.0\",\n  evm: \"1.0\",\n  personal: \"1.0\"\n} as const"
 				},
 				{
-					"id": 378,
+					"id": 692,
 					"name": "version",
 					"kind": 32,
 					"kindString": "Variable",
@@ -9625,7 +16240,7 @@
 					"sources": [
 						{
 							"fileName": "chains/ethereum/ethereum/src/api.ts",
-							"line": 55,
+							"line": 56,
 							"character": 15
 						}
 					],
@@ -9635,21 +16250,21 @@
 					}
 				},
 				{
-					"id": 390,
+					"id": 704,
 					"name": "assertExceptionalTransactions",
 					"kind": 64,
 					"kindString": "Function",
 					"flags": {},
 					"signatures": [
 						{
-							"id": 391,
+							"id": 705,
 							"name": "assertExceptionalTransactions",
 							"kind": 4096,
 							"kindString": "Call signature",
 							"flags": {},
 							"parameters": [
 								{
-									"id": 392,
+									"id": 706,
 									"name": "transactions",
 									"kind": 32768,
 									"kindString": "Parameter",
@@ -9658,7 +16273,7 @@
 										"type": "array",
 										"elementType": {
 											"type": "reference",
-											"name": "RuntimeTransaction"
+											"name": "TypedTransaction"
 										}
 									}
 								}
@@ -9672,7 +16287,7 @@
 					"sources": [
 						{
 							"fileName": "chains/ethereum/ethereum/src/api.ts",
-							"line": 79,
+							"line": 80,
 							"character": 38
 						}
 					]
@@ -9690,24 +16305,24 @@
 					"title": "Type aliases",
 					"kind": 4194304,
 					"children": [
-						389
+						703
 					]
 				},
 				{
 					"title": "Variables",
 					"kind": 32,
 					"children": [
-						379,
-						380,
-						381,
-						378
+						693,
+						694,
+						695,
+						692
 					]
 				},
 				{
 					"title": "Functions",
 					"kind": 64,
 					"children": [
-						390
+						704
 					]
 				}
 			],

--- a/docs/typedoc/api.json
+++ b/docs/typedoc/api.json
@@ -1926,7 +1926,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 42,
+																	"line": 43,
 																	"character": 21
 																}
 															],
@@ -1946,7 +1946,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 33,
+																	"line": 34,
 																	"character": 18
 																}
 															],
@@ -1966,7 +1966,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 39,
+																	"line": 40,
 																	"character": 17
 																}
 															],
@@ -1986,7 +1986,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 36,
+																	"line": 37,
 																	"character": 16
 																}
 															],
@@ -2006,7 +2006,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 37,
+																	"line": 38,
 																	"character": 15
 																}
 															],
@@ -2026,7 +2026,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 43,
+																	"line": 44,
 																	"character": 12
 																}
 															],
@@ -2046,7 +2046,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 32,
+																	"line": 33,
 																	"character": 17
 																}
 															],
@@ -2066,7 +2066,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 28,
+																	"line": 29,
 																	"character": 13
 																}
 															],
@@ -2086,7 +2086,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 40,
+																	"line": 41,
 																	"character": 15
 																}
 															],
@@ -2106,7 +2106,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 41,
+																	"line": 42,
 																	"character": 13
 																}
 															],
@@ -2126,7 +2126,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 35,
+																	"line": 36,
 																	"character": 14
 																}
 															],
@@ -2146,7 +2146,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 26,
+																	"line": 27,
 																	"character": 18
 																}
 															],
@@ -2166,7 +2166,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 31,
+																	"line": 32,
 																	"character": 20
 																}
 															],
@@ -2186,7 +2186,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 27,
+																	"line": 28,
 																	"character": 18
 																}
 															],
@@ -2206,7 +2206,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 23,
+																	"line": 24,
 																	"character": 12
 																}
 															],
@@ -2226,7 +2226,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 29,
+																	"line": 30,
 																	"character": 17
 																}
 															],
@@ -2246,7 +2246,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 38,
+																	"line": 39,
 																	"character": 17
 																}
 															],
@@ -2266,7 +2266,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 34,
+																	"line": 35,
 																	"character": 23
 																}
 															],
@@ -2286,7 +2286,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 24,
+																	"line": 25,
 																	"character": 20
 																}
 															],
@@ -3452,7 +3452,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 30,
+																	"line": 31,
 																	"character": 24
 																}
 															],
@@ -3472,7 +3472,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 25,
+																	"line": 26,
 																	"character": 14
 																}
 															],
@@ -3639,7 +3639,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 42,
+																	"line": 43,
 																	"character": 21
 																}
 															],
@@ -3659,7 +3659,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 33,
+																	"line": 34,
 																	"character": 18
 																}
 															],
@@ -3679,7 +3679,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 39,
+																	"line": 40,
 																	"character": 17
 																}
 															],
@@ -3699,7 +3699,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 36,
+																	"line": 37,
 																	"character": 16
 																}
 															],
@@ -3719,7 +3719,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 37,
+																	"line": 38,
 																	"character": 15
 																}
 															],
@@ -3739,7 +3739,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 43,
+																	"line": 44,
 																	"character": 12
 																}
 															],
@@ -3759,7 +3759,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 32,
+																	"line": 33,
 																	"character": 17
 																}
 															],
@@ -3779,7 +3779,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 28,
+																	"line": 29,
 																	"character": 13
 																}
 															],
@@ -3799,7 +3799,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 40,
+																	"line": 41,
 																	"character": 15
 																}
 															],
@@ -3819,7 +3819,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 41,
+																	"line": 42,
 																	"character": 13
 																}
 															],
@@ -3839,7 +3839,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 35,
+																	"line": 36,
 																	"character": 14
 																}
 															],
@@ -3859,7 +3859,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 26,
+																	"line": 27,
 																	"character": 18
 																}
 															],
@@ -3879,7 +3879,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 31,
+																	"line": 32,
 																	"character": 20
 																}
 															],
@@ -3899,7 +3899,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 27,
+																	"line": 28,
 																	"character": 18
 																}
 															],
@@ -3919,7 +3919,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 23,
+																	"line": 24,
 																	"character": 12
 																}
 															],
@@ -3939,7 +3939,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 29,
+																	"line": 30,
 																	"character": 17
 																}
 															],
@@ -3959,7 +3959,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 38,
+																	"line": 39,
 																	"character": 17
 																}
 															],
@@ -3979,7 +3979,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 34,
+																	"line": 35,
 																	"character": 23
 																}
 															],
@@ -3999,7 +3999,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 24,
+																	"line": 25,
 																	"character": 20
 																}
 															],
@@ -5165,7 +5165,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 30,
+																	"line": 31,
 																	"character": 24
 																}
 															],
@@ -5185,7 +5185,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 25,
+																	"line": 26,
 																	"character": 14
 																}
 															],
@@ -7946,7 +7946,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 42,
+																	"line": 43,
 																	"character": 21
 																}
 															],
@@ -7966,7 +7966,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 33,
+																	"line": 34,
 																	"character": 18
 																}
 															],
@@ -7986,7 +7986,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 39,
+																	"line": 40,
 																	"character": 17
 																}
 															],
@@ -8006,7 +8006,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 36,
+																	"line": 37,
 																	"character": 16
 																}
 															],
@@ -8026,7 +8026,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 37,
+																	"line": 38,
 																	"character": 15
 																}
 															],
@@ -8046,7 +8046,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 43,
+																	"line": 44,
 																	"character": 12
 																}
 															],
@@ -8066,7 +8066,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 32,
+																	"line": 33,
 																	"character": 17
 																}
 															],
@@ -8086,7 +8086,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 28,
+																	"line": 29,
 																	"character": 13
 																}
 															],
@@ -8106,7 +8106,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 40,
+																	"line": 41,
 																	"character": 15
 																}
 															],
@@ -8126,7 +8126,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 41,
+																	"line": 42,
 																	"character": 13
 																}
 															],
@@ -8146,7 +8146,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 35,
+																	"line": 36,
 																	"character": 14
 																}
 															],
@@ -8166,7 +8166,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 26,
+																	"line": 27,
 																	"character": 18
 																}
 															],
@@ -8186,7 +8186,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 31,
+																	"line": 32,
 																	"character": 20
 																}
 															],
@@ -8206,7 +8206,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 27,
+																	"line": 28,
 																	"character": 18
 																}
 															],
@@ -8226,7 +8226,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 23,
+																	"line": 24,
 																	"character": 12
 																}
 															],
@@ -8246,7 +8246,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 29,
+																	"line": 30,
 																	"character": 17
 																}
 															],
@@ -8266,7 +8266,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 38,
+																	"line": 39,
 																	"character": 17
 																}
 															],
@@ -8286,7 +8286,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 34,
+																	"line": 35,
 																	"character": 23
 																}
 															],
@@ -8306,7 +8306,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 24,
+																	"line": 25,
 																	"character": 20
 																}
 															],
@@ -9472,7 +9472,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 30,
+																	"line": 31,
 																	"character": 24
 																}
 															],
@@ -9492,7 +9492,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 25,
+																	"line": 26,
 																	"character": 14
 																}
 															],
@@ -9657,7 +9657,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 42,
+																	"line": 43,
 																	"character": 21
 																}
 															],
@@ -9677,7 +9677,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 33,
+																	"line": 34,
 																	"character": 18
 																}
 															],
@@ -9697,7 +9697,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 39,
+																	"line": 40,
 																	"character": 17
 																}
 															],
@@ -9717,7 +9717,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 36,
+																	"line": 37,
 																	"character": 16
 																}
 															],
@@ -9737,7 +9737,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 37,
+																	"line": 38,
 																	"character": 15
 																}
 															],
@@ -9757,7 +9757,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 43,
+																	"line": 44,
 																	"character": 12
 																}
 															],
@@ -9777,7 +9777,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 32,
+																	"line": 33,
 																	"character": 17
 																}
 															],
@@ -9797,7 +9797,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 28,
+																	"line": 29,
 																	"character": 13
 																}
 															],
@@ -9817,7 +9817,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 40,
+																	"line": 41,
 																	"character": 15
 																}
 															],
@@ -9837,7 +9837,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 41,
+																	"line": 42,
 																	"character": 13
 																}
 															],
@@ -9857,7 +9857,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 35,
+																	"line": 36,
 																	"character": 14
 																}
 															],
@@ -9877,7 +9877,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 26,
+																	"line": 27,
 																	"character": 18
 																}
 															],
@@ -9897,7 +9897,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 31,
+																	"line": 32,
 																	"character": 20
 																}
 															],
@@ -9917,7 +9917,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 27,
+																	"line": 28,
 																	"character": 18
 																}
 															],
@@ -9937,7 +9937,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 23,
+																	"line": 24,
 																	"character": 12
 																}
 															],
@@ -9957,7 +9957,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 29,
+																	"line": 30,
 																	"character": 17
 																}
 															],
@@ -9977,7 +9977,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 38,
+																	"line": 39,
 																	"character": 17
 																}
 															],
@@ -9997,7 +9997,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 34,
+																	"line": 35,
 																	"character": 23
 																}
 															],
@@ -10017,7 +10017,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 24,
+																	"line": 25,
 																	"character": 20
 																}
 															],
@@ -11183,7 +11183,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 30,
+																	"line": 31,
 																	"character": 24
 																}
 															],
@@ -11203,7 +11203,7 @@
 															"sources": [
 																{
 																	"fileName": "chains/ethereum/block/typings/src/block.d.ts",
-																	"line": 25,
+																	"line": 26,
 																	"character": 14
 																}
 															],

--- a/docs/typedoc/classes/_api_.ethereumapi.html
+++ b/docs/typedoc/classes/_api_.ethereumapi.html
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L120">chains/ethereum/ethereum/src/api.ts:120</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L120">chains/ethereum/ethereum/src/api.ts:120</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 					<div class="tsd-signature tsd-kind-icon">#blockchain<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Blockchain</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L119">chains/ethereum/ethereum/src/api.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L119">chains/ethereum/ethereum/src/api.ts:119</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -278,7 +278,7 @@
 					<div class="tsd-signature tsd-kind-icon">#filters<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string, Filter&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L116">chains/ethereum/ethereum/src/api.ts:116</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L116">chains/ethereum/ethereum/src/api.ts:116</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -288,7 +288,7 @@
 					<div class="tsd-signature tsd-kind-icon">#get<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = (id &#x3D;&gt; () &#x3D;&gt; Quantity.from(++id))(0)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L115">chains/ethereum/ethereum/src/api.ts:115</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L115">chains/ethereum/ethereum/src/api.ts:115</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -298,7 +298,7 @@
 					<div class="tsd-signature tsd-kind-icon">#options<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">EthereumInternalOptions</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L118">chains/ethereum/ethereum/src/api.ts:118</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L118">chains/ethereum/ethereum/src/api.ts:118</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -308,7 +308,7 @@
 					<div class="tsd-signature tsd-kind-icon">#subscriptions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">function</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string, Emittery.UnsubscribeFn&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L117">chains/ethereum/ethereum/src/api.ts:117</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L117">chains/ethereum/ethereum/src/api.ts:117</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -318,7 +318,7 @@
 					<div class="tsd-signature tsd-kind-icon">#wallet<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Wallet</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L120">chains/ethereum/ethereum/src/api.ts:120</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L120">chains/ethereum/ethereum/src/api.ts:120</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -335,7 +335,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L218">chains/ethereum/ethereum/src/api.ts:218</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L218">chains/ethereum/ethereum/src/api.ts:218</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -363,7 +363,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L231">chains/ethereum/ethereum/src/api.ts:231</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L231">chains/ethereum/ethereum/src/api.ts:231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -391,7 +391,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L203">chains/ethereum/ethereum/src/api.ts:203</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L203">chains/ethereum/ethereum/src/api.ts:203</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -434,7 +434,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L170">chains/ethereum/ethereum/src/api.ts:170</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L170">chains/ethereum/ethereum/src/api.ts:170</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -477,7 +477,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L187">chains/ethereum/ethereum/src/api.ts:187</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L187">chains/ethereum/ethereum/src/api.ts:187</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -526,7 +526,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L154">chains/ethereum/ethereum/src/api.ts:154</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L154">chains/ethereum/ethereum/src/api.ts:154</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -575,7 +575,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2576">chains/ethereum/ethereum/src/api.ts:2576</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2576">chains/ethereum/ethereum/src/api.ts:2576</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -664,7 +664,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2526">chains/ethereum/ethereum/src/api.ts:2526</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2526">chains/ethereum/ethereum/src/api.ts:2526</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -746,7 +746,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1328">chains/ethereum/ethereum/src/api.ts:1328</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1328">chains/ethereum/ethereum/src/api.ts:1328</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -775,7 +775,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1342">chains/ethereum/ethereum/src/api.ts:1342</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1342">chains/ethereum/ethereum/src/api.ts:1342</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -804,7 +804,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2413">chains/ethereum/ethereum/src/api.ts:2413</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2413">chains/ethereum/ethereum/src/api.ts:2413</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -871,7 +871,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1359">chains/ethereum/ethereum/src/api.ts:1359</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1359">chains/ethereum/ethereum/src/api.ts:1359</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -904,7 +904,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L831">chains/ethereum/ethereum/src/api.ts:831</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L831">chains/ethereum/ethereum/src/api.ts:831</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -933,7 +933,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L738">chains/ethereum/ethereum/src/api.ts:738</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L738">chains/ethereum/ethereum/src/api.ts:738</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -992,7 +992,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1314">chains/ethereum/ethereum/src/api.ts:1314</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1314">chains/ethereum/ethereum/src/api.ts:1314</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1021,7 +1021,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1379">chains/ethereum/ethereum/src/api.ts:1379</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1379">chains/ethereum/ethereum/src/api.ts:1379</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1067,7 +1067,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L929">chains/ethereum/ethereum/src/api.ts:929</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L929">chains/ethereum/ethereum/src/api.ts:929</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1150,7 +1150,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L871">chains/ethereum/ethereum/src/api.ts:871</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L871">chains/ethereum/ethereum/src/api.ts:871</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1218,7 +1218,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L985">chains/ethereum/ethereum/src/api.ts:985</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L985">chains/ethereum/ethereum/src/api.ts:985</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1272,7 +1272,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L948">chains/ethereum/ethereum/src/api.ts:948</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L948">chains/ethereum/ethereum/src/api.ts:948</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1307,7 +1307,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1418">chains/ethereum/ethereum/src/api.ts:1418</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1418">chains/ethereum/ethereum/src/api.ts:1418</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1367,7 +1367,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1007">chains/ethereum/ethereum/src/api.ts:1007</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1007">chains/ethereum/ethereum/src/api.ts:1007</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1396,7 +1396,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2217">chains/ethereum/ethereum/src/api.ts:2217</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2217">chains/ethereum/ethereum/src/api.ts:2217</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1477,7 +1477,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2287">chains/ethereum/ethereum/src/api.ts:2287</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2287">chains/ethereum/ethereum/src/api.ts:2287</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1539,7 +1539,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2344">chains/ethereum/ethereum/src/api.ts:2344</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2344">chains/ethereum/ethereum/src/api.ts:2344</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1614,7 +1614,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1453">chains/ethereum/ethereum/src/api.ts:1453</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1453">chains/ethereum/ethereum/src/api.ts:1453</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1681,7 +1681,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1045">chains/ethereum/ethereum/src/api.ts:1045</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1045">chains/ethereum/ethereum/src/api.ts:1045</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1747,7 +1747,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1091">chains/ethereum/ethereum/src/api.ts:1091</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1091">chains/ethereum/ethereum/src/api.ts:1091</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1813,7 +1813,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1526">chains/ethereum/ethereum/src/api.ts:1526</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1526">chains/ethereum/ethereum/src/api.ts:1526</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1872,7 +1872,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2367">chains/ethereum/ethereum/src/api.ts:2367</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2367">chains/ethereum/ethereum/src/api.ts:2367</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1922,7 +1922,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1563">chains/ethereum/ethereum/src/api.ts:1563</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1563">chains/ethereum/ethereum/src/api.ts:1563</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1966,7 +1966,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1171">chains/ethereum/ethereum/src/api.ts:1171</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1171">chains/ethereum/ethereum/src/api.ts:1171</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2033,7 +2033,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1210">chains/ethereum/ethereum/src/api.ts:1210</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1210">chains/ethereum/ethereum/src/api.ts:1210</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2099,7 +2099,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1116">chains/ethereum/ethereum/src/api.ts:1116</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1116">chains/ethereum/ethereum/src/api.ts:1116</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2138,7 +2138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1131">chains/ethereum/ethereum/src/api.ts:1131</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1131">chains/ethereum/ethereum/src/api.ts:1131</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2176,7 +2176,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1231">chains/ethereum/ethereum/src/api.ts:1231</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1231">chains/ethereum/ethereum/src/api.ts:1231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2216,7 +2216,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1300">chains/ethereum/ethereum/src/api.ts:1300</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1300">chains/ethereum/ethereum/src/api.ts:1300</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2245,7 +2245,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1285">chains/ethereum/ethereum/src/api.ts:1285</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1285">chains/ethereum/ethereum/src/api.ts:1285</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2274,7 +2274,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2053">chains/ethereum/ethereum/src/api.ts:2053</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2053">chains/ethereum/ethereum/src/api.ts:2053</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2304,7 +2304,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2139">chains/ethereum/ethereum/src/api.ts:2139</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2139">chains/ethereum/ethereum/src/api.ts:2139</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2373,7 +2373,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2080">chains/ethereum/ethereum/src/api.ts:2080</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2080">chains/ethereum/ethereum/src/api.ts:2080</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2403,7 +2403,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L796">chains/ethereum/ethereum/src/api.ts:796</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L796">chains/ethereum/ethereum/src/api.ts:796</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2432,7 +2432,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1738">chains/ethereum/ethereum/src/api.ts:1738</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1738">chains/ethereum/ethereum/src/api.ts:1738</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2472,7 +2472,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1632">chains/ethereum/ethereum/src/api.ts:1632</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1632">chains/ethereum/ethereum/src/api.ts:1632</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2522,7 +2522,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1771">chains/ethereum/ethereum/src/api.ts:1771</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1771">chains/ethereum/ethereum/src/api.ts:1771</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2578,7 +2578,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1701">chains/ethereum/ethereum/src/api.ts:1701</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1701">chains/ethereum/ethereum/src/api.ts:1701</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2626,7 +2626,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1841">chains/ethereum/ethereum/src/api.ts:1841</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1841">chains/ethereum/ethereum/src/api.ts:1841</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2713,7 +2713,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1271">chains/ethereum/ethereum/src/api.ts:1271</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1271">chains/ethereum/ethereum/src/api.ts:1271</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2759,7 +2759,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1252">chains/ethereum/ethereum/src/api.ts:1252</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1252">chains/ethereum/ethereum/src/api.ts:1252</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2813,7 +2813,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1885">chains/ethereum/ethereum/src/api.ts:1885</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1885">chains/ethereum/ethereum/src/api.ts:1885</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2844,7 +2844,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1898">chains/ethereum/ethereum/src/api.ts:1898</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1898">chains/ethereum/ethereum/src/api.ts:1898</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2886,7 +2886,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L817">chains/ethereum/ethereum/src/api.ts:817</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L817">chains/ethereum/ethereum/src/api.ts:817</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2921,7 +2921,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2243">chains/ethereum/ethereum/src/api.ts:2243</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2243">chains/ethereum/ethereum/src/api.ts:2243</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2962,7 +2962,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2029">chains/ethereum/ethereum/src/api.ts:2029</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2029">chains/ethereum/ethereum/src/api.ts:2029</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3002,7 +3002,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L353">chains/ethereum/ethereum/src/api.ts:353</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L353">chains/ethereum/ethereum/src/api.ts:353</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3041,7 +3041,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L520">chains/ethereum/ethereum/src/api.ts:520</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L520">chains/ethereum/ethereum/src/api.ts:520</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3085,7 +3085,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L258">chains/ethereum/ethereum/src/api.ts:258</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L258">chains/ethereum/ethereum/src/api.ts:258</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3121,7 +3121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L259">chains/ethereum/ethereum/src/api.ts:259</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L259">chains/ethereum/ethereum/src/api.ts:259</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -3152,7 +3152,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L435">chains/ethereum/ethereum/src/api.ts:435</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L435">chains/ethereum/ethereum/src/api.ts:435</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3216,7 +3216,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L321">chains/ethereum/ethereum/src/api.ts:321</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L321">chains/ethereum/ethereum/src/api.ts:321</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3264,7 +3264,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L380">chains/ethereum/ethereum/src/api.ts:380</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L380">chains/ethereum/ethereum/src/api.ts:380</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3308,7 +3308,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L476">chains/ethereum/ethereum/src/api.ts:476</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L476">chains/ethereum/ethereum/src/api.ts:476</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3363,7 +3363,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L499">chains/ethereum/ethereum/src/api.ts:499</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L499">chains/ethereum/ethereum/src/api.ts:499</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3413,7 +3413,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L607">chains/ethereum/ethereum/src/api.ts:607</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L607">chains/ethereum/ethereum/src/api.ts:607</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3451,7 +3451,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L622">chains/ethereum/ethereum/src/api.ts:622</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L622">chains/ethereum/ethereum/src/api.ts:622</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3488,7 +3488,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L591">chains/ethereum/ethereum/src/api.ts:591</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L591">chains/ethereum/ethereum/src/api.ts:591</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3527,7 +3527,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L549">chains/ethereum/ethereum/src/api.ts:549</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L549">chains/ethereum/ethereum/src/api.ts:549</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3570,7 +3570,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L574">chains/ethereum/ethereum/src/api.ts:574</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L574">chains/ethereum/ethereum/src/api.ts:574</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3602,7 +3602,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L688">chains/ethereum/ethereum/src/api.ts:688</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L688">chains/ethereum/ethereum/src/api.ts:688</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3630,7 +3630,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L701">chains/ethereum/ethereum/src/api.ts:701</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L701">chains/ethereum/ethereum/src/api.ts:701</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3658,7 +3658,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L675">chains/ethereum/ethereum/src/api.ts:675</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L675">chains/ethereum/ethereum/src/api.ts:675</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3687,7 +3687,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2658">chains/ethereum/ethereum/src/api.ts:2658</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2658">chains/ethereum/ethereum/src/api.ts:2658</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3734,7 +3734,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2605">chains/ethereum/ethereum/src/api.ts:2605</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2605">chains/ethereum/ethereum/src/api.ts:2605</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3763,7 +3763,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2689">chains/ethereum/ethereum/src/api.ts:2689</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2689">chains/ethereum/ethereum/src/api.ts:2689</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3802,7 +3802,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2623">chains/ethereum/ethereum/src/api.ts:2623</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2623">chains/ethereum/ethereum/src/api.ts:2623</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3842,7 +3842,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2762">chains/ethereum/ethereum/src/api.ts:2762</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2762">chains/ethereum/ethereum/src/api.ts:2762</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3902,7 +3902,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2815">chains/ethereum/ethereum/src/api.ts:2815</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2815">chains/ethereum/ethereum/src/api.ts:2815</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3961,7 +3961,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2718">chains/ethereum/ethereum/src/api.ts:2718</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2718">chains/ethereum/ethereum/src/api.ts:2718</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4020,7 +4020,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2849">chains/ethereum/ethereum/src/api.ts:2849</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2849">chains/ethereum/ethereum/src/api.ts:2849</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4048,7 +4048,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2906">chains/ethereum/ethereum/src/api.ts:2906</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2906">chains/ethereum/ethereum/src/api.ts:2906</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4085,7 +4085,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2954">chains/ethereum/ethereum/src/api.ts:2954</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2954">chains/ethereum/ethereum/src/api.ts:2954</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4122,7 +4122,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2969">chains/ethereum/ethereum/src/api.ts:2969</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2969">chains/ethereum/ethereum/src/api.ts:2969</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4159,7 +4159,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2881">chains/ethereum/ethereum/src/api.ts:2881</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2881">chains/ethereum/ethereum/src/api.ts:2881</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4196,7 +4196,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2923">chains/ethereum/ethereum/src/api.ts:2923</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2923">chains/ethereum/ethereum/src/api.ts:2923</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4240,7 +4240,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2891">chains/ethereum/ethereum/src/api.ts:2891</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2891">chains/ethereum/ethereum/src/api.ts:2891</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4263,7 +4263,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2866">chains/ethereum/ethereum/src/api.ts:2866</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2866">chains/ethereum/ethereum/src/api.ts:2866</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4293,7 +4293,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2984">chains/ethereum/ethereum/src/api.ts:2984</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2984">chains/ethereum/ethereum/src/api.ts:2984</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4327,7 +4327,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2939">chains/ethereum/ethereum/src/api.ts:2939</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2939">chains/ethereum/ethereum/src/api.ts:2939</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4365,7 +4365,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2998">chains/ethereum/ethereum/src/api.ts:2998</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2998">chains/ethereum/ethereum/src/api.ts:2998</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4393,7 +4393,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L643">chains/ethereum/ethereum/src/api.ts:643</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L643">chains/ethereum/ethereum/src/api.ts:643</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4421,7 +4421,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L659">chains/ethereum/ethereum/src/api.ts:659</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L659">chains/ethereum/ethereum/src/api.ts:659</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/typedoc/classes/_api_.ethereumapi.html
+++ b/docs/typedoc/classes/_api_.ethereumapi.html
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L120">chains/ethereum/ethereum/src/api.ts:120</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L120">chains/ethereum/ethereum/src/api.ts:120</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 					<div class="tsd-signature tsd-kind-icon">#blockchain<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Blockchain</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L119">chains/ethereum/ethereum/src/api.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L119">chains/ethereum/ethereum/src/api.ts:119</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -278,7 +278,7 @@
 					<div class="tsd-signature tsd-kind-icon">#filters<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string, Filter&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L116">chains/ethereum/ethereum/src/api.ts:116</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L116">chains/ethereum/ethereum/src/api.ts:116</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -288,7 +288,7 @@
 					<div class="tsd-signature tsd-kind-icon">#get<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = (id &#x3D;&gt; () &#x3D;&gt; Quantity.from(++id))(0)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L115">chains/ethereum/ethereum/src/api.ts:115</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L115">chains/ethereum/ethereum/src/api.ts:115</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -298,7 +298,7 @@
 					<div class="tsd-signature tsd-kind-icon">#options<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">EthereumInternalOptions</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L118">chains/ethereum/ethereum/src/api.ts:118</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L118">chains/ethereum/ethereum/src/api.ts:118</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -308,7 +308,7 @@
 					<div class="tsd-signature tsd-kind-icon">#subscriptions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">function</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string, Emittery.UnsubscribeFn&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L117">chains/ethereum/ethereum/src/api.ts:117</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L117">chains/ethereum/ethereum/src/api.ts:117</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -318,7 +318,7 @@
 					<div class="tsd-signature tsd-kind-icon">#wallet<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Wallet</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L120">chains/ethereum/ethereum/src/api.ts:120</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L120">chains/ethereum/ethereum/src/api.ts:120</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -335,7 +335,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L218">chains/ethereum/ethereum/src/api.ts:218</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L218">chains/ethereum/ethereum/src/api.ts:218</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -363,7 +363,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L231">chains/ethereum/ethereum/src/api.ts:231</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L231">chains/ethereum/ethereum/src/api.ts:231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -391,7 +391,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L203">chains/ethereum/ethereum/src/api.ts:203</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L203">chains/ethereum/ethereum/src/api.ts:203</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -434,7 +434,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L170">chains/ethereum/ethereum/src/api.ts:170</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L170">chains/ethereum/ethereum/src/api.ts:170</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -477,7 +477,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L187">chains/ethereum/ethereum/src/api.ts:187</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L187">chains/ethereum/ethereum/src/api.ts:187</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -526,7 +526,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L154">chains/ethereum/ethereum/src/api.ts:154</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L154">chains/ethereum/ethereum/src/api.ts:154</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -575,7 +575,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2576">chains/ethereum/ethereum/src/api.ts:2576</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2576">chains/ethereum/ethereum/src/api.ts:2576</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -664,7 +664,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2526">chains/ethereum/ethereum/src/api.ts:2526</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2526">chains/ethereum/ethereum/src/api.ts:2526</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -746,7 +746,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1328">chains/ethereum/ethereum/src/api.ts:1328</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1328">chains/ethereum/ethereum/src/api.ts:1328</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -775,7 +775,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1342">chains/ethereum/ethereum/src/api.ts:1342</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1342">chains/ethereum/ethereum/src/api.ts:1342</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -804,7 +804,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2413">chains/ethereum/ethereum/src/api.ts:2413</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2413">chains/ethereum/ethereum/src/api.ts:2413</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -871,7 +871,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1359">chains/ethereum/ethereum/src/api.ts:1359</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1359">chains/ethereum/ethereum/src/api.ts:1359</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -904,7 +904,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L831">chains/ethereum/ethereum/src/api.ts:831</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L831">chains/ethereum/ethereum/src/api.ts:831</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -933,7 +933,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L738">chains/ethereum/ethereum/src/api.ts:738</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L738">chains/ethereum/ethereum/src/api.ts:738</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -992,7 +992,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1314">chains/ethereum/ethereum/src/api.ts:1314</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1314">chains/ethereum/ethereum/src/api.ts:1314</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1021,7 +1021,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1379">chains/ethereum/ethereum/src/api.ts:1379</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1379">chains/ethereum/ethereum/src/api.ts:1379</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1067,7 +1067,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L929">chains/ethereum/ethereum/src/api.ts:929</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L929">chains/ethereum/ethereum/src/api.ts:929</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1150,7 +1150,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L871">chains/ethereum/ethereum/src/api.ts:871</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L871">chains/ethereum/ethereum/src/api.ts:871</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1218,7 +1218,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L985">chains/ethereum/ethereum/src/api.ts:985</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L985">chains/ethereum/ethereum/src/api.ts:985</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1272,7 +1272,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L948">chains/ethereum/ethereum/src/api.ts:948</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L948">chains/ethereum/ethereum/src/api.ts:948</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1307,7 +1307,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1418">chains/ethereum/ethereum/src/api.ts:1418</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1418">chains/ethereum/ethereum/src/api.ts:1418</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1367,7 +1367,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1007">chains/ethereum/ethereum/src/api.ts:1007</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1007">chains/ethereum/ethereum/src/api.ts:1007</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1396,7 +1396,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2217">chains/ethereum/ethereum/src/api.ts:2217</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2217">chains/ethereum/ethereum/src/api.ts:2217</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1477,7 +1477,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2287">chains/ethereum/ethereum/src/api.ts:2287</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2287">chains/ethereum/ethereum/src/api.ts:2287</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1539,7 +1539,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2344">chains/ethereum/ethereum/src/api.ts:2344</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2344">chains/ethereum/ethereum/src/api.ts:2344</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1614,7 +1614,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1453">chains/ethereum/ethereum/src/api.ts:1453</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1453">chains/ethereum/ethereum/src/api.ts:1453</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1681,7 +1681,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1045">chains/ethereum/ethereum/src/api.ts:1045</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1045">chains/ethereum/ethereum/src/api.ts:1045</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1747,7 +1747,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1091">chains/ethereum/ethereum/src/api.ts:1091</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1091">chains/ethereum/ethereum/src/api.ts:1091</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1813,7 +1813,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1526">chains/ethereum/ethereum/src/api.ts:1526</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1526">chains/ethereum/ethereum/src/api.ts:1526</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1872,7 +1872,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2367">chains/ethereum/ethereum/src/api.ts:2367</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2367">chains/ethereum/ethereum/src/api.ts:2367</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1922,7 +1922,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1563">chains/ethereum/ethereum/src/api.ts:1563</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1563">chains/ethereum/ethereum/src/api.ts:1563</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1966,7 +1966,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1171">chains/ethereum/ethereum/src/api.ts:1171</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1171">chains/ethereum/ethereum/src/api.ts:1171</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2033,7 +2033,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1210">chains/ethereum/ethereum/src/api.ts:1210</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1210">chains/ethereum/ethereum/src/api.ts:1210</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2099,7 +2099,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1116">chains/ethereum/ethereum/src/api.ts:1116</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1116">chains/ethereum/ethereum/src/api.ts:1116</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2138,7 +2138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1131">chains/ethereum/ethereum/src/api.ts:1131</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1131">chains/ethereum/ethereum/src/api.ts:1131</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2176,7 +2176,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1231">chains/ethereum/ethereum/src/api.ts:1231</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1231">chains/ethereum/ethereum/src/api.ts:1231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2216,7 +2216,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1300">chains/ethereum/ethereum/src/api.ts:1300</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1300">chains/ethereum/ethereum/src/api.ts:1300</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2245,7 +2245,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1285">chains/ethereum/ethereum/src/api.ts:1285</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1285">chains/ethereum/ethereum/src/api.ts:1285</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2274,7 +2274,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2053">chains/ethereum/ethereum/src/api.ts:2053</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2053">chains/ethereum/ethereum/src/api.ts:2053</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2304,7 +2304,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2139">chains/ethereum/ethereum/src/api.ts:2139</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2139">chains/ethereum/ethereum/src/api.ts:2139</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2373,7 +2373,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2080">chains/ethereum/ethereum/src/api.ts:2080</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2080">chains/ethereum/ethereum/src/api.ts:2080</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2403,7 +2403,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L796">chains/ethereum/ethereum/src/api.ts:796</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L796">chains/ethereum/ethereum/src/api.ts:796</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2432,7 +2432,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1738">chains/ethereum/ethereum/src/api.ts:1738</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1738">chains/ethereum/ethereum/src/api.ts:1738</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2472,7 +2472,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1632">chains/ethereum/ethereum/src/api.ts:1632</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1632">chains/ethereum/ethereum/src/api.ts:1632</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2522,7 +2522,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1771">chains/ethereum/ethereum/src/api.ts:1771</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1771">chains/ethereum/ethereum/src/api.ts:1771</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2578,7 +2578,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1701">chains/ethereum/ethereum/src/api.ts:1701</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1701">chains/ethereum/ethereum/src/api.ts:1701</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2626,7 +2626,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1841">chains/ethereum/ethereum/src/api.ts:1841</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1841">chains/ethereum/ethereum/src/api.ts:1841</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2713,7 +2713,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1271">chains/ethereum/ethereum/src/api.ts:1271</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1271">chains/ethereum/ethereum/src/api.ts:1271</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2759,7 +2759,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1252">chains/ethereum/ethereum/src/api.ts:1252</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1252">chains/ethereum/ethereum/src/api.ts:1252</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2813,7 +2813,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1885">chains/ethereum/ethereum/src/api.ts:1885</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1885">chains/ethereum/ethereum/src/api.ts:1885</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2844,7 +2844,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1898">chains/ethereum/ethereum/src/api.ts:1898</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L1898">chains/ethereum/ethereum/src/api.ts:1898</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2886,7 +2886,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L817">chains/ethereum/ethereum/src/api.ts:817</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L817">chains/ethereum/ethereum/src/api.ts:817</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2921,7 +2921,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2243">chains/ethereum/ethereum/src/api.ts:2243</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2243">chains/ethereum/ethereum/src/api.ts:2243</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2962,7 +2962,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2029">chains/ethereum/ethereum/src/api.ts:2029</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2029">chains/ethereum/ethereum/src/api.ts:2029</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3002,7 +3002,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L353">chains/ethereum/ethereum/src/api.ts:353</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L353">chains/ethereum/ethereum/src/api.ts:353</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3041,7 +3041,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L520">chains/ethereum/ethereum/src/api.ts:520</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L520">chains/ethereum/ethereum/src/api.ts:520</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3085,7 +3085,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L258">chains/ethereum/ethereum/src/api.ts:258</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L258">chains/ethereum/ethereum/src/api.ts:258</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3121,7 +3121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L259">chains/ethereum/ethereum/src/api.ts:259</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L259">chains/ethereum/ethereum/src/api.ts:259</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -3152,7 +3152,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L435">chains/ethereum/ethereum/src/api.ts:435</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L435">chains/ethereum/ethereum/src/api.ts:435</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3216,7 +3216,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L321">chains/ethereum/ethereum/src/api.ts:321</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L321">chains/ethereum/ethereum/src/api.ts:321</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3264,7 +3264,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L380">chains/ethereum/ethereum/src/api.ts:380</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L380">chains/ethereum/ethereum/src/api.ts:380</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3308,7 +3308,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L476">chains/ethereum/ethereum/src/api.ts:476</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L476">chains/ethereum/ethereum/src/api.ts:476</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3363,7 +3363,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L499">chains/ethereum/ethereum/src/api.ts:499</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L499">chains/ethereum/ethereum/src/api.ts:499</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3413,7 +3413,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L607">chains/ethereum/ethereum/src/api.ts:607</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L607">chains/ethereum/ethereum/src/api.ts:607</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3451,7 +3451,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L622">chains/ethereum/ethereum/src/api.ts:622</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L622">chains/ethereum/ethereum/src/api.ts:622</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3488,7 +3488,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L591">chains/ethereum/ethereum/src/api.ts:591</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L591">chains/ethereum/ethereum/src/api.ts:591</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3527,7 +3527,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L549">chains/ethereum/ethereum/src/api.ts:549</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L549">chains/ethereum/ethereum/src/api.ts:549</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3570,7 +3570,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L574">chains/ethereum/ethereum/src/api.ts:574</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L574">chains/ethereum/ethereum/src/api.ts:574</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3602,7 +3602,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L688">chains/ethereum/ethereum/src/api.ts:688</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L688">chains/ethereum/ethereum/src/api.ts:688</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3630,7 +3630,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L701">chains/ethereum/ethereum/src/api.ts:701</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L701">chains/ethereum/ethereum/src/api.ts:701</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3658,7 +3658,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L675">chains/ethereum/ethereum/src/api.ts:675</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L675">chains/ethereum/ethereum/src/api.ts:675</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3687,7 +3687,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2658">chains/ethereum/ethereum/src/api.ts:2658</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2658">chains/ethereum/ethereum/src/api.ts:2658</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3734,7 +3734,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2605">chains/ethereum/ethereum/src/api.ts:2605</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2605">chains/ethereum/ethereum/src/api.ts:2605</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3763,7 +3763,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2689">chains/ethereum/ethereum/src/api.ts:2689</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2689">chains/ethereum/ethereum/src/api.ts:2689</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3802,7 +3802,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2623">chains/ethereum/ethereum/src/api.ts:2623</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2623">chains/ethereum/ethereum/src/api.ts:2623</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3842,7 +3842,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2762">chains/ethereum/ethereum/src/api.ts:2762</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2762">chains/ethereum/ethereum/src/api.ts:2762</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3902,7 +3902,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2815">chains/ethereum/ethereum/src/api.ts:2815</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2815">chains/ethereum/ethereum/src/api.ts:2815</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3961,7 +3961,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2718">chains/ethereum/ethereum/src/api.ts:2718</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2718">chains/ethereum/ethereum/src/api.ts:2718</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4020,7 +4020,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2849">chains/ethereum/ethereum/src/api.ts:2849</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2849">chains/ethereum/ethereum/src/api.ts:2849</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4048,7 +4048,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2906">chains/ethereum/ethereum/src/api.ts:2906</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2906">chains/ethereum/ethereum/src/api.ts:2906</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4085,7 +4085,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2954">chains/ethereum/ethereum/src/api.ts:2954</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2954">chains/ethereum/ethereum/src/api.ts:2954</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4122,7 +4122,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2969">chains/ethereum/ethereum/src/api.ts:2969</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2969">chains/ethereum/ethereum/src/api.ts:2969</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4159,7 +4159,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2881">chains/ethereum/ethereum/src/api.ts:2881</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2881">chains/ethereum/ethereum/src/api.ts:2881</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4196,7 +4196,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2923">chains/ethereum/ethereum/src/api.ts:2923</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2923">chains/ethereum/ethereum/src/api.ts:2923</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4240,7 +4240,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2891">chains/ethereum/ethereum/src/api.ts:2891</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2891">chains/ethereum/ethereum/src/api.ts:2891</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4263,7 +4263,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2866">chains/ethereum/ethereum/src/api.ts:2866</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2866">chains/ethereum/ethereum/src/api.ts:2866</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4293,7 +4293,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2984">chains/ethereum/ethereum/src/api.ts:2984</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2984">chains/ethereum/ethereum/src/api.ts:2984</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4327,7 +4327,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2939">chains/ethereum/ethereum/src/api.ts:2939</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2939">chains/ethereum/ethereum/src/api.ts:2939</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4365,7 +4365,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2998">chains/ethereum/ethereum/src/api.ts:2998</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L2998">chains/ethereum/ethereum/src/api.ts:2998</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4393,7 +4393,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L643">chains/ethereum/ethereum/src/api.ts:643</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L643">chains/ethereum/ethereum/src/api.ts:643</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4421,7 +4421,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L659">chains/ethereum/ethereum/src/api.ts:659</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L659">chains/ethereum/ethereum/src/api.ts:659</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/typedoc/classes/_api_.ethereumapi.html
+++ b/docs/typedoc/classes/_api_.ethereumapi.html
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L120">chains/ethereum/ethereum/src/api.ts:120</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L120">chains/ethereum/ethereum/src/api.ts:120</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 					<div class="tsd-signature tsd-kind-icon">#blockchain<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Blockchain</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L119">chains/ethereum/ethereum/src/api.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L119">chains/ethereum/ethereum/src/api.ts:119</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -278,7 +278,7 @@
 					<div class="tsd-signature tsd-kind-icon">#filters<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string, Filter&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L116">chains/ethereum/ethereum/src/api.ts:116</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L116">chains/ethereum/ethereum/src/api.ts:116</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -288,7 +288,7 @@
 					<div class="tsd-signature tsd-kind-icon">#get<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = (id &#x3D;&gt; () &#x3D;&gt; Quantity.from(++id))(0)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L115">chains/ethereum/ethereum/src/api.ts:115</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L115">chains/ethereum/ethereum/src/api.ts:115</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -298,7 +298,7 @@
 					<div class="tsd-signature tsd-kind-icon">#options<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">EthereumInternalOptions</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L118">chains/ethereum/ethereum/src/api.ts:118</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L118">chains/ethereum/ethereum/src/api.ts:118</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -308,7 +308,7 @@
 					<div class="tsd-signature tsd-kind-icon">#subscriptions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">function</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string, Emittery.UnsubscribeFn&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L117">chains/ethereum/ethereum/src/api.ts:117</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L117">chains/ethereum/ethereum/src/api.ts:117</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -318,7 +318,7 @@
 					<div class="tsd-signature tsd-kind-icon">#wallet<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Wallet</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L120">chains/ethereum/ethereum/src/api.ts:120</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L120">chains/ethereum/ethereum/src/api.ts:120</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -335,7 +335,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L218">chains/ethereum/ethereum/src/api.ts:218</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L218">chains/ethereum/ethereum/src/api.ts:218</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -363,7 +363,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L231">chains/ethereum/ethereum/src/api.ts:231</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L231">chains/ethereum/ethereum/src/api.ts:231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -391,7 +391,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L203">chains/ethereum/ethereum/src/api.ts:203</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L203">chains/ethereum/ethereum/src/api.ts:203</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -434,7 +434,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L170">chains/ethereum/ethereum/src/api.ts:170</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L170">chains/ethereum/ethereum/src/api.ts:170</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -477,7 +477,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L187">chains/ethereum/ethereum/src/api.ts:187</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L187">chains/ethereum/ethereum/src/api.ts:187</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -526,7 +526,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L154">chains/ethereum/ethereum/src/api.ts:154</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L154">chains/ethereum/ethereum/src/api.ts:154</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -575,7 +575,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2576">chains/ethereum/ethereum/src/api.ts:2576</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2576">chains/ethereum/ethereum/src/api.ts:2576</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -664,7 +664,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2526">chains/ethereum/ethereum/src/api.ts:2526</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2526">chains/ethereum/ethereum/src/api.ts:2526</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -746,7 +746,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1328">chains/ethereum/ethereum/src/api.ts:1328</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1328">chains/ethereum/ethereum/src/api.ts:1328</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -775,7 +775,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1342">chains/ethereum/ethereum/src/api.ts:1342</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1342">chains/ethereum/ethereum/src/api.ts:1342</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -804,7 +804,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2413">chains/ethereum/ethereum/src/api.ts:2413</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2413">chains/ethereum/ethereum/src/api.ts:2413</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -871,7 +871,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1359">chains/ethereum/ethereum/src/api.ts:1359</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1359">chains/ethereum/ethereum/src/api.ts:1359</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -904,7 +904,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L831">chains/ethereum/ethereum/src/api.ts:831</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L831">chains/ethereum/ethereum/src/api.ts:831</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -933,7 +933,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L738">chains/ethereum/ethereum/src/api.ts:738</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L738">chains/ethereum/ethereum/src/api.ts:738</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -992,7 +992,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1314">chains/ethereum/ethereum/src/api.ts:1314</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1314">chains/ethereum/ethereum/src/api.ts:1314</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1021,7 +1021,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1379">chains/ethereum/ethereum/src/api.ts:1379</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1379">chains/ethereum/ethereum/src/api.ts:1379</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1067,7 +1067,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L929">chains/ethereum/ethereum/src/api.ts:929</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L929">chains/ethereum/ethereum/src/api.ts:929</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1150,7 +1150,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L871">chains/ethereum/ethereum/src/api.ts:871</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L871">chains/ethereum/ethereum/src/api.ts:871</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1218,7 +1218,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L985">chains/ethereum/ethereum/src/api.ts:985</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L985">chains/ethereum/ethereum/src/api.ts:985</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1272,7 +1272,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L948">chains/ethereum/ethereum/src/api.ts:948</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L948">chains/ethereum/ethereum/src/api.ts:948</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1307,7 +1307,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1418">chains/ethereum/ethereum/src/api.ts:1418</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1418">chains/ethereum/ethereum/src/api.ts:1418</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1367,7 +1367,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1007">chains/ethereum/ethereum/src/api.ts:1007</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1007">chains/ethereum/ethereum/src/api.ts:1007</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1396,7 +1396,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2217">chains/ethereum/ethereum/src/api.ts:2217</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2217">chains/ethereum/ethereum/src/api.ts:2217</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1477,7 +1477,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2287">chains/ethereum/ethereum/src/api.ts:2287</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2287">chains/ethereum/ethereum/src/api.ts:2287</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1539,7 +1539,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2344">chains/ethereum/ethereum/src/api.ts:2344</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2344">chains/ethereum/ethereum/src/api.ts:2344</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1614,7 +1614,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1453">chains/ethereum/ethereum/src/api.ts:1453</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1453">chains/ethereum/ethereum/src/api.ts:1453</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1681,7 +1681,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1045">chains/ethereum/ethereum/src/api.ts:1045</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1045">chains/ethereum/ethereum/src/api.ts:1045</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1747,7 +1747,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1091">chains/ethereum/ethereum/src/api.ts:1091</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1091">chains/ethereum/ethereum/src/api.ts:1091</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1813,7 +1813,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1526">chains/ethereum/ethereum/src/api.ts:1526</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1526">chains/ethereum/ethereum/src/api.ts:1526</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1872,7 +1872,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2367">chains/ethereum/ethereum/src/api.ts:2367</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2367">chains/ethereum/ethereum/src/api.ts:2367</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1922,7 +1922,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1563">chains/ethereum/ethereum/src/api.ts:1563</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1563">chains/ethereum/ethereum/src/api.ts:1563</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1966,7 +1966,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1171">chains/ethereum/ethereum/src/api.ts:1171</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1171">chains/ethereum/ethereum/src/api.ts:1171</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2033,7 +2033,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1210">chains/ethereum/ethereum/src/api.ts:1210</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1210">chains/ethereum/ethereum/src/api.ts:1210</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2099,7 +2099,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1116">chains/ethereum/ethereum/src/api.ts:1116</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1116">chains/ethereum/ethereum/src/api.ts:1116</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2138,7 +2138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1131">chains/ethereum/ethereum/src/api.ts:1131</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1131">chains/ethereum/ethereum/src/api.ts:1131</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2176,7 +2176,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1231">chains/ethereum/ethereum/src/api.ts:1231</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1231">chains/ethereum/ethereum/src/api.ts:1231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2216,7 +2216,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1300">chains/ethereum/ethereum/src/api.ts:1300</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1300">chains/ethereum/ethereum/src/api.ts:1300</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2245,7 +2245,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1285">chains/ethereum/ethereum/src/api.ts:1285</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1285">chains/ethereum/ethereum/src/api.ts:1285</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2274,7 +2274,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2053">chains/ethereum/ethereum/src/api.ts:2053</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2053">chains/ethereum/ethereum/src/api.ts:2053</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2304,7 +2304,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2139">chains/ethereum/ethereum/src/api.ts:2139</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2139">chains/ethereum/ethereum/src/api.ts:2139</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2373,7 +2373,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2080">chains/ethereum/ethereum/src/api.ts:2080</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2080">chains/ethereum/ethereum/src/api.ts:2080</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2403,7 +2403,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L796">chains/ethereum/ethereum/src/api.ts:796</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L796">chains/ethereum/ethereum/src/api.ts:796</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2432,7 +2432,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1738">chains/ethereum/ethereum/src/api.ts:1738</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1738">chains/ethereum/ethereum/src/api.ts:1738</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2472,7 +2472,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1632">chains/ethereum/ethereum/src/api.ts:1632</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1632">chains/ethereum/ethereum/src/api.ts:1632</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2522,7 +2522,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1771">chains/ethereum/ethereum/src/api.ts:1771</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1771">chains/ethereum/ethereum/src/api.ts:1771</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2578,7 +2578,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1701">chains/ethereum/ethereum/src/api.ts:1701</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1701">chains/ethereum/ethereum/src/api.ts:1701</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2626,7 +2626,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1841">chains/ethereum/ethereum/src/api.ts:1841</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1841">chains/ethereum/ethereum/src/api.ts:1841</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2713,7 +2713,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1271">chains/ethereum/ethereum/src/api.ts:1271</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1271">chains/ethereum/ethereum/src/api.ts:1271</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2759,7 +2759,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1252">chains/ethereum/ethereum/src/api.ts:1252</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1252">chains/ethereum/ethereum/src/api.ts:1252</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2813,7 +2813,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1885">chains/ethereum/ethereum/src/api.ts:1885</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1885">chains/ethereum/ethereum/src/api.ts:1885</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2844,7 +2844,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L1898">chains/ethereum/ethereum/src/api.ts:1898</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L1898">chains/ethereum/ethereum/src/api.ts:1898</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2886,7 +2886,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L817">chains/ethereum/ethereum/src/api.ts:817</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L817">chains/ethereum/ethereum/src/api.ts:817</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2921,7 +2921,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2243">chains/ethereum/ethereum/src/api.ts:2243</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2243">chains/ethereum/ethereum/src/api.ts:2243</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2962,7 +2962,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2029">chains/ethereum/ethereum/src/api.ts:2029</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2029">chains/ethereum/ethereum/src/api.ts:2029</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3002,7 +3002,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L353">chains/ethereum/ethereum/src/api.ts:353</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L353">chains/ethereum/ethereum/src/api.ts:353</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3041,7 +3041,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L520">chains/ethereum/ethereum/src/api.ts:520</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L520">chains/ethereum/ethereum/src/api.ts:520</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3085,7 +3085,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L258">chains/ethereum/ethereum/src/api.ts:258</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L258">chains/ethereum/ethereum/src/api.ts:258</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3121,7 +3121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L259">chains/ethereum/ethereum/src/api.ts:259</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L259">chains/ethereum/ethereum/src/api.ts:259</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -3152,7 +3152,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L435">chains/ethereum/ethereum/src/api.ts:435</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L435">chains/ethereum/ethereum/src/api.ts:435</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3216,7 +3216,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L321">chains/ethereum/ethereum/src/api.ts:321</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L321">chains/ethereum/ethereum/src/api.ts:321</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3264,7 +3264,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L380">chains/ethereum/ethereum/src/api.ts:380</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L380">chains/ethereum/ethereum/src/api.ts:380</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3308,7 +3308,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L476">chains/ethereum/ethereum/src/api.ts:476</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L476">chains/ethereum/ethereum/src/api.ts:476</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3363,7 +3363,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L499">chains/ethereum/ethereum/src/api.ts:499</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L499">chains/ethereum/ethereum/src/api.ts:499</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3413,7 +3413,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L607">chains/ethereum/ethereum/src/api.ts:607</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L607">chains/ethereum/ethereum/src/api.ts:607</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3451,7 +3451,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L622">chains/ethereum/ethereum/src/api.ts:622</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L622">chains/ethereum/ethereum/src/api.ts:622</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3488,7 +3488,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L591">chains/ethereum/ethereum/src/api.ts:591</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L591">chains/ethereum/ethereum/src/api.ts:591</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3527,7 +3527,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L549">chains/ethereum/ethereum/src/api.ts:549</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L549">chains/ethereum/ethereum/src/api.ts:549</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3570,7 +3570,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L574">chains/ethereum/ethereum/src/api.ts:574</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L574">chains/ethereum/ethereum/src/api.ts:574</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3602,7 +3602,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L688">chains/ethereum/ethereum/src/api.ts:688</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L688">chains/ethereum/ethereum/src/api.ts:688</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3630,7 +3630,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L701">chains/ethereum/ethereum/src/api.ts:701</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L701">chains/ethereum/ethereum/src/api.ts:701</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3658,7 +3658,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L675">chains/ethereum/ethereum/src/api.ts:675</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L675">chains/ethereum/ethereum/src/api.ts:675</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3687,7 +3687,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2658">chains/ethereum/ethereum/src/api.ts:2658</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2658">chains/ethereum/ethereum/src/api.ts:2658</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3734,7 +3734,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2605">chains/ethereum/ethereum/src/api.ts:2605</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2605">chains/ethereum/ethereum/src/api.ts:2605</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3763,7 +3763,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2689">chains/ethereum/ethereum/src/api.ts:2689</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2689">chains/ethereum/ethereum/src/api.ts:2689</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3802,7 +3802,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2623">chains/ethereum/ethereum/src/api.ts:2623</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2623">chains/ethereum/ethereum/src/api.ts:2623</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3842,7 +3842,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2762">chains/ethereum/ethereum/src/api.ts:2762</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2762">chains/ethereum/ethereum/src/api.ts:2762</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3902,7 +3902,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2815">chains/ethereum/ethereum/src/api.ts:2815</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2815">chains/ethereum/ethereum/src/api.ts:2815</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3961,7 +3961,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2718">chains/ethereum/ethereum/src/api.ts:2718</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2718">chains/ethereum/ethereum/src/api.ts:2718</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4020,7 +4020,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2849">chains/ethereum/ethereum/src/api.ts:2849</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2849">chains/ethereum/ethereum/src/api.ts:2849</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4048,7 +4048,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2906">chains/ethereum/ethereum/src/api.ts:2906</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2906">chains/ethereum/ethereum/src/api.ts:2906</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4085,7 +4085,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2954">chains/ethereum/ethereum/src/api.ts:2954</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2954">chains/ethereum/ethereum/src/api.ts:2954</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4122,7 +4122,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2969">chains/ethereum/ethereum/src/api.ts:2969</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2969">chains/ethereum/ethereum/src/api.ts:2969</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4159,7 +4159,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2881">chains/ethereum/ethereum/src/api.ts:2881</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2881">chains/ethereum/ethereum/src/api.ts:2881</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4196,7 +4196,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2923">chains/ethereum/ethereum/src/api.ts:2923</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2923">chains/ethereum/ethereum/src/api.ts:2923</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4240,7 +4240,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2891">chains/ethereum/ethereum/src/api.ts:2891</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2891">chains/ethereum/ethereum/src/api.ts:2891</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4263,7 +4263,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2866">chains/ethereum/ethereum/src/api.ts:2866</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2866">chains/ethereum/ethereum/src/api.ts:2866</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4293,7 +4293,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2984">chains/ethereum/ethereum/src/api.ts:2984</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2984">chains/ethereum/ethereum/src/api.ts:2984</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4327,7 +4327,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2939">chains/ethereum/ethereum/src/api.ts:2939</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2939">chains/ethereum/ethereum/src/api.ts:2939</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4365,7 +4365,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L2998">chains/ethereum/ethereum/src/api.ts:2998</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L2998">chains/ethereum/ethereum/src/api.ts:2998</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4393,7 +4393,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L643">chains/ethereum/ethereum/src/api.ts:643</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L643">chains/ethereum/ethereum/src/api.ts:643</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4421,7 +4421,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L659">chains/ethereum/ethereum/src/api.ts:659</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L659">chains/ethereum/ethereum/src/api.ts:659</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/typedoc/classes/_api_.ethereumapi.html
+++ b/docs/typedoc/classes/_api_.ethereumapi.html
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L119">chains/ethereum/ethereum/src/api.ts:119</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L120">chains/ethereum/ethereum/src/api.ts:120</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 					<div class="tsd-signature tsd-kind-icon">#blockchain<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Blockchain</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L118">chains/ethereum/ethereum/src/api.ts:118</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L119">chains/ethereum/ethereum/src/api.ts:119</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -278,7 +278,7 @@
 					<div class="tsd-signature tsd-kind-icon">#filters<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string, Filter&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L115">chains/ethereum/ethereum/src/api.ts:115</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L116">chains/ethereum/ethereum/src/api.ts:116</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -288,7 +288,7 @@
 					<div class="tsd-signature tsd-kind-icon">#get<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = (id &#x3D;&gt; () &#x3D;&gt; Quantity.from(++id))(0)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L114">chains/ethereum/ethereum/src/api.ts:114</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L115">chains/ethereum/ethereum/src/api.ts:115</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -298,7 +298,7 @@
 					<div class="tsd-signature tsd-kind-icon">#options<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">EthereumInternalOptions</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L117">chains/ethereum/ethereum/src/api.ts:117</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L118">chains/ethereum/ethereum/src/api.ts:118</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -308,7 +308,7 @@
 					<div class="tsd-signature tsd-kind-icon">#subscriptions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">function</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string, Emittery.UnsubscribeFn&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L116">chains/ethereum/ethereum/src/api.ts:116</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L117">chains/ethereum/ethereum/src/api.ts:117</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -318,7 +318,7 @@
 					<div class="tsd-signature tsd-kind-icon">#wallet<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Wallet</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L119">chains/ethereum/ethereum/src/api.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L120">chains/ethereum/ethereum/src/api.ts:120</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -335,7 +335,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L217">chains/ethereum/ethereum/src/api.ts:217</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L218">chains/ethereum/ethereum/src/api.ts:218</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -363,7 +363,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L230">chains/ethereum/ethereum/src/api.ts:230</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L231">chains/ethereum/ethereum/src/api.ts:231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -391,7 +391,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L202">chains/ethereum/ethereum/src/api.ts:202</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L203">chains/ethereum/ethereum/src/api.ts:203</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -434,7 +434,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L169">chains/ethereum/ethereum/src/api.ts:169</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L170">chains/ethereum/ethereum/src/api.ts:170</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -477,7 +477,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L186">chains/ethereum/ethereum/src/api.ts:186</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L187">chains/ethereum/ethereum/src/api.ts:187</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -526,7 +526,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L153">chains/ethereum/ethereum/src/api.ts:153</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L154">chains/ethereum/ethereum/src/api.ts:154</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -575,7 +575,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2539">chains/ethereum/ethereum/src/api.ts:2539</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2576">chains/ethereum/ethereum/src/api.ts:2576</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -664,7 +664,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2489">chains/ethereum/ethereum/src/api.ts:2489</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2526">chains/ethereum/ethereum/src/api.ts:2526</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -746,7 +746,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1307">chains/ethereum/ethereum/src/api.ts:1307</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1328">chains/ethereum/ethereum/src/api.ts:1328</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -775,7 +775,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1321">chains/ethereum/ethereum/src/api.ts:1321</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1342">chains/ethereum/ethereum/src/api.ts:1342</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -804,7 +804,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2378">chains/ethereum/ethereum/src/api.ts:2378</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2413">chains/ethereum/ethereum/src/api.ts:2413</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -871,7 +871,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1338">chains/ethereum/ethereum/src/api.ts:1338</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1359">chains/ethereum/ethereum/src/api.ts:1359</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -904,7 +904,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L820">chains/ethereum/ethereum/src/api.ts:820</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L831">chains/ethereum/ethereum/src/api.ts:831</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -933,7 +933,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L729">chains/ethereum/ethereum/src/api.ts:729</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L738">chains/ethereum/ethereum/src/api.ts:738</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -992,7 +992,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1293">chains/ethereum/ethereum/src/api.ts:1293</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1314">chains/ethereum/ethereum/src/api.ts:1314</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1021,7 +1021,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1358">chains/ethereum/ethereum/src/api.ts:1358</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1379">chains/ethereum/ethereum/src/api.ts:1379</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1061,13 +1061,13 @@
 					<a name="eth_getblockbyhash" class="tsd-anchor"></a>
 					<h3>eth_<wbr>get<wbr>Block<wbr>ByHash</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">eth_<wbr>get<wbr>Block<wbr>ByHash<span class="tsd-signature-symbol">(</span>hash<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">DATA</span>, transactions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">eth_<wbr>get<wbr>Block<wbr>ByHash<span class="tsd-signature-symbol">(</span>hash<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">DATA</span>, transactions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L916">chains/ethereum/ethereum/src/api.ts:916</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L929">chains/ethereum/ethereum/src/api.ts:929</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1113,7 +1113,7 @@
 									</div>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></h4>
 							<p>The block, <code>null</code> if the block doesn&#39;t exist.</p>
 							<ul>
 								<li><code>hash</code>: <code>DATA</code>, 32 Bytes - Hash of the block. <code>null</code> when pending.</li>
@@ -1144,13 +1144,13 @@
 					<a name="eth_getblockbynumber" class="tsd-anchor"></a>
 					<h3>eth_<wbr>get<wbr>Block<wbr>ByNumber</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">eth_<wbr>get<wbr>Block<wbr>ByNumber<span class="tsd-signature-symbol">(</span>number<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">QUANTITY</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Tag</span>, transactions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">eth_<wbr>get<wbr>Block<wbr>ByNumber<span class="tsd-signature-symbol">(</span>number<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">QUANTITY</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Tag</span>, transactions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L860">chains/ethereum/ethereum/src/api.ts:860</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L871">chains/ethereum/ethereum/src/api.ts:871</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1181,7 +1181,7 @@
 									</div>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></h4>
 							<p>The block, <code>null</code> if the block doesn&#39;t exist.</p>
 							<ul>
 								<li><code>hash</code>: <code>DATA</code>, 32 Bytes - Hash of the block. <code>null</code> when pending.</li>
@@ -1218,7 +1218,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L972">chains/ethereum/ethereum/src/api.ts:972</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L985">chains/ethereum/ethereum/src/api.ts:985</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1272,7 +1272,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L935">chains/ethereum/ethereum/src/api.ts:935</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L948">chains/ethereum/ethereum/src/api.ts:948</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1307,7 +1307,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1397">chains/ethereum/ethereum/src/api.ts:1397</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1418">chains/ethereum/ethereum/src/api.ts:1418</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1367,7 +1367,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L994">chains/ethereum/ethereum/src/api.ts:994</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1007">chains/ethereum/ethereum/src/api.ts:1007</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1396,7 +1396,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2182">chains/ethereum/ethereum/src/api.ts:2182</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2217">chains/ethereum/ethereum/src/api.ts:2217</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1477,7 +1477,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2252">chains/ethereum/ethereum/src/api.ts:2252</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2287">chains/ethereum/ethereum/src/api.ts:2287</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1539,7 +1539,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2309">chains/ethereum/ethereum/src/api.ts:2309</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2344">chains/ethereum/ethereum/src/api.ts:2344</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1614,7 +1614,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1432">chains/ethereum/ethereum/src/api.ts:1432</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1453">chains/ethereum/ethereum/src/api.ts:1453</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1675,13 +1675,13 @@
 					<a name="eth_gettransactionbyblockhashandindex" class="tsd-anchor"></a>
 					<h3>eth_<wbr>get<wbr>Transaction<wbr>ByBlock<wbr>Hash<wbr>And<wbr>Index</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">eth_<wbr>get<wbr>Transaction<wbr>ByBlock<wbr>Hash<wbr>And<wbr>Index<span class="tsd-signature-symbol">(</span>hash<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">DATA</span>, index<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">QUANTITY</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">eth_<wbr>get<wbr>Transaction<wbr>ByBlock<wbr>Hash<wbr>And<wbr>Index<span class="tsd-signature-symbol">(</span>hash<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">DATA</span>, index<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">QUANTITY</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1032">chains/ethereum/ethereum/src/api.ts:1032</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1045">chains/ethereum/ethereum/src/api.ts:1045</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1716,7 +1716,7 @@
 									</div>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></h4>
 							<p>The transaction object or <code>null</code> if no transaction was found.</p>
 							<ul>
 								<li><code>hash</code>: <code>DATA</code>, 32 Bytes - The transaction hash.</li>
@@ -1741,13 +1741,13 @@
 					<a name="eth_gettransactionbyblocknumberandindex" class="tsd-anchor"></a>
 					<h3>eth_<wbr>get<wbr>Transaction<wbr>ByBlock<wbr>Number<wbr>And<wbr>Index</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">eth_<wbr>get<wbr>Transaction<wbr>ByBlock<wbr>Number<wbr>And<wbr>Index<span class="tsd-signature-symbol">(</span>number<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">QUANTITY</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Tag</span>, index<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">QUANTITY</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">eth_<wbr>get<wbr>Transaction<wbr>ByBlock<wbr>Number<wbr>And<wbr>Index<span class="tsd-signature-symbol">(</span>number<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">QUANTITY</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Tag</span>, index<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">QUANTITY</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1075">chains/ethereum/ethereum/src/api.ts:1075</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1091">chains/ethereum/ethereum/src/api.ts:1091</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1782,7 +1782,7 @@
 									</div>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></h4>
 							<p>The transaction object or <code>null</code> if no transaction was found.</p>
 							<ul>
 								<li><code>hash</code>: <code>DATA</code>, 32 Bytes - The transaction hash.</li>
@@ -1813,7 +1813,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1505">chains/ethereum/ethereum/src/api.ts:1505</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1526">chains/ethereum/ethereum/src/api.ts:1526</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1872,7 +1872,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2332">chains/ethereum/ethereum/src/api.ts:2332</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2367">chains/ethereum/ethereum/src/api.ts:2367</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1916,13 +1916,13 @@
 					<a name="eth_gettransactionreceipt" class="tsd-anchor"></a>
 					<h3>eth_<wbr>get<wbr>Transaction<wbr>Receipt</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">eth_<wbr>get<wbr>Transaction<wbr>Receipt<span class="tsd-signature-symbol">(</span>transactionHash<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">DATA</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">eth_<wbr>get<wbr>Transaction<wbr>Receipt<span class="tsd-signature-symbol">(</span>transactionHash<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">DATA</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TransactionReceiptJSON</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1542">chains/ethereum/ethereum/src/api.ts:1542</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1563">chains/ethereum/ethereum/src/api.ts:1563</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1951,7 +1951,7 @@
 									</div>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TransactionReceiptJSON</span><span class="tsd-signature-symbol">&gt;</span></h4>
 							<p>Returns the receipt of a transaction by transaction hash.</p>
 						</li>
 					</ul>
@@ -1960,13 +1960,13 @@
 					<a name="eth_getunclebyblockhashandindex" class="tsd-anchor"></a>
 					<h3>eth_<wbr>get<wbr>Uncle<wbr>ByBlock<wbr>Hash<wbr>And<wbr>Index</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">eth_<wbr>get<wbr>Uncle<wbr>ByBlock<wbr>Hash<wbr>And<wbr>Index<span class="tsd-signature-symbol">(</span>hash<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">DATA</span>, index<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">QUANTITY</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">eth_<wbr>get<wbr>Uncle<wbr>ByBlock<wbr>Hash<wbr>And<wbr>Index<span class="tsd-signature-symbol">(</span>hash<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">DATA</span>, index<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">QUANTITY</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1150">chains/ethereum/ethereum/src/api.ts:1150</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1171">chains/ethereum/ethereum/src/api.ts:1171</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1996,7 +1996,7 @@
 									</div>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></h4>
 							<p>A block object or <code>null</code> when no block is found.</p>
 							<ul>
 								<li><code>hash</code>: <code>DATA</code>, 32 Bytes - Hash of the block. <code>null</code> when pending.</li>
@@ -2027,13 +2027,13 @@
 					<a name="eth_getunclebyblocknumberandindex" class="tsd-anchor"></a>
 					<h3>eth_<wbr>get<wbr>Uncle<wbr>ByBlock<wbr>Number<wbr>And<wbr>Index</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">eth_<wbr>get<wbr>Uncle<wbr>ByBlock<wbr>Number<wbr>And<wbr>Index<span class="tsd-signature-symbol">(</span>blockNumber<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">QUANTITY</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Tag</span>, uncleIndex<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">QUANTITY</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">eth_<wbr>get<wbr>Uncle<wbr>ByBlock<wbr>Number<wbr>And<wbr>Index<span class="tsd-signature-symbol">(</span>blockNumber<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">QUANTITY</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Tag</span>, uncleIndex<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">QUANTITY</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1189">chains/ethereum/ethereum/src/api.ts:1189</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1210">chains/ethereum/ethereum/src/api.ts:1210</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2062,7 +2062,7 @@
 									</div>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></h4>
 							<p>A block object or <code>null</code> when no block is found.</p>
 							<ul>
 								<li><code>hash</code>: <code>DATA</code>, 32 Bytes - Hash of the block. <code>null</code> when pending.</li>
@@ -2099,7 +2099,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1095">chains/ethereum/ethereum/src/api.ts:1095</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1116">chains/ethereum/ethereum/src/api.ts:1116</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2138,7 +2138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1110">chains/ethereum/ethereum/src/api.ts:1110</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1131">chains/ethereum/ethereum/src/api.ts:1131</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2176,7 +2176,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1210">chains/ethereum/ethereum/src/api.ts:1210</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1231">chains/ethereum/ethereum/src/api.ts:1231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2216,7 +2216,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1279">chains/ethereum/ethereum/src/api.ts:1279</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1300">chains/ethereum/ethereum/src/api.ts:1300</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2245,7 +2245,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1264">chains/ethereum/ethereum/src/api.ts:1264</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1285">chains/ethereum/ethereum/src/api.ts:1285</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2274,7 +2274,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2018">chains/ethereum/ethereum/src/api.ts:2018</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2053">chains/ethereum/ethereum/src/api.ts:2053</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2304,7 +2304,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2104">chains/ethereum/ethereum/src/api.ts:2104</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2139">chains/ethereum/ethereum/src/api.ts:2139</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2373,7 +2373,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2045">chains/ethereum/ethereum/src/api.ts:2045</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2080">chains/ethereum/ethereum/src/api.ts:2080</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2403,7 +2403,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L785">chains/ethereum/ethereum/src/api.ts:785</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L796">chains/ethereum/ethereum/src/api.ts:796</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2432,7 +2432,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1704">chains/ethereum/ethereum/src/api.ts:1704</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1738">chains/ethereum/ethereum/src/api.ts:1738</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2466,13 +2466,13 @@
 					<a name="eth_sendtransaction" class="tsd-anchor"></a>
 					<h3>eth_<wbr>send<wbr>Transaction</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">eth_<wbr>send<wbr>Transaction<span class="tsd-signature-symbol">(</span>transaction<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">RpcTransaction</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Data</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">eth_<wbr>send<wbr>Transaction<span class="tsd-signature-symbol">(</span>transaction<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">TypedRpcTransaction</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Data</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1606">chains/ethereum/ethereum/src/api.ts:1606</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1632">chains/ethereum/ethereum/src/api.ts:1632</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2501,7 +2501,7 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>transaction: <span class="tsd-signature-type">RpcTransaction</span></h5>
+									<h5>transaction: <span class="tsd-signature-type">TypedRpcTransaction</span></h5>
 									<div class="tsd-comment tsd-typography">
 										<p>The transaction call object as seen in source.</p>
 									</div>
@@ -2522,7 +2522,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1739">chains/ethereum/ethereum/src/api.ts:1739</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1771">chains/ethereum/ethereum/src/api.ts:1771</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2572,13 +2572,13 @@
 					<a name="eth_signtransaction" class="tsd-anchor"></a>
 					<h3>eth_<wbr>sign<wbr>Transaction</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">eth_<wbr>sign<wbr>Transaction<span class="tsd-signature-symbol">(</span>transaction<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">RpcTransaction</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">eth_<wbr>sign<wbr>Transaction<span class="tsd-signature-symbol">(</span>transaction<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">TypedRpcTransaction</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1667">chains/ethereum/ethereum/src/api.ts:1667</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1701">chains/ethereum/ethereum/src/api.ts:1701</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2605,7 +2605,7 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>transaction: <span class="tsd-signature-type">RpcTransaction</span></h5>
+									<h5>transaction: <span class="tsd-signature-type">TypedRpcTransaction</span></h5>
 									<div class="tsd-comment tsd-typography">
 										<p>The transaction call object as seen in source.</p>
 									</div>
@@ -2626,7 +2626,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1809">chains/ethereum/ethereum/src/api.ts:1809</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1841">chains/ethereum/ethereum/src/api.ts:1841</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2713,7 +2713,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1250">chains/ethereum/ethereum/src/api.ts:1250</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1271">chains/ethereum/ethereum/src/api.ts:1271</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2759,7 +2759,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1231">chains/ethereum/ethereum/src/api.ts:1231</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1252">chains/ethereum/ethereum/src/api.ts:1252</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2813,7 +2813,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1853">chains/ethereum/ethereum/src/api.ts:1853</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1885">chains/ethereum/ethereum/src/api.ts:1885</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2844,7 +2844,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1866">chains/ethereum/ethereum/src/api.ts:1866</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L1898">chains/ethereum/ethereum/src/api.ts:1898</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2886,7 +2886,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L806">chains/ethereum/ethereum/src/api.ts:806</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L817">chains/ethereum/ethereum/src/api.ts:817</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2921,7 +2921,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2208">chains/ethereum/ethereum/src/api.ts:2208</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2243">chains/ethereum/ethereum/src/api.ts:2243</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2962,7 +2962,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L1994">chains/ethereum/ethereum/src/api.ts:1994</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2029">chains/ethereum/ethereum/src/api.ts:2029</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3002,7 +3002,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L344">chains/ethereum/ethereum/src/api.ts:344</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L353">chains/ethereum/ethereum/src/api.ts:353</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3041,7 +3041,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L511">chains/ethereum/ethereum/src/api.ts:511</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L520">chains/ethereum/ethereum/src/api.ts:520</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3085,7 +3085,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L257">chains/ethereum/ethereum/src/api.ts:257</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L258">chains/ethereum/ethereum/src/api.ts:258</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3121,7 +3121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L258">chains/ethereum/ethereum/src/api.ts:258</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L259">chains/ethereum/ethereum/src/api.ts:259</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -3152,7 +3152,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L426">chains/ethereum/ethereum/src/api.ts:426</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L435">chains/ethereum/ethereum/src/api.ts:435</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3216,7 +3216,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L312">chains/ethereum/ethereum/src/api.ts:312</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L321">chains/ethereum/ethereum/src/api.ts:321</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3264,7 +3264,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L371">chains/ethereum/ethereum/src/api.ts:371</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L380">chains/ethereum/ethereum/src/api.ts:380</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3308,7 +3308,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L467">chains/ethereum/ethereum/src/api.ts:467</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L476">chains/ethereum/ethereum/src/api.ts:476</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3363,7 +3363,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L490">chains/ethereum/ethereum/src/api.ts:490</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L499">chains/ethereum/ethereum/src/api.ts:499</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3413,7 +3413,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L598">chains/ethereum/ethereum/src/api.ts:598</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L607">chains/ethereum/ethereum/src/api.ts:607</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3451,7 +3451,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L613">chains/ethereum/ethereum/src/api.ts:613</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L622">chains/ethereum/ethereum/src/api.ts:622</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3488,7 +3488,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L582">chains/ethereum/ethereum/src/api.ts:582</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L591">chains/ethereum/ethereum/src/api.ts:591</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3527,7 +3527,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L540">chains/ethereum/ethereum/src/api.ts:540</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L549">chains/ethereum/ethereum/src/api.ts:549</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3570,7 +3570,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L565">chains/ethereum/ethereum/src/api.ts:565</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L574">chains/ethereum/ethereum/src/api.ts:574</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3602,7 +3602,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L679">chains/ethereum/ethereum/src/api.ts:679</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L688">chains/ethereum/ethereum/src/api.ts:688</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3630,7 +3630,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L692">chains/ethereum/ethereum/src/api.ts:692</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L701">chains/ethereum/ethereum/src/api.ts:701</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3658,7 +3658,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L666">chains/ethereum/ethereum/src/api.ts:666</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L675">chains/ethereum/ethereum/src/api.ts:675</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3687,7 +3687,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2621">chains/ethereum/ethereum/src/api.ts:2621</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2658">chains/ethereum/ethereum/src/api.ts:2658</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3734,7 +3734,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2568">chains/ethereum/ethereum/src/api.ts:2568</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2605">chains/ethereum/ethereum/src/api.ts:2605</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3763,7 +3763,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2652">chains/ethereum/ethereum/src/api.ts:2652</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2689">chains/ethereum/ethereum/src/api.ts:2689</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3802,7 +3802,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2586">chains/ethereum/ethereum/src/api.ts:2586</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2623">chains/ethereum/ethereum/src/api.ts:2623</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3842,7 +3842,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2725">chains/ethereum/ethereum/src/api.ts:2725</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2762">chains/ethereum/ethereum/src/api.ts:2762</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3896,13 +3896,13 @@ assert(isReverted);
 					<a name="personal_signtransaction" class="tsd-anchor"></a>
 					<h3>personal_<wbr>sign<wbr>Transaction</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">personal_<wbr>sign<wbr>Transaction<span class="tsd-signature-symbol">(</span>transaction<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">RpcTransaction</span>, passphrase<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">personal_<wbr>sign<wbr>Transaction<span class="tsd-signature-symbol">(</span>transaction<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">TypedRpcTransaction</span>, passphrase<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2778">chains/ethereum/ethereum/src/api.ts:2778</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2815">chains/ethereum/ethereum/src/api.ts:2815</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -3937,7 +3937,7 @@ assert(isReverted);
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>transaction: <span class="tsd-signature-type">RpcTransaction</span></h5>
+									<h5>transaction: <span class="tsd-signature-type">TypedRpcTransaction</span></h5>
 									<div class="tsd-comment tsd-typography">
 										<p>The transaction call object as seen in source.</p>
 									</div>
@@ -3961,7 +3961,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2681">chains/ethereum/ethereum/src/api.ts:2681</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2718">chains/ethereum/ethereum/src/api.ts:2718</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4020,7 +4020,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2812">chains/ethereum/ethereum/src/api.ts:2812</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2849">chains/ethereum/ethereum/src/api.ts:2849</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4048,7 +4048,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2869">chains/ethereum/ethereum/src/api.ts:2869</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2906">chains/ethereum/ethereum/src/api.ts:2906</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4085,7 +4085,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2917">chains/ethereum/ethereum/src/api.ts:2917</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2954">chains/ethereum/ethereum/src/api.ts:2954</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4122,7 +4122,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2932">chains/ethereum/ethereum/src/api.ts:2932</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2969">chains/ethereum/ethereum/src/api.ts:2969</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4159,7 +4159,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2844">chains/ethereum/ethereum/src/api.ts:2844</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2881">chains/ethereum/ethereum/src/api.ts:2881</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4196,7 +4196,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2886">chains/ethereum/ethereum/src/api.ts:2886</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2923">chains/ethereum/ethereum/src/api.ts:2923</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4240,7 +4240,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2854">chains/ethereum/ethereum/src/api.ts:2854</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2891">chains/ethereum/ethereum/src/api.ts:2891</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4263,7 +4263,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2829">chains/ethereum/ethereum/src/api.ts:2829</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2866">chains/ethereum/ethereum/src/api.ts:2866</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4293,7 +4293,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2947">chains/ethereum/ethereum/src/api.ts:2947</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2984">chains/ethereum/ethereum/src/api.ts:2984</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4327,7 +4327,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2902">chains/ethereum/ethereum/src/api.ts:2902</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2939">chains/ethereum/ethereum/src/api.ts:2939</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4365,7 +4365,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L2961">chains/ethereum/ethereum/src/api.ts:2961</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L2998">chains/ethereum/ethereum/src/api.ts:2998</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4393,7 +4393,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L634">chains/ethereum/ethereum/src/api.ts:634</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L643">chains/ethereum/ethereum/src/api.ts:643</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -4421,7 +4421,7 @@ assert(isReverted);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L650">chains/ethereum/ethereum/src/api.ts:650</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L659">chains/ethereum/ethereum/src/api.ts:659</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/typedoc/modules/_api_.html
+++ b/docs/typedoc/modules/_api_.html
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">Typed<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Exclude</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Parameters&lt;typeof signTypedData_v4&gt;[1][&quot;data&quot;]</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">NotTypedData</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L73">chains/ethereum/ethereum/src/api.ts:73</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L73">chains/ethereum/ethereum/src/api.ts:73</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">CLIENT_<wbr>VERSION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &#x60;Ganache/v${version}/EthereumJS TestRPC/v${version}/ethereum-js&#x60;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L60">chains/ethereum/ethereum/src/api.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L60">chains/ethereum/ethereum/src/api.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">PROTOCOL_<wbr>VERSION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Data</span><span class="tsd-signature-symbol"> = Data.from(&quot;0x3f&quot;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L61">chains/ethereum/ethereum/src/api.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L61">chains/ethereum/ethereum/src/api.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">RPC_<wbr>MODULES<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span><span class="tsd-signature-symbol"> = {eth: &quot;1.0&quot;,net: &quot;1.0&quot;,rpc: &quot;1.0&quot;,web3: &quot;1.0&quot;,evm: &quot;1.0&quot;,personal: &quot;1.0&quot;} as const</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L62">chains/ethereum/ethereum/src/api.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L62">chains/ethereum/ethereum/src/api.ts:62</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L56">chains/ethereum/ethereum/src/api.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L56">chains/ethereum/ethereum/src/api.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L80">chains/ethereum/ethereum/src/api.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L80">chains/ethereum/ethereum/src/api.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/typedoc/modules/_api_.html
+++ b/docs/typedoc/modules/_api_.html
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">Typed<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Exclude</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Parameters&lt;typeof signTypedData_v4&gt;[1][&quot;data&quot;]</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">NotTypedData</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L72">chains/ethereum/ethereum/src/api.ts:72</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L73">chains/ethereum/ethereum/src/api.ts:73</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">CLIENT_<wbr>VERSION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &#x60;Ganache/v${version}/EthereumJS TestRPC/v${version}/ethereum-js&#x60;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L59">chains/ethereum/ethereum/src/api.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L60">chains/ethereum/ethereum/src/api.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">PROTOCOL_<wbr>VERSION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Data</span><span class="tsd-signature-symbol"> = Data.from(&quot;0x3f&quot;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L60">chains/ethereum/ethereum/src/api.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L61">chains/ethereum/ethereum/src/api.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">RPC_<wbr>MODULES<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span><span class="tsd-signature-symbol"> = {eth: &quot;1.0&quot;,net: &quot;1.0&quot;,rpc: &quot;1.0&quot;,web3: &quot;1.0&quot;,evm: &quot;1.0&quot;,personal: &quot;1.0&quot;} as const</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L61">chains/ethereum/ethereum/src/api.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L62">chains/ethereum/ethereum/src/api.ts:62</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L55">chains/ethereum/ethereum/src/api.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L56">chains/ethereum/ethereum/src/api.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,19 +183,19 @@
 					<a name="assertexceptionaltransactions" class="tsd-anchor"></a>
 					<h3>assert<wbr>Exceptional<wbr>Transactions</h3>
 					<ul class="tsd-signatures tsd-kind-function tsd-parent-kind-module tsd-is-not-exported">
-						<li class="tsd-signature tsd-kind-icon">assert<wbr>Exceptional<wbr>Transactions<span class="tsd-signature-symbol">(</span>transactions<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">RuntimeTransaction</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">assert<wbr>Exceptional<wbr>Transactions<span class="tsd-signature-symbol">(</span>transactions<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">TypedTransaction</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/c27953d/src/chains/ethereum/ethereum/src/api.ts#L79">chains/ethereum/ethereum/src/api.ts:79</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/874e9dbb/src/chains/ethereum/ethereum/src/api.ts#L80">chains/ethereum/ethereum/src/api.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>transactions: <span class="tsd-signature-type">RuntimeTransaction</span><span class="tsd-signature-symbol">[]</span></h5>
+									<h5>transactions: <span class="tsd-signature-type">TypedTransaction</span><span class="tsd-signature-symbol">[]</span></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/typedoc/modules/_api_.html
+++ b/docs/typedoc/modules/_api_.html
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">Typed<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Exclude</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Parameters&lt;typeof signTypedData_v4&gt;[1][&quot;data&quot;]</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">NotTypedData</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L73">chains/ethereum/ethereum/src/api.ts:73</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L73">chains/ethereum/ethereum/src/api.ts:73</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">CLIENT_<wbr>VERSION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &#x60;Ganache/v${version}/EthereumJS TestRPC/v${version}/ethereum-js&#x60;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L60">chains/ethereum/ethereum/src/api.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L60">chains/ethereum/ethereum/src/api.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">PROTOCOL_<wbr>VERSION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Data</span><span class="tsd-signature-symbol"> = Data.from(&quot;0x3f&quot;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L61">chains/ethereum/ethereum/src/api.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L61">chains/ethereum/ethereum/src/api.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">RPC_<wbr>MODULES<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span><span class="tsd-signature-symbol"> = {eth: &quot;1.0&quot;,net: &quot;1.0&quot;,rpc: &quot;1.0&quot;,web3: &quot;1.0&quot;,evm: &quot;1.0&quot;,personal: &quot;1.0&quot;} as const</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L62">chains/ethereum/ethereum/src/api.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L62">chains/ethereum/ethereum/src/api.ts:62</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L56">chains/ethereum/ethereum/src/api.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L56">chains/ethereum/ethereum/src/api.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L80">chains/ethereum/ethereum/src/api.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/34d22404/src/chains/ethereum/ethereum/src/api.ts#L80">chains/ethereum/ethereum/src/api.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/typedoc/modules/_api_.html
+++ b/docs/typedoc/modules/_api_.html
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">Typed<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Exclude</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Parameters&lt;typeof signTypedData_v4&gt;[1][&quot;data&quot;]</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">NotTypedData</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L73">chains/ethereum/ethereum/src/api.ts:73</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L73">chains/ethereum/ethereum/src/api.ts:73</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">CLIENT_<wbr>VERSION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &#x60;Ganache/v${version}/EthereumJS TestRPC/v${version}/ethereum-js&#x60;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L60">chains/ethereum/ethereum/src/api.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L60">chains/ethereum/ethereum/src/api.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">PROTOCOL_<wbr>VERSION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Data</span><span class="tsd-signature-symbol"> = Data.from(&quot;0x3f&quot;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L61">chains/ethereum/ethereum/src/api.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L61">chains/ethereum/ethereum/src/api.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">RPC_<wbr>MODULES<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span><span class="tsd-signature-symbol"> = {eth: &quot;1.0&quot;,net: &quot;1.0&quot;,rpc: &quot;1.0&quot;,web3: &quot;1.0&quot;,evm: &quot;1.0&quot;,personal: &quot;1.0&quot;} as const</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L62">chains/ethereum/ethereum/src/api.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L62">chains/ethereum/ethereum/src/api.ts:62</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L56">chains/ethereum/ethereum/src/api.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L56">chains/ethereum/ethereum/src/api.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/27e39ecd/src/chains/ethereum/ethereum/src/api.ts#L80">chains/ethereum/ethereum/src/api.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/trufflesuite/ganache/blob/d75de719/src/chains/ethereum/ethereum/src/api.ts#L80">chains/ethereum/ethereum/src/api.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/chains/ethereum/block/src/block-params.ts
+++ b/src/chains/ethereum/block/src/block-params.ts
@@ -1,0 +1,20 @@
+// NOTE these params may need to be changed at each hardfork
+// they can be tracked here: https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/hardforks/
+
+import { Quantity } from "@ganache/utils";
+
+export const BlockParams = {
+  /**
+   *  Base fee per gas for blocks without a parent containing a base fee per gas.
+   */
+  INITIAL_BASE_FEE_PER_GAS: Quantity.from(1000000000).toBuffer(),
+  /**
+   * Divisor used to set a block's target gas usage.
+   */
+  ELASTICITY: 2,
+
+  /**
+   * Divisor used to limit the amount the base fee per gas can change from one block to another.
+   */
+  BASE_FEE_MAX_CHANGE_DENOMINATOR: 8
+};

--- a/src/chains/ethereum/block/src/block-params.ts
+++ b/src/chains/ethereum/block/src/block-params.ts
@@ -7,14 +7,14 @@ export const BlockParams = {
   /**
    *  Base fee per gas for blocks without a parent containing a base fee per gas.
    */
-  INITIAL_BASE_FEE_PER_GAS: Quantity.from(1000000000).toBuffer(),
+  INITIAL_BASE_FEE_PER_GAS: 1000000000n,
   /**
    * Divisor used to set a block's target gas usage.
    */
-  ELASTICITY: 2,
+  ELASTICITY: 2n,
 
   /**
    * Divisor used to limit the amount the base fee per gas can change from one block to another.
    */
-  BASE_FEE_MAX_CHANGE_DENOMINATOR: 8
+  BASE_FEE_MAX_CHANGE_DENOMINATOR: 8n
 };

--- a/src/chains/ethereum/block/src/block-params.ts
+++ b/src/chains/ethereum/block/src/block-params.ts
@@ -1,20 +1,18 @@
 // NOTE these params may need to be changed at each hardfork
 // they can be tracked here: https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/hardforks/
 
-import { Quantity } from "@ganache/utils";
-
 export const BlockParams = {
   /**
    *  Base fee per gas for blocks without a parent containing a base fee per gas.
    */
-  INITIAL_BASE_FEE_PER_GAS: 1000000000n,
+  INITIAL_BASE_FEE_PER_GAS: 1000000000n as const,
   /**
    * Divisor used to set a block's target gas usage.
    */
-  ELASTICITY: 2n,
+  ELASTICITY: 2n as const,
 
   /**
    * Divisor used to limit the amount the base fee per gas can change from one block to another.
    */
-  BASE_FEE_MAX_CHANGE_DENOMINATOR: 8n
+  BASE_FEE_MAX_CHANGE_DENOMINATOR: 8n as const
 };

--- a/src/chains/ethereum/block/src/block.ts
+++ b/src/chains/ethereum/block/src/block.ts
@@ -10,13 +10,9 @@ import type Common from "@ethereumjs/common";
 import { encode, decode } from "@ganache/rlp";
 import { BaseFeeHeader, BlockHeader, makeHeader } from "./runtime-block";
 import { keccak } from "@ganache/utils";
-import {
-  EthereumRawBlockHeader,
-  GanacheRawBlock,
-  serialize
-} from "./serialize";
-import { Address } from "@ganache/ethereum-address";
+import { EthereumRawBlockHeader, GanacheRawBlock } from "./serialize";
 import { BlockParams } from "./block-params";
+
 export class Block {
   /**
    *  Base fee per gas for blocks without a parent containing a base fee per gas.

--- a/src/chains/ethereum/block/src/block.ts
+++ b/src/chains/ethereum/block/src/block.ts
@@ -64,12 +64,11 @@ export class Block {
     });
   }
 
-  toJSON(includeFullTransactions = false) {
+  toJSON(includeFullTransactions = false, common: Common) {
     const hash = this.hash();
     const txFn = this.getTxFn(includeFullTransactions);
     const hashBuffer = hash.toBuffer();
     const number = this.header.number.toBuffer();
-    const common = this._common;
     const jsonTxs = this._rawTransactions.map((raw, index) => {
       const [from, hash] = this._rawTransactionMetaData[index];
       const extra: GanacheRawExtraTx = [

--- a/src/chains/ethereum/block/src/block.ts
+++ b/src/chains/ethereum/block/src/block.ts
@@ -168,7 +168,7 @@ export class Block {
     // each block's base fee must be appropriately "floored" (Math.floor) before
     // the following block's base fee is calculated. If we don't do this we'll
     // end up with compounding rounding errors.
-    // FYI: the more performance but rounding error-prone would be:
+    // FYI: the more performant, but rounding error-prone, way is:
     // return lastMaxBlockBaseFee + (lastMaxBlockBaseFee * ((BASE_FEE_MAX_CHANGE_DENOMINATOR-1)**(blocks-1)) / ((BASE_FEE_MAX_CHANGE_DENOMINATOR)**(blocks-1)))
     while (--blocks) {
       lastMaxBlockBaseFee +=

--- a/src/chains/ethereum/block/src/block.ts
+++ b/src/chains/ethereum/block/src/block.ts
@@ -194,6 +194,6 @@ export class Block {
         nextBaseFee = baseFeePerGas - adjustedFeeDelta;
       }
     }
-    return Quantity.from(nextBaseFee).toBuffer(); // TODO there must be a better way
+    return Quantity.from(nextBaseFee).toBuffer();
   }
 }

--- a/src/chains/ethereum/block/src/block.ts
+++ b/src/chains/ethereum/block/src/block.ts
@@ -56,6 +56,7 @@ export class Block {
   }
 
   getTransactions() {
+    const common = this._common;
     return this._rawTransactions.map((raw, index) => {
       const [from, hash] = this._rawTransactionMetaData[index];
       const extra: GanacheRawExtraTx = [
@@ -65,7 +66,7 @@ export class Block {
         this.header.number.toBuffer(),
         Quantity.from(index).toBuffer()
       ];
-      return TransactionFactory.fromDatabaseTx(raw, this._common, extra);
+      return TransactionFactory.fromDatabaseTx(raw, common, extra);
     });
   }
 
@@ -74,6 +75,7 @@ export class Block {
     const txFn = this.getTxFn(includeFullTransactions);
     const hashBuffer = hash.toBuffer();
     const number = this.header.number.toBuffer();
+    const common = this._common;
     const jsonTxs = this._rawTransactions.map((raw, index) => {
       const [from, hash] = this._rawTransactionMetaData[index];
       const extra: GanacheRawExtraTx = [
@@ -83,7 +85,7 @@ export class Block {
         number,
         Quantity.from(index).toBuffer()
       ];
-      const tx = TransactionFactory.fromDatabaseTx(raw, this._common, extra);
+      const tx = TransactionFactory.fromDatabaseTx(raw, common, extra);
       return txFn(tx);
     });
 

--- a/src/chains/ethereum/block/src/block.ts
+++ b/src/chains/ethereum/block/src/block.ts
@@ -159,7 +159,7 @@ export class Block {
     return nextBaseFee;
   }
 
-  static calcMaxNBlocksBaseFee(blocks: number, parentHeader: BaseFeeHeader) {
+  static calcNBlocksMaxBaseFee(blocks: number, parentHeader: BaseFeeHeader) {
     const { BASE_FEE_MAX_CHANGE_DENOMINATOR } = BlockParams;
 
     let maxPossibleBaseFee = this.calcNextBaseFeeBigInt(parentHeader);

--- a/src/chains/ethereum/block/src/block.ts
+++ b/src/chains/ethereum/block/src/block.ts
@@ -162,7 +162,7 @@ export class Block {
   static calcMaxNBlocksBaseFee(blocks: number, parentHeader: BaseFeeHeader) {
     const { BASE_FEE_MAX_CHANGE_DENOMINATOR } = BlockParams;
 
-    let lastMaxBlockBaseFee = this.calcNextBaseFeeBigInt(parentHeader);
+    let maxPossibleBaseFee = this.calcNextBaseFeeBigInt(parentHeader);
 
     // we must calculate each future block's max base fee individually because
     // each block's base fee must be appropriately "floored" (Math.floor) before
@@ -171,10 +171,10 @@ export class Block {
     // FYI: the more performant, but rounding error-prone, way is:
     // return lastMaxBlockBaseFee + (lastMaxBlockBaseFee * ((BASE_FEE_MAX_CHANGE_DENOMINATOR-1)**(blocks-1)) / ((BASE_FEE_MAX_CHANGE_DENOMINATOR)**(blocks-1)))
     while (--blocks) {
-      lastMaxBlockBaseFee +=
-        lastMaxBlockBaseFee / BASE_FEE_MAX_CHANGE_DENOMINATOR;
+      maxPossibleBaseFee +=
+        maxPossibleBaseFee / BASE_FEE_MAX_CHANGE_DENOMINATOR;
     }
-    return lastMaxBlockBaseFee;
+    return maxPossibleBaseFee;
   }
 
   static calcNextBaseFee(parentBlock: Block) {

--- a/src/chains/ethereum/block/src/block.ts
+++ b/src/chains/ethereum/block/src/block.ts
@@ -8,10 +8,13 @@ import {
 } from "@ganache/ethereum-transaction";
 import type Common from "@ethereumjs/common";
 import { encode, decode } from "@ganache/rlp";
-import { BaseFeeHeader, BlockHeader, makeHeader } from "./runtime-block";
+import { BlockHeader, makeHeader } from "./runtime-block";
 import { keccak } from "@ganache/utils";
 import { EthereumRawBlockHeader, GanacheRawBlock } from "./serialize";
 import { BlockParams } from "./block-params";
+
+export type BaseFeeHeader = BlockHeader &
+  Required<Pick<BlockHeader, "baseFeePerGas">>;
 
 export class Block {
   /**

--- a/src/chains/ethereum/block/src/block.ts
+++ b/src/chains/ethereum/block/src/block.ts
@@ -8,7 +8,7 @@ import {
 } from "@ganache/ethereum-transaction";
 import type Common from "@ethereumjs/common";
 import { encode, decode } from "@ganache/rlp";
-import { BlockHeader, makeHeader } from "./runtime-block";
+import { BaseFeeHeader, BlockHeader, makeHeader } from "./runtime-block";
 import { keccak } from "@ganache/utils";
 import {
   EthereumRawBlockHeader,
@@ -18,6 +18,12 @@ import {
 import { Address } from "@ganache/ethereum-address";
 import { BlockParams } from "./block-params";
 export class Block {
+  /**
+   *  Base fee per gas for blocks without a parent containing a base fee per gas.
+   */
+  static readonly INITIAL_BASE_FEE_PER_GAS =
+    BlockParams.INITIAL_BASE_FEE_PER_GAS;
+
   protected _size: number;
   protected _raw: EthereumRawBlockHeader;
   protected _common: Common;
@@ -50,7 +56,6 @@ export class Block {
   }
 
   getTransactions() {
-    const common = this._common;
     return this._rawTransactions.map((raw, index) => {
       const [from, hash] = this._rawTransactionMetaData[index];
       const extra: GanacheRawExtraTx = [
@@ -60,11 +65,11 @@ export class Block {
         this.header.number.toBuffer(),
         Quantity.from(index).toBuffer()
       ];
-      return TransactionFactory.fromDatabaseTx(raw, common, extra);
+      return TransactionFactory.fromDatabaseTx(raw, this._common, extra);
     });
   }
 
-  toJSON(includeFullTransactions = false, common: Common) {
+  toJSON(includeFullTransactions = false) {
     const hash = this.hash();
     const txFn = this.getTxFn(includeFullTransactions);
     const hashBuffer = hash.toBuffer();
@@ -78,7 +83,7 @@ export class Block {
         number,
         Quantity.from(index).toBuffer()
       ];
-      const tx = TransactionFactory.fromDatabaseTx(raw, common, extra);
+      const tx = TransactionFactory.fromDatabaseTx(raw, this._common, extra);
       return txFn(tx);
     });
 
@@ -89,44 +94,6 @@ export class Block {
       transactions: jsonTxs,
       uncles: [] as string[] // this.value.uncleHeaders.map(function(uncleHash) {return to.hex(uncleHash)})
     };
-  }
-
-  static rawFromJSON(json: any, common: Common) {
-    const header: EthereumRawBlockHeader = [
-      Data.from(json.parentHash).toBuffer(),
-      Data.from(json.sha3Uncles).toBuffer(),
-      Address.from(json.miner).toBuffer(),
-      Data.from(json.stateRoot).toBuffer(),
-      Data.from(json.transactionsRoot).toBuffer(),
-      Data.from(json.receiptsRoot).toBuffer(),
-      Data.from(json.logsBloom).toBuffer(),
-      Quantity.from(json.difficulty).toBuffer(),
-      Quantity.from(json.number).toBuffer(),
-      Quantity.from(json.gasLimit).toBuffer(),
-      Quantity.from(json.gasUsed).toBuffer(),
-      Quantity.from(json.timestamp).toBuffer(),
-      Data.from(json.extraData).toBuffer(),
-      Data.from(json.mixHash).toBuffer(),
-      Data.from(json.nonce).toBuffer()
-    ];
-    const totalDifficulty = Quantity.from(json.totalDifficulty).toBuffer();
-    const txs: TypedDatabaseTransaction[] = [];
-    const extraTxs: GanacheRawBlockTransactionMetaData[] = [];
-    json.transactions.forEach(tx => {
-      const typedTx = TransactionFactory.fromRpc(tx, common);
-      const raw = typedTx.toEthRawTransaction(
-        typedTx.v.toBuffer(),
-        typedTx.r.toBuffer(),
-        typedTx.s.toBuffer()
-      );
-      txs.push(<TypedDatabaseTransaction>raw);
-      extraTxs.push([
-        Quantity.from(tx.from).toBuffer(),
-        Quantity.from(tx.hash).toBuffer()
-      ]);
-    });
-
-    return serialize([header, txs, [], totalDifficulty, extraTxs]).serialized;
   }
 
   getTxFn(
@@ -156,44 +123,68 @@ export class Block {
     return block;
   }
 
-  static calcNextBaseFee(common: Common, parentBlock?: Block) {
-    if (!common.isActivatedEIP(1559)) {
-      return undefined;
-    }
+  static calcNextBaseFeeBigInt(parentHeader: BaseFeeHeader) {
     let nextBaseFee: bigint;
-    // genesis block
-    if (parentBlock === undefined) {
-      nextBaseFee = BlockParams.INITIAL_BASE_FEE_PER_GAS;
-    } else {
-      const header = parentBlock.header;
-      const parentGasTarget =
-        header.gasLimit.toBigInt() / BlockParams.ELASTICITY;
-      const parentGasUsed = header.gasUsed.toBigInt();
-      const baseFeePerGas = header.baseFeePerGas
-        ? header.baseFeePerGas.toBigInt()
-        : BlockParams.INITIAL_BASE_FEE_PER_GAS;
-      if (parentGasTarget === parentGasUsed) {
-        nextBaseFee = baseFeePerGas;
-      } else if (parentGasUsed > parentGasTarget) {
-        const gasUsedDelta = parentGasUsed - parentGasTarget;
-        const adjustedFeeDelta =
-          (baseFeePerGas * gasUsedDelta) /
-          parentGasTarget /
-          BlockParams.BASE_FEE_MAX_CHANGE_DENOMINATOR;
-        if (adjustedFeeDelta > 1n) {
-          nextBaseFee = baseFeePerGas + adjustedFeeDelta;
-        } else {
-          nextBaseFee = baseFeePerGas + 1n;
-        }
+
+    const header = parentHeader;
+    const parentGasTarget = header.gasLimit.toBigInt() / BlockParams.ELASTICITY;
+    const parentGasUsed = header.gasUsed.toBigInt();
+    const baseFeePerGas = header.baseFeePerGas
+      ? header.baseFeePerGas.toBigInt()
+      : BlockParams.INITIAL_BASE_FEE_PER_GAS;
+
+    if (parentGasTarget === parentGasUsed) {
+      // If the parent gasUsed is the same as the target, the baseFee remains unchanged.
+      nextBaseFee = baseFeePerGas;
+    } else if (parentGasUsed > parentGasTarget) {
+      // If the parent block used more gas than its target, the baseFee should increase.
+      const gasUsedDelta = parentGasUsed - parentGasTarget;
+      const adjustedFeeDelta =
+        (baseFeePerGas * gasUsedDelta) /
+        parentGasTarget /
+        BlockParams.BASE_FEE_MAX_CHANGE_DENOMINATOR;
+      if (adjustedFeeDelta > 1n) {
+        nextBaseFee = baseFeePerGas + adjustedFeeDelta;
       } else {
-        const gasUsedDelta = parentGasTarget - parentGasUsed;
-        const adjustedFeeDelta =
-          (baseFeePerGas * gasUsedDelta) /
-          parentGasTarget /
-          BlockParams.BASE_FEE_MAX_CHANGE_DENOMINATOR;
-        nextBaseFee = baseFeePerGas - adjustedFeeDelta;
+        nextBaseFee = baseFeePerGas + 1n;
       }
+    } else {
+      // Otherwise if the parent block used less gas than its target, the baseFee should decrease.
+      const gasUsedDelta = parentGasTarget - parentGasUsed;
+      const adjustedFeeDelta =
+        (baseFeePerGas * gasUsedDelta) /
+        parentGasTarget /
+        BlockParams.BASE_FEE_MAX_CHANGE_DENOMINATOR;
+      nextBaseFee = baseFeePerGas - adjustedFeeDelta;
     }
-    return Quantity.from(nextBaseFee).toBuffer();
+
+    return nextBaseFee;
+  }
+
+  static calcMaxNBlocksBaseFee(blocks: number, parentHeader: BaseFeeHeader) {
+    const { BASE_FEE_MAX_CHANGE_DENOMINATOR } = BlockParams;
+
+    let lastMaxBlockBaseFee = this.calcNextBaseFeeBigInt(parentHeader);
+
+    // we must calculate each future block's max base fee individually because
+    // each block's base fee must be appropriately "floored" (Math.floor) before
+    // the following block's base fee is calculated. If we don't do this we'll
+    // end up with compounding rounding errors.
+    // FYI: the more performance but rounding error-prone would be:
+    // return lastMaxBlockBaseFee + (lastMaxBlockBaseFee * ((BASE_FEE_MAX_CHANGE_DENOMINATOR-1)**(blocks-1)) / ((BASE_FEE_MAX_CHANGE_DENOMINATOR)**(blocks-1)))
+    while (--blocks) {
+      lastMaxBlockBaseFee +=
+        lastMaxBlockBaseFee / BASE_FEE_MAX_CHANGE_DENOMINATOR;
+    }
+    return lastMaxBlockBaseFee;
+  }
+
+  static calcNextBaseFee(parentBlock: Block) {
+    const header = parentBlock.header;
+    if (header.baseFeePerGas === undefined) {
+      return undefined;
+    } else {
+      return this.calcNextBaseFeeBigInt(<BaseFeeHeader>header);
+    }
   }
 }

--- a/src/chains/ethereum/block/src/block.ts
+++ b/src/chains/ethereum/block/src/block.ts
@@ -194,6 +194,6 @@ export class Block {
         nextBaseFee = baseFeePerGas - adjustedFeeDelta;
       }
     }
-    return Quantity.from(nextBaseFee);
+    return Quantity.from(nextBaseFee).toBuffer(); // TODO there must be a better way
   }
 }

--- a/src/chains/ethereum/block/src/runtime-block.ts
+++ b/src/chains/ethereum/block/src/runtime-block.ts
@@ -48,9 +48,6 @@ export type BlockHeader = {
   baseFeePerGas?: Quantity;
 };
 
-export type BaseFeeHeader = BlockHeader &
-  Required<Pick<BlockHeader, "baseFeePerGas">>;
-
 /**
  * Returns the size of the serialized data as it would have been calculated had
  * we stored things geth does, i.e., `totalDfficulty` is not usually stored in

--- a/src/chains/ethereum/block/src/runtime-block.ts
+++ b/src/chains/ethereum/block/src/runtime-block.ts
@@ -45,6 +45,7 @@ export type BlockHeader = {
   extraData: Data;
   mixHash: Data;
   nonce: Data;
+  baseFeePerGas?: Quantity;
 };
 
 /**
@@ -79,7 +80,9 @@ export function makeHeader(
     extraData: Data.from(raw[12]),
     mixHash: Data.from(raw[13], 32),
     nonce: Data.from(raw[14], 8),
-    totalDifficulty: Quantity.from(totalDifficulty, false)
+    totalDifficulty: Quantity.from(totalDifficulty, false),
+    baseFeePerGas:
+      raw[15] === BUFFER_EMPTY ? undefined : Quantity.from(raw[15], false)
   };
 }
 
@@ -96,6 +99,7 @@ export class RuntimeBlock {
     gasLimit: BnExtra;
     gasUsed: BnExtra;
     timestamp: BnExtra;
+    baseFeePerGas?: BnExtra;
   };
 
   constructor(
@@ -106,7 +110,8 @@ export class RuntimeBlock {
     gasUsed: Buffer,
     timestamp: Quantity,
     difficulty: Quantity,
-    previousBlockTotalDifficulty: Quantity
+    previousBlockTotalDifficulty: Quantity,
+    baseFeePerGas?: Buffer
   ) {
     const ts = timestamp.toBuffer();
     const coinbaseBuffer = coinbase.toBuffer();
@@ -120,7 +125,9 @@ export class RuntimeBlock {
       ).toBuffer(),
       gasLimit: new BnExtra(gasLimit),
       gasUsed: new BnExtra(gasUsed),
-      timestamp: new BnExtra(ts)
+      timestamp: new BnExtra(ts),
+      baseFeePerGas:
+        baseFeePerGas === undefined ? undefined : new BnExtra(baseFeePerGas)
     };
   }
 
@@ -154,7 +161,10 @@ export class RuntimeBlock {
       header.timestamp.buf,
       extraData.toBuffer(),
       BUFFER_32_ZERO, // mixHash
-      BUFFER_8_ZERO // nonce
+      BUFFER_8_ZERO, // nonce
+      header.baseFeePerGas === undefined
+        ? BUFFER_EMPTY
+        : header.baseFeePerGas.buf
     ];
     const { totalDifficulty } = header;
     const txs: TypedDatabaseTransaction[] = [];

--- a/src/chains/ethereum/block/src/serialize.ts
+++ b/src/chains/ethereum/block/src/serialize.ts
@@ -25,7 +25,8 @@ export type EthereumRawBlockHeader = [
   timestamp: Buffer,
   extraData: Buffer,
   mixHash: Buffer,
-  nonce: Buffer
+  nonce: Buffer,
+  baseFeePerGas?: Buffer
 ];
 export type EthereumRawBlock = [
   rawHeader: EthereumRawBlockHeader,

--- a/src/chains/ethereum/block/tests/index.test.ts
+++ b/src/chains/ethereum/block/tests/index.test.ts
@@ -28,7 +28,8 @@ describe("@ganache/ethereum-block", async () => {
         miner: {
           blockGasLimit: "0xB749E0"
         },
-        chain: { chainId: 1337 }
+        chain: { chainId: 1337 },
+        logging: { logger: { log: (_message: string) => {} } } // ignore logging
       });
       const wallet = new Wallet(options.wallet);
       const [from, to] = wallet.addresses;

--- a/src/chains/ethereum/block/tests/index.test.ts
+++ b/src/chains/ethereum/block/tests/index.test.ts
@@ -66,7 +66,7 @@ describe("@ganache/ethereum-block", async () => {
         { txCount: 290, newGasLimit: 11988553 },
         { txCount: 10, newGasLimit: 11976847 },
         // because we use the previous block to calculate the base fee,
-        // send/mine one more tx so we can see what the reulting base fee
+        // send/mine one more tx so we can see what the resulting base fee
         // is from the previous block
         { txCount: 1, newGasLimit: 11965152 }
       ];

--- a/src/chains/ethereum/block/tests/index.test.ts
+++ b/src/chains/ethereum/block/tests/index.test.ts
@@ -1,6 +1,104 @@
 import assert from "assert";
-import ethereumBlock from "../";
+import { Address } from "@ganache/ethereum-address";
+import { BUFFER_ZERO, Data, Quantity } from "@ganache/utils";
+import Common from "@ethereumjs/common";
+import Wallet from "../../ethereum/src/wallet";
+import { TransactionFactory } from "@ganache/ethereum-transaction";
+import { TypedRpcTransaction } from "@ganache/ethereum-transaction";
+import Blockchain from "../../ethereum/src/blockchain";
+import { EthereumOptionsConfig } from "../../options/src/index";
 
-describe("@ganache/ethereum-block", () => {
-  it("needs tests");
+describe("@ganache/ethereum-block", async () => {
+  describe("baseFeePerGas calculations", () => {
+    let blockchain: Blockchain;
+    before(async function () {
+      this.timeout(0);
+      const privKey = `0x${"46".repeat(32)}`;
+      const privKeyData = Data.from(privKey);
+      const options = EthereumOptionsConfig.normalize({
+        wallet: {
+          accounts: [
+            { secretKey: privKey, balance: 1000000000000000000000n },
+            {
+              secretKey: `0x${"46".repeat(31)}47`,
+              balance: 1000000000000000000000n
+            }
+          ]
+        },
+        miner: {
+          blockGasLimit: "0xB749E0",
+          extraData: "0xd883010a06846765746888676f312e31362e34856c696e7578"
+        },
+        chain: { chainId: 1337 }
+      });
+      const wallet = new Wallet(options.wallet);
+      const [from, to] = wallet.addresses;
+      const fromAddress = new Address(from);
+      const tx: TypedRpcTransaction = {
+        type: "0x2",
+        from: from,
+        to: to,
+        maxFeePerGas: "0x344221FFF",
+        chainId: "0x539",
+        gas: "0x5208"
+      };
+
+      const common = Common.forCustomChain(
+        "mainnet",
+        {
+          name: "ganache",
+          chainId: 1337,
+          comment: "Local test network",
+          bootstrapNodes: []
+        },
+        "london"
+      );
+      blockchain = new Blockchain(options, fromAddress);
+      await blockchain.initialize(wallet.initialAccounts);
+      // to verify our calculations for the block's baseFeePerGas,
+      // we're comparing our data to geth. Geth's gasLimit changes
+      // every block, so we need to set those values here according
+      // to what geth had. We'll need to reset each time a block is
+      // mined and we'll need to mine blocks such that we have one
+      // with each of the cases: 1. gasUsed < gasTarget, 2. gasUsed >
+      // gasTarget, gasUsed = gasTarget.
+      const gethBlockData = [
+        { txCount: 286, newGasLimit: 12000271 },
+        { txCount: 290, newGasLimit: 11988553 },
+        { txCount: 10, newGasLimit: 11976847 },
+        // because we use the previous block to calculate the base fee,
+        // send/mine one more tx so we can see what the reulting base fee
+        // is from the previous block
+        { txCount: 1, newGasLimit: 11965152 }
+      ];
+
+      for (let i = 0; i < gethBlockData.length; i++) {
+        const data = gethBlockData[i];
+        options.miner.blockGasLimit = Quantity.from(data.newGasLimit);
+        blockchain.pause();
+        for (let j = 0; j < data.txCount; j++) {
+          const feeMarketTx = TransactionFactory.fromRpc(tx, common);
+          await blockchain.queueTransaction(feeMarketTx, privKeyData);
+        }
+        // mine all txs in that group before moving onto the next block
+        await blockchain.resume();
+      }
+    });
+    it("genesis block has initial baseFeePerGas of 1000000000", async () => {
+      const block = await blockchain.blocks.get(BUFFER_ZERO);
+      assert.strictEqual(block.header.baseFeePerGas.toNumber(), 1000000000);
+    });
+    it("baseFeePerGas is calculated correctly when gasUsed is equal to gasTarget", async () => {
+      const block = await blockchain.blocks.get(Buffer.from([2]));
+      assert.strictEqual(block.header.baseFeePerGas.toNumber(), 875106911);
+    });
+    it("baseFeePerGas is calculated correctly when gasUsed is above gasTarget", async () => {
+      const block = await blockchain.blocks.get(Buffer.from([3]));
+      assert.strictEqual(block.header.baseFeePerGas.toNumber(), 876853759);
+    });
+    it("baseFeePerGas is calculated correctly when gasUsed is below gasTarget", async () => {
+      const block = await blockchain.blocks.get(Buffer.from([4]));
+      assert.strictEqual(block.header.baseFeePerGas.toNumber(), 771090691);
+    });
+  });
 });

--- a/src/chains/ethereum/block/tests/index.test.ts
+++ b/src/chains/ethereum/block/tests/index.test.ts
@@ -12,7 +12,7 @@ describe("@ganache/ethereum-block", async () => {
   describe("baseFeePerGas calculations", () => {
     let blockchain: Blockchain;
     before(async function () {
-      this.timeout(0);
+      this.timeout(5000);
       const privKey = `0x${"46".repeat(32)}`;
       const privKeyData = Data.from(privKey);
       const options = EthereumOptionsConfig.normalize({

--- a/src/chains/ethereum/block/tests/index.test.ts
+++ b/src/chains/ethereum/block/tests/index.test.ts
@@ -26,8 +26,7 @@ describe("@ganache/ethereum-block", async () => {
           ]
         },
         miner: {
-          blockGasLimit: "0xB749E0",
-          extraData: "0xd883010a06846765746888676f312e31362e34856c696e7578"
+          blockGasLimit: "0xB749E0"
         },
         chain: { chainId: 1337 }
       });

--- a/src/chains/ethereum/block/tests/index.test.ts
+++ b/src/chains/ethereum/block/tests/index.test.ts
@@ -83,19 +83,19 @@ describe("@ganache/ethereum-block", async () => {
         await blockchain.resume();
       }
     });
-    it("genesis block has initial baseFeePerGas of 1000000000", async () => {
+    it("has initial baseFeePerGas of 1000000000 for genesis block", async () => {
       const block = await blockchain.blocks.get(BUFFER_ZERO);
       assert.strictEqual(block.header.baseFeePerGas.toNumber(), 1000000000);
     });
-    it("baseFeePerGas is calculated correctly when gasUsed is equal to gasTarget", async () => {
+    it("calculates baseFeePerGas correctly when gasUsed is equal to gasTarget", async () => {
       const block = await blockchain.blocks.get(Buffer.from([2]));
       assert.strictEqual(block.header.baseFeePerGas.toNumber(), 875106911);
     });
-    it("baseFeePerGas is calculated correctly when gasUsed is above gasTarget", async () => {
+    it("calculates baseFeePerGas correctly when gasUsed is above gasTarget", async () => {
       const block = await blockchain.blocks.get(Buffer.from([3]));
       assert.strictEqual(block.header.baseFeePerGas.toNumber(), 876853759);
     });
-    it("baseFeePerGas is calculated correctly when gasUsed is below gasTarget", async () => {
+    it("calculates baseFeePerGas correctly when gasUsed is below gasTarget", async () => {
       const block = await blockchain.blocks.get(Buffer.from([4]));
       assert.strictEqual(block.header.baseFeePerGas.toNumber(), 771090691);
     });

--- a/src/chains/ethereum/ethereum/package.json
+++ b/src/chains/ethereum/ethereum/package.json
@@ -77,7 +77,6 @@
     "lodash.clonedeep": "4.5.0",
     "merkle-patricia-tree": "4.2.0",
     "scrypt-js": "3.0.1",
-    "secp256k1": "4.0.2",
     "seedrandom": "3.0.5",
     "semaphore": "1.1.0",
     "subleveldown": "5.0.1",

--- a/src/chains/ethereum/ethereum/package.json
+++ b/src/chains/ethereum/ethereum/package.json
@@ -62,6 +62,7 @@
     "@ganache/options": "0.1.1-alpha.0",
     "@ganache/promise-queue": "0.1.1-alpha.0",
     "@ganache/rlp": "0.1.1-alpha.0",
+    "@ganache/secp256k1": "0.1.0",
     "@ganache/utils": "0.1.1-alpha.0",
     "abort-controller": "3.0.0",
     "bip39": "3.0.4",

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -39,7 +39,7 @@ import {
   JsonRpcErrorCode
 } from "@ganache/utils";
 import Blockchain from "./blockchain";
-import { EthereumInternalOptions, Hardfork } from "@ganache/ethereum-options";
+import { EthereumInternalOptions } from "@ganache/ethereum-options";
 import Wallet from "./wallet";
 import { $INLINE_JSON } from "ts-transformer-inline-file";
 

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -50,6 +50,7 @@ import { parseFilterDetails, parseFilterRange } from "./helpers/filter-parsing";
 import { decode } from "@ganache/rlp";
 import { Address } from "@ganache/ethereum-address";
 import { GanacheRawBlock } from "@ganache/ethereum-block";
+import { Capacity } from "./miner/miner";
 
 // Read in the current ganache version from core's package.json
 const { version } = $INLINE_JSON("../../../../packages/ganache/package.json");
@@ -276,13 +277,21 @@ export default class EthereumApi implements Api {
       // Developers like to move the blockchain forward by thousands of blocks
       // at a time and doing this would make it way faster
       for (let i = 0; i < blocks; i++) {
-        const transactions = await blockchain.mine(-1, timestamp, true);
+        const transactions = await blockchain.mine(
+          Capacity.FillBlock,
+          timestamp,
+          true
+        );
         if (vmErrorsOnRPCResponse) {
           assertExceptionalTransactions(transactions);
         }
       }
     } else {
-      const transactions = await blockchain.mine(-1, arg as number, true);
+      const transactions = await blockchain.mine(
+        Capacity.FillBlock,
+        arg as number,
+        true
+      );
       if (vmErrorsOnRPCResponse) {
         assertExceptionalTransactions(transactions);
       }
@@ -325,7 +334,7 @@ export default class EthereumApi implements Api {
 
     // TODO: do we need to mine a block here? The changes we're making really don't make any sense at all
     // and produce an invalid trie going forward.
-    await blockchain.mine(0);
+    await blockchain.mine(Capacity.Empty);
     return true;
   }
 

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -1512,8 +1512,7 @@ export default class EthereumApi implements Api {
    * ```
    */
   @assertArgLength(1)
-  async eth_getTransactionByHash(transactionHash: DATA): Promise<any> {
-    // TODO: fix return type
+  async eth_getTransactionByHash(transactionHash: DATA) {
     const { transactions } = this.#blockchain;
     const hashBuffer = Data.from(transactionHash).toBuffer();
 

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -1654,7 +1654,9 @@ export default class EthereumApi implements Api {
 
     if ("maxFeePerGas" in tx && tx.maxFeePerGas.isNull()) {
       const block = await this.#blockchain.blocks.get("latest").catch(_ => null); // prettier-ignore
-      tx.maxFeePerGas = Block.calcNextBaseFee(this.#blockchain.common, block);
+      tx.maxFeePerGas = Quantity.from(
+        Block.calcNextBaseFee(this.#blockchain.common, block)
+      );
     }
 
     if (isUnlockedAccount) {

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -289,7 +289,7 @@ export default class EthereumApi implements Api {
     } else {
       const transactions = await blockchain.mine(
         Capacity.FillBlock,
-        arg as number,
+        arg as number | null,
         true
       );
       if (vmErrorsOnRPCResponse) {

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -1665,7 +1665,7 @@ export default class EthereumApi implements Api {
     if ("maxFeePerGas" in tx && tx.maxFeePerGas.isNull()) {
       const block = blockchain.blocks.latest;
       tx.maxFeePerGas = Quantity.from(
-        Block.calcMaxNBlocksBaseFee(3, <BaseFeeHeader>block.header)
+        Block.calcNBlocksMaxBaseFee(3, <BaseFeeHeader>block.header)
       );
     }
 

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -1663,7 +1663,7 @@ export default class EthereumApi implements Api {
     }
 
     if ("maxFeePerGas" in tx && tx.maxFeePerGas.isNull()) {
-      const block = this.#blockchain.blocks.latest;
+      const block = blockchain.blocks.latest;
       tx.maxFeePerGas = Quantity.from(
         Block.calcMaxNBlocksBaseFee(3, <BaseFeeHeader>block.header)
       );

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -860,7 +860,7 @@ export default class EthereumApi implements Api {
   @assertArgLength(1, 2)
   async eth_getBlockByNumber(number: QUANTITY | Tag, transactions = false) {
     const block = await this.#blockchain.blocks.get(number).catch(_ => null);
-    return block ? block.toJSON(transactions) : null;
+    return block ? block.toJSON(transactions, this.#blockchain.common) : null;
   }
 
   /**
@@ -1503,7 +1503,8 @@ export default class EthereumApi implements Api {
    * ```
    */
   @assertArgLength(1)
-  async eth_getTransactionByHash(transactionHash: DATA) {
+  async eth_getTransactionByHash(transactionHash: DATA): Promise<any> {
+    // TODO: fix return type
     const { transactions } = this.#blockchain;
     const hashBuffer = Data.from(transactionHash).toBuffer();
 
@@ -1638,9 +1639,13 @@ export default class EthereumApi implements Api {
         tx.gas = defaultLimit;
       }
     }
-
-    if (tx.gasPrice.isNull()) {
+    if ("gasPrice" in tx && tx.gasPrice.isNull()) {
       tx.gasPrice = this.#options.miner.defaultGasPrice;
+    }
+
+    if ("maxFeePerGas" in tx && tx.maxFeePerGas.isNull()) {
+      const block = await this.#blockchain.blocks.get("latest").catch(_ => null); // prettier-ignore
+      tx.maxFeePerGas = Block.calcNextBaseFee(this.#blockchain.common, block);
     }
 
     if (isUnlockedAccount) {
@@ -1650,6 +1655,7 @@ export default class EthereumApi implements Api {
       return blockchain.queueTransaction(tx);
     }
   }
+
   /**
    * Signs a transaction that can be submitted to the network at a later time using `eth_sendRawTransaction`.
    *

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -335,18 +335,18 @@ export default class Blockchain extends Emittery.Typed<
 
       //#region automatic mining
       const nullResolved = Promise.resolve(null);
-      const mineAll = (maxTransactions: number | Capacity) =>
+      const mineAll = (maxTransactions: Capacity) =>
         this.#isPaused() ? nullResolved : this.mine(maxTransactions);
       if (instamine) {
         // insta mining
         // whenever the transaction pool is drained mine the txs into blocks
-        txPool.on("drain", mineAll.bind(null, 1));
+        txPool.on("drain", mineAll.bind(null, Capacity.Single));
       } else {
         // interval mining
         const wait = () =>
           // unref, so we don't hold the chain open if nothing can interact with it
           unref((this.#timer = setTimeout(next, minerOpts.blockTime * 1e3)));
-        const next = () => mineAll(-1).then(wait);
+        const next = () => mineAll(Capacity.FillBlock).then(wait);
         wait();
       }
       //#endregion

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -681,7 +681,7 @@ export default class Blockchain extends Emittery.Typed<
       : undefined;
     const genesis = new RuntimeBlock(
       rawBlockNumber,
-      Quantity.from(BUFFER_32_ZERO),
+      Data.from(BUFFER_32_ZERO),
       this.coinbase,
       blockGasLimit.toBuffer(),
       BUFFER_ZERO,

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -1140,12 +1140,12 @@ export default class Blockchain extends Emittery.Typed<
         }
       }
     };
-    let mypromise;
+
     const beforeTxListener = async (tx: VmTransaction) => {
       if (tx === transaction) {
         if (keys && contractAddress) {
           const database = this.#database;
-          return (mypromise = Promise.all(
+          return Promise.all(
             keys.map(async key => {
               // get the raw key using the hashed key
               let rawKey = await database.storageKeys.get(key);
@@ -1160,7 +1160,7 @@ export default class Blockchain extends Emittery.Typed<
                 value: Data.from(result, 32)
               };
             })
-          ));
+          );
         }
         vm.on("step", stepListener);
       }
@@ -1193,7 +1193,6 @@ export default class Blockchain extends Emittery.Typed<
     // It's possible we've removed handling specific cases in this implementation.
     // e.g., the previous incantation of RuntimeError
     await runTransactions(vm, newBlock.transactions, newBlock);
-    await mypromise;
 
     // Just to be safe
     removeListeners();

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -524,7 +524,8 @@ export default class Blockchain extends Emittery.Typed<
       BUFFER_ZERO,
       Quantity.from(timestamp == null ? this.#currentTime() : timestamp),
       this.#options.miner.difficulty,
-      previousBlock.header.totalDifficulty
+      previousBlock.header.totalDifficulty,
+      Block.calcNextBaseFee(this.common, previousBlock)
     );
   };
 
@@ -630,7 +631,8 @@ export default class Blockchain extends Emittery.Typed<
         BUFFER_ZERO,
         Quantity.from(timestamp),
         this.#options.miner.difficulty,
-        this.fallback.block.header.totalDifficulty
+        this.fallback.block.header.totalDifficulty,
+        Block.calcNextBaseFee(this.common)
       );
 
       // store the genesis block in the database
@@ -672,7 +674,8 @@ export default class Blockchain extends Emittery.Typed<
       BUFFER_ZERO,
       Quantity.from(timestamp),
       this.#options.miner.difficulty,
-      RPCQUANTITY_ZERO // we start the totalDifficulty at 0
+      RPCQUANTITY_ZERO, // we start the totalDifficulty at 0
+      Block.calcNextBaseFee(this.common)
     );
 
     // store the genesis block in the database
@@ -1208,7 +1211,8 @@ export default class Blockchain extends Emittery.Typed<
       // make sure we use the same timestamp as the target block
       targetBlock.header.timestamp,
       this.#options.miner.difficulty,
-      parentBlock.header.totalDifficulty
+      parentBlock.header.totalDifficulty,
+      Block.calcNextBaseFee(this.common, parentBlock)
     ) as RuntimeBlock & {
       uncleHeaders: [];
       transactions: VmTransaction[];

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -1,5 +1,5 @@
 import { EOL } from "os";
-import Miner from "./miner/miner";
+import Miner, { Capacity } from "./miner/miner";
 import Database from "./database";
 import Emittery from "emittery";
 import {
@@ -336,7 +336,7 @@ export default class Blockchain extends Emittery.Typed<
 
       //#region automatic mining
       const nullResolved = Promise.resolve(null);
-      const mineAll = (maxTransactions: number) =>
+      const mineAll = (maxTransactions: number | Capacity) =>
         this.#isPaused() ? nullResolved : this.mine(maxTransactions);
       if (instamine) {
         // insta mining
@@ -534,7 +534,7 @@ export default class Blockchain extends Emittery.Typed<
   };
 
   mine = async (
-    maxTransactions: number,
+    maxTransactions: number | Capacity,
     timestamp?: number,
     onlyOneBlock: boolean = false
   ) => {
@@ -562,7 +562,7 @@ export default class Blockchain extends Emittery.Typed<
 
     // if we are instamining mine a block right away
     if (this.#instamine) {
-      return this.mine(-1);
+      return this.mine(Capacity.FillBlock);
     }
   }
 

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -483,8 +483,8 @@ export default class Blockchain extends Emittery.Typed<
       str += `  Contract created: ${Address.from(contractAddress)}${EOL}`;
     }
 
-    str += `  Gas usage: ${Quantity.from(receipt.raw[1]).toNumber()}${EOL}
-  Block number: ${blockNumber.toNumber()}${EOL}
+    str += `  Gas usage: ${Quantity.from(receipt.raw[1]).toNumber()}
+  Block number: ${blockNumber.toNumber()}
   Block time: ${timestamp}${EOL}`;
 
     if (error) {

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -329,7 +329,6 @@ export default class Blockchain extends Emittery.Typed<
       const miner = (this.#miner = new Miner(
         minerOpts,
         txPool.executables,
-        instamine,
         this.vm,
         this.#readyNextBlock
       ));
@@ -525,7 +524,7 @@ export default class Blockchain extends Emittery.Typed<
       Quantity.from(timestamp == null ? this.#currentTime() : timestamp),
       this.#options.miner.difficulty,
       previousBlock.header.totalDifficulty,
-      Block.calcNextBaseFee(this.common, previousBlock).toBuffer()
+      Block.calcNextBaseFee(this.common, previousBlock)
     );
   };
 
@@ -632,7 +631,7 @@ export default class Blockchain extends Emittery.Typed<
         Quantity.from(timestamp),
         this.#options.miner.difficulty,
         this.fallback.block.header.totalDifficulty,
-        Block.calcNextBaseFee(this.common, this.fallback.block).toBuffer()
+        Block.calcNextBaseFee(this.common, this.fallback.block)
       );
 
       // store the genesis block in the database
@@ -675,7 +674,7 @@ export default class Blockchain extends Emittery.Typed<
       Quantity.from(timestamp),
       this.#options.miner.difficulty,
       RPCQUANTITY_ZERO, // we start the totalDifficulty at 0
-      Block.calcNextBaseFee(this.common).toBuffer()
+      Block.calcNextBaseFee(this.common)
     );
 
     // store the genesis block in the database
@@ -1212,7 +1211,7 @@ export default class Blockchain extends Emittery.Typed<
       targetBlock.header.timestamp,
       this.#options.miner.difficulty,
       parentBlock.header.totalDifficulty,
-      Block.calcNextBaseFee(this.common, parentBlock).toBuffer()
+      Block.calcNextBaseFee(this.common, parentBlock)
     ) as RuntimeBlock & {
       uncleHeaders: [];
       transactions: VmTransaction[];

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -525,7 +525,7 @@ export default class Blockchain extends Emittery.Typed<
       Quantity.from(timestamp == null ? this.#currentTime() : timestamp),
       this.#options.miner.difficulty,
       previousBlock.header.totalDifficulty,
-      Block.calcNextBaseFee(this.common, previousBlock)
+      Block.calcNextBaseFee(this.common, previousBlock).toBuffer()
     );
   };
 
@@ -632,7 +632,7 @@ export default class Blockchain extends Emittery.Typed<
         Quantity.from(timestamp),
         this.#options.miner.difficulty,
         this.fallback.block.header.totalDifficulty,
-        Block.calcNextBaseFee(this.common)
+        Block.calcNextBaseFee(this.common, this.fallback.block).toBuffer()
       );
 
       // store the genesis block in the database
@@ -675,7 +675,7 @@ export default class Blockchain extends Emittery.Typed<
       Quantity.from(timestamp),
       this.#options.miner.difficulty,
       RPCQUANTITY_ZERO, // we start the totalDifficulty at 0
-      Block.calcNextBaseFee(this.common)
+      Block.calcNextBaseFee(this.common).toBuffer()
     );
 
     // store the genesis block in the database
@@ -1212,7 +1212,7 @@ export default class Blockchain extends Emittery.Typed<
       targetBlock.header.timestamp,
       this.#options.miner.difficulty,
       parentBlock.header.totalDifficulty,
-      Block.calcNextBaseFee(this.common, parentBlock)
+      Block.calcNextBaseFee(this.common, parentBlock).toBuffer()
     ) as RuntimeBlock & {
       uncleHeaders: [];
       transactions: VmTransaction[];

--- a/src/chains/ethereum/ethereum/src/data-managers/account-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/account-manager.ts
@@ -5,7 +5,7 @@ import {
   Tag
 } from "@ganache/ethereum-utils";
 import { KECCAK256_NULL } from "ethereumjs-util";
-import { Quantity, Data, RPCQUANTITY_ZERO, BUFFER_EMPTY } from "@ganache/utils";
+import { Quantity, Data, RPCQUANTITY_ZERO, DATA_EMPTY } from "@ganache/utils";
 import { Address } from "@ganache/ethereum-address";
 import { decode } from "@ganache/rlp";
 import Blockchain from "../blockchain";
@@ -86,10 +86,10 @@ export default class AccountManager {
   ): Promise<Data> {
     const data = await this.getRaw(address, blockNumber);
 
-    if (data == null) return Data.from(BUFFER_EMPTY);
+    if (data == null) return DATA_EMPTY;
 
     const [, , , codeHash] = decode<EthereumRawAccount>(data);
-    if (codeHash.equals(KECCAK256_NULL)) return Data.from(BUFFER_EMPTY);
+    if (codeHash.equals(KECCAK256_NULL)) return DATA_EMPTY;
     else return this.#blockchain.trie.db.get(codeHash).then(Data.from);
   }
 }

--- a/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
@@ -83,7 +83,7 @@ export default class BlockManager extends Manager<Block> {
       Data.from(json.mixHash).toBuffer(),
       Data.from(json.nonce).toBuffer()
     ];
-    // only add baseFeePerGas if the transaction JSON already has it
+    // only add baseFeePerGas if the block's JSON already has it
     if (json.baseFeePerGas !== undefined) {
       header[15] = Data.from(json.baseFeePerGas).toBuffer();
     }

--- a/src/chains/ethereum/ethereum/src/data-managers/transaction-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/transaction-manager.ts
@@ -8,6 +8,7 @@ import type Common from "@ethereumjs/common";
 import { Data, Quantity } from "@ganache/utils";
 import {
   TransactionFactory,
+  TransactionType,
   TypedRpcTransaction,
   TypedTransaction
 } from "@ganache/ethereum-transaction";
@@ -47,7 +48,14 @@ export default class TransactionManager extends Manager<NoOp> {
       [Data.from(transactionHash).toString()]
     );
     if (tx == null) return null;
-    const runTx = TransactionFactory.fromRpc(tx, fallback.common);
+    const extra = [
+      Data.from(tx.from, 20).toBuffer(),
+      Data.from((tx as any).hash, 32).toBuffer(),
+      Data.from((tx as any).blockHash, 32).toBuffer(),
+      Quantity.from((tx as any).blockNumber).toBuffer(),
+      Quantity.from((tx as any).transactionIndex).toBuffer()
+    ] as any;
+    const runTx = TransactionFactory.fromRpc(tx, fallback.common, extra);
     return runTx.serializeForDb(
       Data.from((tx as any).blockHash, 32),
       Quantity.from((tx as any).blockNumber),

--- a/src/chains/ethereum/ethereum/src/forking/fork.ts
+++ b/src/chains/ethereum/ethereum/src/forking/fork.ts
@@ -9,6 +9,7 @@ import { Tag } from "@ganache/ethereum-utils";
 import { Block } from "@ganache/ethereum-block";
 import { Address } from "@ganache/ethereum-address";
 import { Account } from "@ganache/ethereum-utils";
+import BlockManager from "../data-managers/block-manager";
 
 function fetchChainId(fork: Fork) {
   return fork
@@ -188,7 +189,10 @@ export class Fork {
       this.#setBlockDataFromChainAndOptions(),
       this.#setCommonFromChain()
     ]);
-    this.block = new Block(Block.rawFromJSON(block, this.common), this.common);
+    this.block = new Block(
+      BlockManager.rawFromJSON(block, this.common),
+      this.common
+    );
   }
 
   public request<T = unknown>(method: string, params: unknown[]): Promise<T> {

--- a/src/chains/ethereum/ethereum/src/helpers/run-transactions.ts
+++ b/src/chains/ethereum/ethereum/src/helpers/run-transactions.ts
@@ -24,6 +24,8 @@ export async function runTransactions(
       })
       // we ignore transactions that error because we just want to _run_ these,
       // transactions just to update the blockchain's state
-      .catch(() => {});
+      .catch(e => {
+        console.log(e);
+      });
   }
 }

--- a/src/chains/ethereum/ethereum/src/helpers/run-transactions.ts
+++ b/src/chains/ethereum/ethereum/src/helpers/run-transactions.ts
@@ -24,8 +24,6 @@ export async function runTransactions(
       })
       // we ignore transactions that error because we just want to _run_ these,
       // transactions just to update the blockchain's state
-      .catch(e => {
-        console.log(e);
-      });
+      .catch(() => {});
   }
 }

--- a/src/chains/ethereum/ethereum/src/miner/DESIGN-DECISIONS.md
+++ b/src/chains/ethereum/ethereum/src/miner/DESIGN-DECISIONS.md
@@ -1,0 +1,14 @@
+# Miner Design Decisions
+
+##### [Commit 33aae901f1ba4941e33dea9c5f3a9b3ae9145d37](https://github.com/trufflesuite/ganache/commit/33aae901f1ba4941e33dea9c5f3a9b3ae9145d37)
+
+- Miner no longer sees if ganache is configured with instamine mode.
+  - Instead, the miner just trusts the `maxTransactions` and `onlyOneBlock` flags.
+
+Miner behavior
+
+- From `blockchain.ts`, when `this.resume` and thus `this.mine(Capacity.FillBlock)` is called when in instamine mode, the miner will mine all transactions in the txPool. If there are enough transactions to fill multiple blocks, multiple blocks will be mined until the txPool is empty, then normal instamine behaviour will resume.
+- From `blockchain.ts` when `this.mine(maxTransactions)` is called, either one transaction will be mined per block (instamine mode), or any number of transactions will be allowed, limited by the `blockGasLimit` (block time mode).
+  - Though it is not yet exposed to the api, the miner is set up to allow the user to specify the number of transactions allowed per block, which could be a useful feature.
+- From the api, when `evm_mine` and thus `mine(Capacity.FillBlock, timestamp, true)` is called, a single block will be mined with no limit on the number of transactions per block (aside from the standard `blockGasLimit`). A block will be mined even if txPool is empty.
+- From the api, when `evm_setAccountNonce` and thus `blockchain.mine(Capacity.Empty)`, a single, empty block is mined.

--- a/src/chains/ethereum/ethereum/src/miner/miner.ts
+++ b/src/chains/ethereum/ethereum/src/miner/miner.ts
@@ -24,9 +24,24 @@ import { Params, TypedTransaction } from "@ganache/ethereum-transaction";
 import { Executables } from "./executables";
 import { Block, RuntimeBlock } from "@ganache/ethereum-block";
 
+/**
+ * How many transactions should be in the block.
+ */
 export enum Capacity {
+  /**
+   * Keep mining transactions until there are no more transactions that can fit
+   * in the block, or there are no transactions left to mine.
+   */
   FillBlock = -1,
+  /**
+   * Mine an empty block, even if there are executable transactions available to
+   * mine.
+   */
   Empty = 0,
+  /**
+   * Mine a block with a single transaction, or empty if there are no executable
+   * transactions available to mine.
+   */
   Single = 1
 }
 

--- a/src/chains/ethereum/ethereum/src/miner/miner.ts
+++ b/src/chains/ethereum/ethereum/src/miner/miner.ts
@@ -24,6 +24,12 @@ import { Params, TypedTransaction } from "@ganache/ethereum-transaction";
 import { Executables } from "./executables";
 import { Block, RuntimeBlock } from "@ganache/ethereum-block";
 
+export enum Capacity {
+  FillBlock = -1,
+  Empty = 0,
+  Single = 1
+}
+
 export type BlockData = {
   blockTransactions: TypedTransaction[];
   transactionsTrie: Trie;
@@ -130,7 +136,7 @@ export default class Miner extends Emittery.Typed<
    */
   public async mine(
     block: RuntimeBlock,
-    maxTransactions: number = -1,
+    maxTransactions: number | Capacity = Capacity.FillBlock,
     onlyOneBlock = false
   ) {
     if (this.#paused) {
@@ -156,7 +162,7 @@ export default class Miner extends Emittery.Typed<
 
   #mine = async (
     block: RuntimeBlock,
-    maxTransactions: number = -1,
+    maxTransactions: number | Capacity = Capacity.FillBlock,
     onlyOneBlock = false
   ) => {
     const { block: lastBlock, transactions } = await this.#mineTxs(
@@ -180,7 +186,7 @@ export default class Miner extends Emittery.Typed<
 
   #mineTxs = async (
     runtimeBlock: RuntimeBlock,
-    maxTransactions: number,
+    maxTransactions: number | Capacity,
     onlyOneBlock: boolean
   ) => {
     let block: Block;
@@ -203,7 +209,7 @@ export default class Miner extends Emittery.Typed<
       const receiptTrie = new Trie(null, null);
 
       // don't mine anything at all if maxTransactions is `0`
-      if (maxTransactions === 0) {
+      if (maxTransactions === Capacity.Empty) {
         await vm.stateManager.checkpoint();
         await vm.stateManager.commit();
         const finalizedBlockData = runtimeBlock.finalize(

--- a/src/chains/ethereum/ethereum/src/miner/miner.ts
+++ b/src/chains/ethereum/ethereum/src/miner/miner.ts
@@ -39,7 +39,7 @@ const updateBloom = (blockBloom: Buffer, bloom: Buffer) => {
 };
 
 const sortByPrice = (values: TypedTransaction[], a: number, b: number) =>
-  values[a].gasPrice > values[b].gasPrice;
+  values[a].getStandardizedGasPrice() > values[b].getStandardizedGasPrice();
 
 export default class Miner extends Emittery.Typed<
   {
@@ -262,7 +262,9 @@ export default class Miner extends Emittery.Typed<
           continue;
         }
 
-        this.#currentlyExecutingPrice = best.gasPrice.toBigInt();
+        this.#currentlyExecutingPrice = best
+          .getStandardizedGasPrice()
+          .toBigInt();
 
         // Set a transaction-level checkpoint so we can undo state changes in
         // the case where the transaction is rejected by the VM.
@@ -502,7 +504,7 @@ export default class Miner extends Emittery.Typed<
       const heap = mapping[1];
       const next = heap.peek();
       if (next && !next.locked) {
-        const price = next.gasPrice.toBigInt();
+        const price = next.getStandardizedGasPrice().toBigInt();
 
         if (this.#currentlyExecutingPrice > price) {
           // don't insert a transaction into the miner's `priced` heap

--- a/src/chains/ethereum/ethereum/src/miner/miner.ts
+++ b/src/chains/ethereum/ethereum/src/miner/miner.ts
@@ -552,6 +552,6 @@ export default class Miner extends Emittery.Typed<
     this.#currentBlockBaseFeePerGas =
       baseFeePerGas === undefined
         ? undefined
-        : Quantity.from(baseFeePerGas.toBuffer());
+        : Quantity.from(baseFeePerGas.buf);
   };
 }

--- a/src/chains/ethereum/ethereum/src/miner/miner.ts
+++ b/src/chains/ethereum/ethereum/src/miner/miner.ts
@@ -68,7 +68,6 @@ export default class Miner extends Emittery.Typed<
   #resolver: (value: void) => void;
   readonly #executables: Executables;
   readonly #options: EthereumInternalOptions["miner"];
-  readonly #instamine: boolean;
   readonly #vm: VM;
   readonly #createBlock: (previousBlock: Block) => RuntimeBlock;
 
@@ -107,7 +106,6 @@ export default class Miner extends Emittery.Typed<
   constructor(
     options: EthereumInternalOptions["miner"],
     executables: Executables,
-    instamine: boolean,
     vm: VM,
     createBlock: (previousBlock: Block) => RuntimeBlock
   ) {
@@ -116,7 +114,6 @@ export default class Miner extends Emittery.Typed<
     this.#vm = vm;
     this.#options = options;
     this.#executables = executables;
-    this.#instamine = instamine;
     this.#createBlock = (previousBlock: Block) => {
       const newBlock = createBlock(previousBlock);
       this.#setCurrentBlockBaseFeePerGas(newBlock);
@@ -178,7 +175,7 @@ export default class Miner extends Emittery.Typed<
       this.#pending = false;
       if (!onlyOneBlock && this.#priced.length > 0) {
         const nextBlock = this.#createBlock(lastBlock);
-        await this.#mine(nextBlock, this.#instamine ? 1 : -1);
+        await this.#mine(nextBlock, maxTransactions);
       }
     }
     return transactions;
@@ -415,7 +412,6 @@ export default class Miner extends Emittery.Typed<
         this.#updatePricedHeap();
 
         if (priced.length !== 0) {
-          maxTransactions = this.#instamine ? 1 : -1;
           runtimeBlock = this.#createBlock(block);
           // if baseFeePerGas is undefined, we are pre london hard fork.
           // no need to refresh the order of the heap because all Txs only have gasPrice.

--- a/src/chains/ethereum/ethereum/src/miner/miner.ts
+++ b/src/chains/ethereum/ethereum/src/miner/miner.ts
@@ -62,6 +62,9 @@ const updateBloom = (blockBloom: Buffer, bloom: Buffer) => {
 const sortByPrice = (values: TypedTransaction[], a: number, b: number) =>
   values[a].effectiveGasPrice > values[b].effectiveGasPrice;
 
+const refresher = (item: TypedTransaction, context: Quantity) =>
+  item.updateEffectiveGasPrice(context);
+
 export default class Miner extends Emittery.Typed<
   {
     block: {
@@ -105,13 +108,11 @@ export default class Miner extends Emittery.Typed<
     this.#paused = false;
     this.#resolver();
   }
-  public refresher = (item: TypedTransaction, context: Quantity) => {
-    item.updateEffectiveGasPrice(context);
-  };
+
   // create a Heap that sorts by gasPrice
   readonly #priced = new Heap<TypedTransaction, Quantity>(
     sortByPrice,
-    this.refresher
+    refresher
   );
   /*
    * @param executables A live Map of pending transactions from the transaction

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -118,16 +118,14 @@ export default class TransactionPool extends Emittery.Typed<{}, "drain"> {
       // new transaction away as necessary.
       const pendingArray = executableOriginTransactions.array;
       const priceBump = this.#priceBump;
-      const newGasPrice = transaction.getStandardizedGasPrice().toBigInt();
+      const newGasPrice = transaction.effectiveGasPrice.toBigInt();
       // Notice: we're iterating over the raw heap array, which isn't
       // necessarily sorted
       for (let i = 0; i < length; i++) {
         const currentPendingTx = pendingArray[i];
         const thisNonce = currentPendingTx.nonce.toBigInt();
         if (thisNonce === transactionNonce) {
-          const gasPrice = currentPendingTx
-            .getStandardizedGasPrice()
-            .toBigInt();
+          const gasPrice = currentPendingTx.effectiveGasPrice.toBigInt();
           const thisPricePremium = gasPrice + (gasPrice * priceBump) / 100n;
 
           // if our new price is `gasPrice * priceBumpPercent` better than our

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -118,14 +118,16 @@ export default class TransactionPool extends Emittery.Typed<{}, "drain"> {
       // new transaction away as necessary.
       const pendingArray = executableOriginTransactions.array;
       const priceBump = this.#priceBump;
-      const newGasPrice = transaction.gasPrice.toBigInt();
+      const newGasPrice = transaction.getStandardizedGasPrice().toBigInt();
       // Notice: we're iterating over the raw heap array, which isn't
       // necessarily sorted
       for (let i = 0; i < length; i++) {
         const currentPendingTx = pendingArray[i];
         const thisNonce = currentPendingTx.nonce.toBigInt();
         if (thisNonce === transactionNonce) {
-          const gasPrice = currentPendingTx.gasPrice.toBigInt();
+          const gasPrice = currentPendingTx
+            .getStandardizedGasPrice()
+            .toBigInt();
           const thisPricePremium = gasPrice + (gasPrice * priceBump) / 100n;
 
           // if our new price is `gasPrice * priceBumpPercent` better than our

--- a/src/chains/ethereum/ethereum/tests/api/debug/debug.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/debug/debug.test.ts
@@ -9,7 +9,10 @@ import { Account, TraceStorageMap } from "@ganache/ethereum-utils";
 import Common from "@ethereumjs/common";
 import { EthereumOptionsConfig } from "@ganache/ethereum-options";
 import { Address } from "@ganache/ethereum-address";
-import { LegacyTransaction } from "@ganache/ethereum-transaction";
+import {
+  LegacyTransaction,
+  TransactionFactory
+} from "@ganache/ethereum-transaction";
 import Blockchain from "../../../src/blockchain";
 
 describe("api", () => {
@@ -196,14 +199,15 @@ describe("api", () => {
       const common = Common.forCustomChain("mainnet", { chainId: 1337 });
 
       const blockchain = new Blockchain(
-        EthereumOptionsConfig.normalize({}),
+        // using berlin here because we need this test to cost 0 gas
+        EthereumOptionsConfig.normalize({ chain: { hardfork: "berlin" } }),
         address
       );
 
       await blockchain.initialize(initialAccounts);
 
       // Deployment transaction
-      const deploymentTransaction = new LegacyTransaction(
+      const deploymentTransaction = TransactionFactory.fromRpc(
         {
           data: contract.code,
           from: from.toString(),

--- a/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
@@ -95,8 +95,13 @@ describe("api", () => {
 
       it("should use the default chain id when signing transactions", async () => {
         await provider.send("eth_subscribe", ["newHeads"]);
+        const gasPrice = await provider.send("eth_gasPrice", []);
         const txHash = await provider.send("eth_sendTransaction", [
-          { from: accounts[0], to: accounts[0] }
+          {
+            from: accounts[0],
+            to: accounts[0],
+            gasPrice
+          }
         ]);
         await provider.once("message");
         const tx = await provider.send("eth_getTransactionByHash", [txHash]);
@@ -416,7 +421,8 @@ describe("api", () => {
         {
           from: accounts[0],
           to: accounts[1],
-          value: "0x1"
+          value: "0x1",
+          gasPrice: "0x77359400"
         }
       ]);
       await provider.once("message");
@@ -439,11 +445,13 @@ describe("api", () => {
 
     it("eth_getTransactionByBlockHashAndIndex", async () => {
       await provider.send("eth_subscribe", ["newHeads"]);
+      const gasPrice = await provider.send("eth_gasPrice", []);
       const txHash = await provider.send("eth_sendTransaction", [
         {
           from: accounts[0],
           to: accounts[1],
-          value: "0x1"
+          value: "0x1",
+          gasPrice
         }
       ]);
       const _message = await provider.once("message");

--- a/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
@@ -417,12 +417,13 @@ describe("api", () => {
 
     it("eth_getTransactionByBlockNumberAndIndex", async () => {
       await provider.send("eth_subscribe", ["newHeads"]);
+      const gasPrice = await provider.send("eth_gasPrice", []);
       const txHash = await provider.send("eth_sendTransaction", [
         {
           from: accounts[0],
           to: accounts[1],
           value: "0x1",
-          gasPrice: "0x77359400"
+          gasPrice
         }
       ]);
       await provider.once("message");

--- a/src/chains/ethereum/ethereum/tests/api/eth/sendRawTransaction.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/sendRawTransaction.test.ts
@@ -29,40 +29,41 @@ describe("api", () => {
         provider = await getProvider({
           wallet: {
             mnemonic: "sweet treat",
-            accounts: [{ secretKey, balance: "0xffffff" }]
+            accounts: [{ secretKey, balance: "0xffffffffffffffffff" }]
           }
         });
         accounts = await provider.send("eth_accounts");
       });
-      async function signAndSendRaw(
-        tx: Object,
-        passedProvider?: EthereumProvider
-      ) {
-        if (passedProvider !== undefined) {
-          provider = passedProvider;
-        }
+      async function signAndSendRaw(tx: any, passedProvider: EthereumProvider) {
         const transaction = Transaction.fromTxData(tx, { common });
-        const secretKeyBuffer = Buffer.from(secretKey.substr(2), "hex");
+        const sender = passedProvider.getInitialAccounts()[tx.from];
+        const secret = sender ? sender.secretKey : secretKey;
+        const secretKeyBuffer = Buffer.from(secret.substr(2), "hex");
         const signed = transaction.sign(secretKeyBuffer);
 
-        await provider.send("eth_subscribe", ["newHeads"]);
-        const txHash = await provider.send("eth_sendRawTransaction", [
+        await passedProvider.send("eth_subscribe", ["newHeads"]);
+        const txHash = await passedProvider.send("eth_sendRawTransaction", [
           Data.from(signed.serialize()).toString()
         ]);
-        await provider.once("message");
+        await passedProvider.once("message");
 
-        const receipt = await provider.send("eth_getTransactionReceipt", [
+        const receipt = await passedProvider.send("eth_getTransactionReceipt", [
           txHash
         ]);
         return { receipt, txHash };
       }
       describe("options", () => {
         it("processes a signed transaction", async () => {
-          const { receipt, txHash } = await signAndSendRaw({
-            value: "0xff",
-            gasLimit: "0x33450",
-            to: accounts[0]
-          });
+          const gasPrice = await provider.send("eth_gasPrice", []);
+          const { receipt, txHash } = await signAndSendRaw(
+            {
+              value: "0xff",
+              gasLimit: "0x33450",
+              to: accounts[0],
+              gasPrice
+            },
+            provider
+          );
           assert.strictEqual(receipt.transactionHash, txHash);
         });
       });
@@ -73,10 +74,15 @@ describe("api", () => {
           it('returns `"0x0"` `status`, `null` `to`, and a non-empty `contractAddress` on OOG failure', async () => {
             const { code: data } = compile(join(contractDir, "NoOp.sol"));
 
-            const { receipt } = await signAndSendRaw({
-              data,
-              gasLimit: 60000
-            });
+            const gasPrice = await provider.send("eth_gasPrice", []);
+            const { receipt } = await signAndSendRaw(
+              {
+                data,
+                gasLimit: 60000,
+                gasPrice
+              },
+              provider
+            );
             assert.strictEqual(receipt.status, "0x0");
             // ensure that even though the status is `"0x0"` (failure), the
             // `contractAddress` is included and the `to` prop is still `null`.
@@ -91,11 +97,13 @@ describe("api", () => {
             accounts: string[]
           ) {
             const contract = compile(join(contractDir, "Reverts.sol"));
+            const gasPrice = await provider.send("eth_gasPrice", []);
             const { receipt } = await signAndSendRaw(
               {
                 from: accounts[0],
                 data: contract.code,
-                gasLimit: 3141592
+                gasLimit: 3141592,
+                gasPrice
               },
               provider
             );
@@ -117,11 +125,13 @@ describe("api", () => {
                 accounts
               );
               const contractMethods = contract.contract.evm.methodIdentifiers;
+              const gasPrice = await provider.send("eth_gasPrice", []);
               const prom = provider.send("eth_call", [
                 {
                   from: accounts[0],
                   to: contractAddress,
-                  data: "0x" + contractMethods["invalidRevertReason()"]
+                  data: "0x" + contractMethods["invalidRevertReason()"],
+                  gasPrice
                 }
               ]);
 

--- a/src/chains/ethereum/ethereum/tests/api/eth/sendTransaction.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/sendTransaction.test.ts
@@ -18,10 +18,12 @@ describe("api", () => {
             });
             const [from] = await provider.send("eth_accounts");
 
+            const gasPrice = await provider.send("eth_gasPrice", []);
             const gasEstimate = await provider.send("eth_estimateGas", [
               {
                 from,
-                to: from
+                to: from,
+                gasPrice
               }
             ]);
             await provider.send("eth_subscribe", ["newHeads"]);
@@ -29,7 +31,8 @@ describe("api", () => {
             const hash = await provider.send("eth_sendTransaction", [
               {
                 from,
-                to: from
+                to: from,
+                gasPrice
               }
             ]);
 
@@ -177,6 +180,15 @@ describe("api", () => {
             },
             wallet: {
               unlockedAccounts: [ZERO_ADDRESS]
+            },
+            chain: {
+              // use berlin here because we just want to test if we can use the
+              // "zero" address, and we do this by transferring value while
+              // setting the gasPrice to `0`. This isn't possible after the
+              // `london` hardfork currently, as we don't provide an option to
+              // allow for a 0 `maxFeePerGas` value.
+              // TODO: remove once we have a configurable `maxFeePerGas`
+              hardfork: "berlin"
             }
           });
           const [from] = await provider.send("eth_accounts");

--- a/src/chains/ethereum/ethereum/tests/api/eth/signTransaction.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/signTransaction.test.ts
@@ -5,14 +5,17 @@ describe("api", () => {
   describe("eth", () => {
     describe("eth_signTransaction", () => {
       it("signs a transaction that can then be submitted to the network", async () => {
-        const provider = await getProvider();
+        const provider = await getProvider({ wallet: { deterministic: true } });
         const [from, to] = await provider.send("eth_accounts");
 
         const signedTx = await provider.send("eth_signTransaction", [
           {
+            type: "0x2",
+            chainId: "0x1337",
             from: from,
             to: to,
-            gas: "0x5b8d80"
+            gas: "0x5b8d80",
+            maxFeePerGas: `0x${(1000000000).toString(16)}`
           }
         ]);
 

--- a/src/chains/ethereum/ethereum/tests/api/eth/subscribe.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/subscribe.test.ts
@@ -76,14 +76,14 @@ describe("api", () => {
                 gasLimit: gasLimit,
                 gasUsed: "0x0",
                 hash:
-                  "0x9b684f238f60b82ca0af6162da9f3ee80ab3858485b1a291ac07c5d0ac708c1f",
+                  "0xe2c5d64b9e17e25abc0589c378b77adecf06668dd3c073ab9c53dec51baf2048",
                 logsBloom: `0x${"0".repeat(512)}`,
                 miner: `0x${"0".repeat(40)}`,
                 mixHash: `0x${"0".repeat(64)}`,
                 nonce: "0x0000000000000000",
                 number: Quantity.from(startingBlockNumber + 1).toString(),
                 parentHash:
-                  "0xc550a7d0f9b24658dc0b8f60d3cf27dc43afdc7a471591b08f1a39ffd487bfb7",
+                  "0x599bbde60ad155e0c9dbfa8575e325235c2c48f8b6c4100c175dc9b68c5c2dba",
                 receiptsRoot:
                   "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
                 sha3Uncles:

--- a/src/chains/ethereum/ethereum/tests/api/eth/subscribe.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/subscribe.test.ts
@@ -69,20 +69,21 @@ describe("api", () => {
             type: "eth_subscription",
             data: {
               result: {
+                baseFeePerGas: "0x342770c0",
                 difficulty: "0x1",
                 totalDifficulty: "0x2",
                 extraData: "0x",
                 gasLimit: gasLimit,
                 gasUsed: "0x0",
                 hash:
-                  "0xbda5af9012bf0f767232d80fd2eba0872001a0910f8324af8ef20268849f554a",
+                  "0x9b684f238f60b82ca0af6162da9f3ee80ab3858485b1a291ac07c5d0ac708c1f",
                 logsBloom: `0x${"0".repeat(512)}`,
                 miner: `0x${"0".repeat(40)}`,
                 mixHash: `0x${"0".repeat(64)}`,
                 nonce: "0x0000000000000000",
                 number: Quantity.from(startingBlockNumber + 1).toString(),
                 parentHash:
-                  "0x5063838e49a74a67242ded810c134d34a892acd7e726ea1dcc5499c9c36471db",
+                  "0xc550a7d0f9b24658dc0b8f60d3cf27dc43afdc7a471591b08f1a39ffd487bfb7",
                 receiptsRoot:
                   "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
                 sha3Uncles:

--- a/src/chains/ethereum/ethereum/tests/api/evm/snapshot.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/evm/snapshot.test.ts
@@ -423,8 +423,12 @@ describe("api", () => {
 
         // send some transactions
         const inFlightTxs = [
-          send("eth_sendTransaction", [{ from, to, value: value++ }]),
-          send("eth_sendTransaction", [{ from, to, value: value++ }])
+          send("eth_sendTransaction", [
+            { from, to, value: value++, gasPrice: "0xffffffff" }
+          ]),
+          send("eth_sendTransaction", [
+            { from, to, value: value++, gasPrice: "0xffffffff" }
+          ])
         ];
 
         // these two transactions have nonces that are too high to be executed immediately

--- a/src/chains/ethereum/ethereum/tests/api/miner/miner.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/miner/miner.test.ts
@@ -109,7 +109,7 @@ describe("api", () => {
       let accounts: string[];
 
       beforeEach(async () => {
-        provider = await getProvider();
+        provider = await getProvider({ chain: { hardfork: "berlin" } });
         accounts = await provider.send("eth_accounts");
       });
 

--- a/src/chains/ethereum/ethereum/tests/api/personal/personal.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/personal/personal.test.ts
@@ -8,7 +8,18 @@ describe("api", () => {
   describe("personal", () => {
     describe("listAccounts", () => {
       it("matches eth_accounts", async () => {
-        const provider = await getProvider({ wallet: { seed: "temet nosce" } });
+        const provider = await getProvider({
+          wallet: { seed: "temet nosce" },
+          chain: {
+            // use berlin here because we just want to test if we can use the
+            // "zero" address, and we do this by transferring value while
+            // setting the gasPrice to `0`. This isn't possible after the
+            // `london` hardfork currently, as we don't provide an option to
+            // allow for a 0 `maxFeePerGas` value.
+            // TODO: remove once we have a configurable `maxFeePerGas`
+            hardfork: "berlin"
+          }
+        });
         const accounts = await provider.send("eth_accounts");
         const personalAccounts = await provider.send("personal_listAccounts");
         assert.deepStrictEqual(personalAccounts, accounts);
@@ -362,7 +373,16 @@ describe("api", () => {
 
       describe("personal_sendTransaction", () => {
         it("generates locked accounts with passphrase", async () => {
-          const provider = await getProvider({ miner: { defaultGasPrice: 0 } });
+          const provider = await getProvider({
+            miner: { defaultGasPrice: 0 },
+            // use berlin here because we just want to test if we can use the
+            // "zero" address, and we do this by transferring value while
+            // setting the gasPrice to `0`. This isn't possible after the
+            // `london` hardfork currently, as we don't provide an option to
+            // allow for a 0 `maxFeePerGas` value.
+            // TODO: remove once we have a configurable `maxFeePerGas`
+            chain: { hardfork: "berlin" }
+          });
           const passphrase = "this is my passphrase";
           // generate an account
           const newAccount = await provider.send("personal_newAccount", [
@@ -378,7 +398,16 @@ describe("api", () => {
       });
       describe("personal_signTransaction", () => {
         it("signs transaction from locked accounts with passphrase", async () => {
-          const provider = await getProvider({ miner: { defaultGasPrice: 0 } });
+          const provider = await getProvider({
+            miner: { defaultGasPrice: 0 },
+            // use berlin here because we just want to test if we can use the
+            // "zero" address, and we do this by transferring value while
+            // setting the gasPrice to `0`. This isn't possible after the
+            // `london` hardfork currently, as we don't provide an option to
+            // allow for a 0 `maxFeePerGas` value.
+            // TODO: remove once we have a configurable `maxFeePerGas`
+            chain: { hardfork: "berlin" }
+          });
           const passphrase = "this is my passphrase";
           // generate an account
           const newAccount = await provider.send("personal_newAccount", [
@@ -414,7 +443,16 @@ describe("api", () => {
 
       describe("personal_unlockAccount ➡ eth_sendTransaction ➡ personal_lockAccount", () => {
         it("generates locked accounts with passphrase", async () => {
-          const provider = await getProvider({ miner: { defaultGasPrice: 0 } });
+          const provider = await getProvider({
+            miner: { defaultGasPrice: 0 },
+            // use berlin here because we just want to test if we can use the
+            // "zero" address, and we do this by transferring value while
+            // setting the gasPrice to `0`. This isn't possible after the
+            // `london` hardfork currently, as we don't provide an option to
+            // allow for a 0 `maxFeePerGas` value.
+            // TODO: remove once we have a configurable `maxFeePerGas`
+            chain: { hardfork: "berlin" }
+          });
           const passphrase = "this is my passphrase";
           // generate an account
           const newAccount = await provider.send("personal_importRawKey", [
@@ -432,7 +470,16 @@ describe("api", () => {
 
       describe("personal_sendTransaction", () => {
         it("generates locked accounts with passphrase", async () => {
-          const provider = await getProvider({ miner: { defaultGasPrice: 0 } });
+          const provider = await getProvider({
+            miner: { defaultGasPrice: 0 },
+            // use berlin here because we just want to test if we can use the
+            // "zero" address, and we do this by transferring value while
+            // setting the gasPrice to `0`. This isn't possible after the
+            // `london` hardfork currently, as we don't provide an option to
+            // allow for a 0 `maxFeePerGas` value.
+            // TODO: remove once we have a configurable `maxFeePerGas`
+            chain: { hardfork: "berlin" }
+          });
           // generate an account
           const newAccount = await provider.send("personal_importRawKey", [
             secretKey,
@@ -449,7 +496,16 @@ describe("api", () => {
 
       describe("personal_signTransaction", () => {
         it("signs transaction from locked accounts with passphrase", async () => {
-          const provider = await getProvider({ miner: { defaultGasPrice: 0 } });
+          const provider = await getProvider({
+            miner: { defaultGasPrice: 0 },
+            // use berlin here because we just want to test if we can use the
+            // "zero" address, and we do this by transferring value while
+            // setting the gasPrice to `0`. This isn't possible after the
+            // `london` hardfork currently, as we don't provide an option to
+            // allow for a 0 `maxFeePerGas` value.
+            // TODO: remove once we have a configurable `maxFeePerGas`
+            chain: { hardfork: "berlin" }
+          });
           // generate an account
           const newAccount = await provider.send("personal_importRawKey", [
             secretKey,

--- a/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
@@ -474,7 +474,7 @@ describe("forking", () => {
         to
       };
       const subId = await remoteProvider.send("eth_subscribe", ["newHeads"]);
-      remoteProvider.send("eth_sendTransaction", [tx]);
+      await remoteProvider.send("eth_sendTransaction", [tx]);
       await remoteProvider.once("message");
       await remoteProvider.send("eth_unsubscribe", [subId]);
 

--- a/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
+++ b/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
@@ -123,12 +123,15 @@ describe.only("miner", async () => {
       const block = await lowGasLimitBlockchain.blocks.get(Buffer.from([1]));
       const lowBlockJson = block.toJSON(true, common);
       const lowBlockTxJson = lowBlockJson.transactions[0] as any;
+      // because of our low gas price, only one transaction should be on the block.
       assert.strictEqual(lowBlockJson.transactions.length, 1);
-      assert.strictEqual(lowBlockTxJson.from.toString(), from1);
+      // the first tx mined in our lowBlock chain (i.e., the only tx on the first block)
+      // should be the same as the first tx mined on our highBlock chain
       assert.strictEqual(
-        (highBlockJson.transactions[0] as any).from.toString(),
-        from1
+        lowBlockTxJson.from.toString(),
+        (highBlockJson.transactions[0] as any).from.toString()
       );
+      // the gasPrice should be equal to the initial gasPrice set on the tx
       assert.strictEqual(lowBlockTxJson.gasPrice.toString(), "0x3b023380");
     });
 
@@ -136,14 +139,17 @@ describe.only("miner", async () => {
       const block = await lowGasLimitBlockchain.blocks.get(Buffer.from([2]));
       const lowBlockJson = block.toJSON(true, common);
       const lowBlockTxJson = lowBlockJson.transactions[0] as any;
+      // because of our low gas price, only one transaction should be on the block.
       assert.strictEqual(lowBlockJson.transactions.length, 1);
-      // they will be in a different order between the two chains
-      assert.strictEqual(lowBlockTxJson.from.toString(), from2);
-      // the second tx should be third tx of the high limit block
+      // the second tx mined in our lowBlock chain (i.e., the only tx on the second block)
+      // should be the same as the THIRD tx mined on our highBlock chain.
+      // This proves that the lowBlock chain's pool was reordered when a new block was mined.
       assert.strictEqual(
-        (highBlockJson.transactions[2] as any).from.toString(),
-        from2
+        lowBlockTxJson.from.toString(),
+        (highBlockJson.transactions[2] as any).from.toString()
       );
+      // the gasPrice should be equal to the maxFeePerGas set on the tx because of the
+      // increase in price of the baseFeePerGas after the block was mined
       assert.strictEqual(lowBlockTxJson.gasPrice.toString(), "0x3b023380");
     });
 

--- a/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
+++ b/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
@@ -20,7 +20,7 @@ describe("miner", async () => {
     let from1: string, from2: string, from3: string, to: string;
 
     before(async function () {
-      this.timeout(0);
+      this.timeout(5000);
       common = Common.forCustomChain(
         "mainnet",
         {

--- a/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
+++ b/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
@@ -18,6 +18,7 @@ describe("miner", async () => {
     let highBlockJson: any;
     let common: Common;
     let from1: string, from2: string, from3: string, to: string;
+
     before(async function () {
       this.timeout(0);
       common = Common.forCustomChain(
@@ -112,6 +113,13 @@ describe("miner", async () => {
         }
         await blockchain.resume();
       }
+
+      // Wait until the the `blockchain` actually says the
+      // `highGasLimitBlockchain` block is ready as `await blockchain.resume()`
+      // above doesn't guarantee that the `blockchain` has processed the the
+      // block.
+      await highGasLimitBlockchain.once("block");
+
       // all txs are on this one block so lets save for future use
       const highGasBlock = await highGasLimitBlockchain.blocks.get(
         Buffer.from([1])
@@ -119,7 +127,7 @@ describe("miner", async () => {
       highBlockJson = highGasBlock.toJSON(true);
     });
 
-    it("orders transactions by gasPrice", async () => {
+    it.only("orders transactions by gasPrice", async () => {
       const block = await lowGasLimitBlockchain.blocks.get(Buffer.from([1]));
       const lowBlockJson = block.toJSON(true);
       const lowBlockTxJson = lowBlockJson.transactions[0] as any;

--- a/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
+++ b/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
@@ -10,7 +10,7 @@ import Blockchain from "../../src/blockchain";
 import Wallet from "../../src/wallet";
 import { EthereumOptionsConfig } from "@ganache/ethereum-options";
 
-describe.only("miner", async () => {
+describe("miner", async () => {
   describe("pre-london transaction ordering", () => {});
   describe("london transaction pool prioritization", () => {
     let lowGasLimitBlockchain: Blockchain;

--- a/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
+++ b/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
@@ -127,7 +127,7 @@ describe("miner", async () => {
       highBlockJson = highGasBlock.toJSON(true);
     });
 
-    it.only("orders transactions by gasPrice", async () => {
+    it("orders transactions by gasPrice", async () => {
       const block = await lowGasLimitBlockchain.blocks.get(Buffer.from([1]));
       const lowBlockJson = block.toJSON(true);
       const lowBlockTxJson = lowBlockJson.transactions[0] as any;

--- a/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
+++ b/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
@@ -116,12 +116,12 @@ describe("miner", async () => {
       const highGasBlock = await highGasLimitBlockchain.blocks.get(
         Buffer.from([1])
       );
-      highBlockJson = highGasBlock.toJSON(true, common);
+      highBlockJson = highGasBlock.toJSON(true);
     });
 
     it("orders transactions by gasPrice", async () => {
       const block = await lowGasLimitBlockchain.blocks.get(Buffer.from([1]));
-      const lowBlockJson = block.toJSON(true, common);
+      const lowBlockJson = block.toJSON(true);
       const lowBlockTxJson = lowBlockJson.transactions[0] as any;
       // because of our low gas price, only one transaction should be on the block.
       assert.strictEqual(lowBlockJson.transactions.length, 1);
@@ -137,7 +137,7 @@ describe("miner", async () => {
 
     it("updates baseFeePerGas and order of tx pool when a new block is mined", async () => {
       const block = await lowGasLimitBlockchain.blocks.get(Buffer.from([2]));
-      const lowBlockJson = block.toJSON(true, common);
+      const lowBlockJson = block.toJSON(true);
       const lowBlockTxJson = lowBlockJson.transactions[0] as any;
       // because of our low gas price, only one transaction should be on the block.
       assert.strictEqual(lowBlockJson.transactions.length, 1);
@@ -155,7 +155,7 @@ describe("miner", async () => {
 
     it("updates baseFeePerGas and rejects txs that don't pay enough for gas when a new block is mined", async () => {
       const block = await lowGasLimitBlockchain.blocks.get(Buffer.from([3]));
-      const lowBlockJson = block.toJSON(false, common);
+      const lowBlockJson = block.toJSON(false);
       // the low gas limit chain will be too expensive for the remaining tx, so it won't be included in the block
       assert.strictEqual(lowBlockJson.transactions.length, 0);
       // the remaining tx should be second tx of the high limit block

--- a/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
+++ b/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
@@ -1,0 +1,162 @@
+import assert from "assert";
+import { Address } from "@ganache/ethereum-address";
+import Common from "@ethereumjs/common";
+import {
+  TransactionFactory,
+  TypedRpcTransaction,
+  TypedTransaction
+} from "@ganache/ethereum-transaction";
+import Blockchain from "../../src/blockchain";
+import Wallet from "../../src/wallet";
+import { EthereumOptionsConfig } from "@ganache/ethereum-options";
+
+describe.only("miner", async () => {
+  describe("pre-london transaction ordering", () => {});
+  describe("london transaction pool prioritization", () => {
+    let lowGasLimitBlockchain: Blockchain;
+    let highGasLimitBlockchain: Blockchain;
+    let highBlockJson: any;
+    let common: Common;
+    let from1: string, from2: string, from3: string, to: string;
+    before(async function () {
+      this.timeout(0);
+      common = Common.forCustomChain(
+        "mainnet",
+        {
+          name: "ganache",
+          chainId: 1337,
+          comment: "Local test network",
+          bootstrapNodes: []
+        },
+        "london"
+      );
+      const optionsJson = {
+        wallet: {
+          deterministic: true
+        },
+        miner: {
+          blockGasLimit: "0x5208" // 21000, or sending one empty tx
+        },
+        chain: { chainId: 1337 }
+      };
+      const options = EthereumOptionsConfig.normalize(optionsJson);
+      const wallet = new Wallet(options.wallet);
+      [from1, from2, from3, to] = wallet.addresses;
+      const fromAddress = new Address(from1);
+
+      lowGasLimitBlockchain = new Blockchain(options, fromAddress);
+      await lowGasLimitBlockchain.initialize(wallet.initialAccounts);
+      optionsJson.miner.blockGasLimit = "0xB749E0"; // 12012000
+      const highGasOptions = EthereumOptionsConfig.normalize(optionsJson);
+      highGasLimitBlockchain = new Blockchain(highGasOptions, fromAddress);
+      await highGasLimitBlockchain.initialize(wallet.initialAccounts);
+
+      /*
+      For the lowGasLimitBlockchain:
+          block 1 baseFeePerGas: 875,000,000
+          tx1: gasPrice: 990,000,000
+          tx2: maxFeePerGas: 990,000,000, maxPriorityFee: 5,000,000 => effectiveGasPrice = 880,000,000
+          tx3: gasPrice: 987,000,000
+          order of queue should be tx1, tx3, tx2
+
+          1 block is mined with tx1 in it
+          new baseFeePerGas: 984,375,000
+          tx2: maxFeePerGas: 990,000,000, maxPriorityFee: 5,000,000 => effectiveGasPrice = 990,000,000
+          tx3: gasPrice 987,000,000
+          order of queue should now be tx2, tx3
+
+          1 block is mined with tx2 in it
+          baseFeePerGas: 1,107,421,875
+          tx3 now has too low a gas price to be mined
+
+        For the highGasLimitBlockchain:
+          all three would be mined in one block with the order: tx1, tx3, tx2
+       */
+      const txs: TypedRpcTransaction[] = [
+        {
+          type: "0x0",
+          from: from1,
+          to: to,
+          gasPrice: "0x3B023380", // 990,000,000
+          gas: "0x5208"
+        },
+        {
+          type: "0x2",
+          from: from2,
+          to: to,
+          maxFeePerGas: "0x3B023380", // 990,000,000
+          maxPriorityFeePerGas: "0x4C4B40", // 5,000,000
+          chainId: "0x539",
+          gas: "0x5208"
+        },
+        {
+          type: "0x0",
+          from: from3,
+          to: to,
+          gasPrice: "0x3AD46CC0", // 987,000,000
+          gas: "0x5208"
+        }
+      ];
+      const blockchains = [lowGasLimitBlockchain, highGasLimitBlockchain];
+      for (let j = 0; j < blockchains.length; j++) {
+        const blockchain = blockchains[j];
+        blockchain.pause();
+        for (let i = 0; i < txs.length; i++) {
+          const txRpc = txs[i];
+          const secretKey = wallet.unlockedAccounts.get(txRpc.from);
+          const tx: TypedTransaction = TransactionFactory.fromRpc(
+            txRpc,
+            common
+          );
+          await blockchain.queueTransaction(tx, secretKey);
+        }
+        await blockchain.resume();
+      }
+      // all txs are on this one block so lets save for future use
+      const highGasBlock = await highGasLimitBlockchain.blocks.get(
+        Buffer.from([1])
+      );
+      highBlockJson = highGasBlock.toJSON(true, common);
+    });
+
+    it("orders transactions by gasPrice", async () => {
+      const block = await lowGasLimitBlockchain.blocks.get(Buffer.from([1]));
+      const lowBlockJson = block.toJSON(true, common);
+      const lowBlockTxJson = lowBlockJson.transactions[0] as any;
+      assert.strictEqual(lowBlockJson.transactions.length, 1);
+      assert.strictEqual(lowBlockTxJson.from.toString(), from1);
+      assert.strictEqual(
+        (highBlockJson.transactions[0] as any).from.toString(),
+        from1
+      );
+      assert.strictEqual(lowBlockTxJson.gasPrice.toString(), "0x3b023380");
+    });
+
+    it("updates baseFeePerGas and order of tx pool when a new block is mined", async () => {
+      const block = await lowGasLimitBlockchain.blocks.get(Buffer.from([2]));
+      const lowBlockJson = block.toJSON(true, common);
+      const lowBlockTxJson = lowBlockJson.transactions[0] as any;
+      assert.strictEqual(lowBlockJson.transactions.length, 1);
+      // they will be in a different order between the two chains
+      assert.strictEqual(lowBlockTxJson.from.toString(), from2);
+      // the second tx should be third tx of the high limit block
+      assert.strictEqual(
+        (highBlockJson.transactions[2] as any).from.toString(),
+        from2
+      );
+      assert.strictEqual(lowBlockTxJson.gasPrice.toString(), "0x3b023380");
+    });
+
+    it("updates baseFeePerGas and rejects txs that don't pay enough for gas when a new block is mined", async () => {
+      const block = await lowGasLimitBlockchain.blocks.get(Buffer.from([3]));
+      const lowBlockJson = block.toJSON(false, common);
+      // the low gas limit chain will be too expensive for the remaining tx, so it won't be included in the block
+      assert.strictEqual(lowBlockJson.transactions.length, 0);
+      // the remaining tx should be second tx of the high limit block
+      assert.strictEqual(
+        (highBlockJson.transactions[1] as any).from.toString(),
+        from3
+      );
+    });
+  });
+});

--- a/src/chains/ethereum/ethereum/tests/temp-tests.test.ts
+++ b/src/chains/ethereum/ethereum/tests/temp-tests.test.ts
@@ -163,7 +163,10 @@ describe("Random tests that are temporary!", () => {
   });
 
   it("transfers value", async () => {
-    const p = await getProvider({ miner: { defaultGasPrice: 0 } });
+    const p = await getProvider({
+      miner: { defaultGasPrice: 0 },
+      chain: { hardfork: "berlin" }
+    });
     const accounts = await p.send("eth_accounts");
     const ONE_ETHER = WEI;
     const options = p.getOptions();

--- a/src/chains/ethereum/ethereum/tests/tsconfig.json
+++ b/src/chains/ethereum/ethereum/tests/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../tsconfig.json",
-  "include": [
-    "./",
-    "../src/blockchain"
-  ]
+  "include": ["./", "../src/**/*"],
+  "compilerOptions": { "rootDir": "../" }
 }

--- a/src/chains/ethereum/ethereum/tsconfig.json
+++ b/src/chains/ethereum/ethereum/tsconfig.json
@@ -45,6 +45,10 @@
     {
       "name": "@ganache/ethereum-block",
       "path": "../block"
+    },
+    {
+      "name": "@ganache/secp256k1",
+      "path": "../../../packages/secp256k1"
     }
   ]
 }

--- a/src/chains/ethereum/options/src/chain-options.ts
+++ b/src/chains/ethereum/options/src/chain-options.ts
@@ -8,7 +8,8 @@ const HARDFORKS = [
   "petersburg",
   "istanbul",
   "muirGlacier",
-  "berlin"
+  "berlin",
+  "london"
 ] as const;
 
 export type Hardfork = Writeable<ArrayToTuple<typeof HARDFORKS>>;
@@ -188,7 +189,7 @@ export const ChainOptions: Definitions<ChainConfig> = {
   hardfork: {
     normalize,
     cliDescription: "Set the hardfork rules for the EVM.",
-    default: () => "berlin",
+    default: () => "london",
     legacyName: "hardfork",
     cliAliases: ["k", "hardfork"],
     cliType: "string",

--- a/src/chains/ethereum/options/src/chain-options.ts
+++ b/src/chains/ethereum/options/src/chain-options.ts
@@ -107,7 +107,7 @@ export type ChainConfig = {
 
     /**
      * Set the hardfork rules for the EVM.
-     * @defaultValue "berlin"
+     * @defaultValue "london"
      */
     readonly hardfork: {
       type: Hardfork;

--- a/src/chains/ethereum/options/src/miner-options.ts
+++ b/src/chains/ethereum/options/src/miner-options.ts
@@ -3,7 +3,7 @@ import {
   Data,
   Quantity,
   ACCOUNT_ZERO,
-  BUFFER_EMPTY,
+  DATA_EMPTY,
   RPCQUANTITY_EMPTY,
   RPCQUANTITY_ONE
 } from "@ganache/utils";
@@ -260,7 +260,7 @@ export const MinerOptions: Definitions<MinerConfig> = {
       return bytes;
     },
     cliDescription: "Set the extraData block header field a miner can include.",
-    default: () => Data.from(BUFFER_EMPTY),
+    default: () => DATA_EMPTY,
     cliType: "string"
   }
 };

--- a/src/chains/ethereum/transaction/index.ts
+++ b/src/chains/ethereum/transaction/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from "./src/eip2930-access-list-transaction";
+export * from "./src/eip1559-fee-market-transaction";
 export * from "./src/base-transaction";
 export * from "./src/hardfork";
 export * from "./src/legacy-transaction";

--- a/src/chains/ethereum/transaction/src/base-transaction.ts
+++ b/src/chains/ethereum/transaction/src/base-transaction.ts
@@ -85,6 +85,7 @@ export class BaseTransaction {
   public v: Quantity | null;
   public r: Quantity | null;
   public s: Quantity | null;
+  public effectiveGasPrice: Quantity;
 
   public from: Data | null;
 

--- a/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
@@ -96,7 +96,7 @@ export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
       value: this.value,
       maxPriorityFeePerGas: this.maxPriorityFeePerGas,
       maxFeePerGas: this.maxFeePerGas,
-      effectiveGasPrice: this.effectiveGasPrice
+      gasPrice: this.effectiveGasPrice
         ? this.effectiveGasPrice
         : this.maxFeePerGas,
       gas: this.gas,
@@ -187,11 +187,9 @@ export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
     const dataLength = data.length;
 
     const ending = encodeRange(raw, 10, 3);
-    const msg = Buffer.concat([
-      typeBuf,
+    const msgHash = keccak(
       digest([data.output, ending.output], dataLength + ending.length)
-    ]);
-    const msgHash = keccak(msg);
+    );
     const sig = ecsign(msgHash, privateKey, chainId);
     this.v = Quantity.from(sig.v);
     this.r = Quantity.from(sig.r);

--- a/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
@@ -1,0 +1,254 @@
+import {
+  Data,
+  Quantity,
+  keccak,
+  BUFFER_EMPTY,
+  BUFFER_32_ZERO,
+  RPCQUANTITY_EMPTY
+} from "@ganache/utils";
+import { Address } from "@ganache/ethereum-address";
+import type Common from "@ethereumjs/common";
+import { BN, ecsign } from "ethereumjs-util";
+import { TypedRpcTransaction } from "./rpc-transaction";
+import { encodeRange, digest } from "@ganache/rlp";
+import { RuntimeTransaction } from "./runtime-transaction";
+import {
+  EIP1559FeeMarketDatabasePayload,
+  EIP1559FeeMarketDatabaseTx,
+  GanacheRawExtraTx,
+  TypedDatabaseTransaction
+} from "./raw";
+import { AccessList, AccessListBuffer } from "@ethereumjs/tx";
+import { AccessLists } from "./access-lists";
+import { computeInstrinsicsFeeMarketTx } from "./signing";
+import {
+  Capability,
+  EIP1559FeeMarketTransactionJSON
+} from "./transaction-types";
+
+const CAPABILITIES = [2718, 2930, 1559];
+export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
+  public chainId: Quantity;
+  public maxPriorityFeePerGas: Quantity;
+  public maxFeePerGas: Quantity;
+  public accessList: AccessListBuffer;
+  public accessListJSON: AccessList;
+  public type: Quantity = Quantity.from("0x2");
+
+  public constructor(
+    data: EIP1559FeeMarketDatabasePayload | TypedRpcTransaction,
+    common: Common,
+    extra?: GanacheRawExtraTx
+  ) {
+    super(data, common, extra);
+    if (Array.isArray(data)) {
+      this.chainId = Quantity.from(data[0]);
+      this.nonce = Quantity.from(data[1], true);
+      this.maxPriorityFeePerGas = Quantity.from(data[2]);
+      this.maxFeePerGas = Quantity.from(data[3]);
+      this.gas = Quantity.from(data[4]);
+      this.to = data[5].length == 0 ? RPCQUANTITY_EMPTY : Address.from(data[5]);
+      this.value = Quantity.from(data[6]);
+      this.data = Data.from(data[7]);
+      const accessListData = AccessLists.getAccessListData(data[8]);
+      this.accessList = accessListData.accessList;
+      this.accessListJSON = accessListData.AccessListJSON;
+      this.v = Quantity.from(data[9]);
+      this.r = Quantity.from(data[10]);
+      this.s = Quantity.from(data[11]);
+      this.raw = [this.type.toBuffer(), ...data];
+
+      const {
+        from,
+        serialized,
+        hash,
+        encodedData,
+        encodedSignature
+      } = this.computeIntrinsics(this.v, this.raw, this.common.chainId());
+
+      this.from = from;
+      this.serialized = serialized;
+      this.hash = hash;
+      this.encodedData = encodedData;
+      this.encodedSignature = encodedSignature;
+    } else {
+      this.chainId = Quantity.from(data.chainId);
+      this.maxPriorityFeePerGas = Quantity.from(data.maxPriorityFeePerGas);
+      this.maxFeePerGas = Quantity.from(data.maxFeePerGas);
+      const accessListData = AccessLists.getAccessListData(data.accessList);
+      this.accessList = accessListData.accessList;
+      this.accessListJSON = accessListData.AccessListJSON;
+      this.validateAndSetSignature(data);
+    }
+  }
+
+  public toJSON(): EIP1559FeeMarketTransactionJSON {
+    return {
+      type: this.type,
+      hash: this.hash,
+      chainId: this.chainId,
+      nonce: this.nonce,
+      blockHash: this.blockHash ? this.blockHash : null,
+      blockNumber: this.blockNumber ? this.blockNumber : null,
+      transactionIndex: this.index ? this.index : null,
+      from: this.from,
+      to: this.to.isNull() ? null : this.to,
+      value: this.value,
+      maxPriorityFeePerGas: this.maxPriorityFeePerGas,
+      maxFeePerGas: this.maxFeePerGas,
+      gas: this.gas,
+      input: this.data,
+      accessList: this.accessListJSON,
+      v: this.v,
+      r: this.r,
+      s: this.s
+    };
+  }
+
+  public static fromTxData(
+    data: EIP1559FeeMarketDatabasePayload | TypedRpcTransaction,
+    common: Common,
+    extra?: GanacheRawExtraTx
+  ) {
+    return new EIP1559FeeMarketTransaction(data, common, extra);
+  }
+
+  public toVmTransaction() {
+    const sender = this.from.toBuffer();
+    const to = this.to.toBuffer();
+    const data = this.data.toBuffer();
+    return {
+      hash: () => BUFFER_32_ZERO,
+      nonce: new BN(this.nonce.toBuffer()),
+      maxPriorityFeePerGas: new BN(this.maxPriorityFeePerGas.toBuffer()),
+      maxFeePerGas: new BN(this.maxFeePerGas.toBuffer()),
+      gasLimit: new BN(this.gas.toBuffer()),
+      to:
+        to.length === 0
+          ? null
+          : { buf: to, equals: (a: { buf: Buffer }) => to.equals(a.buf) },
+      value: new BN(this.value.toBuffer()),
+      data,
+      AccessListJSON: this.accessListJSON,
+      getSenderAddress: () => ({
+        buf: sender,
+        equals: (a: { buf: Buffer }) => sender.equals(a.buf)
+      }),
+      /**
+       * the minimum amount of gas the tx must have (DataFee + TxFee + Creation Fee)
+       */
+      getBaseFee: () => {
+        const fee = this.calculateIntrinsicGas();
+        return new BN(Quantity.from(fee).toBuffer());
+      },
+      getUpfrontCost: (baseFee: BN = new BN(0)) => {
+        const { gas, maxPriorityFeePerGas, maxFeePerGas, value } = this;
+        const maxPriorityFeePerGasBN = new BN(maxPriorityFeePerGas.toBuffer());
+        const maxFeePerGasBN = new BN(maxFeePerGas.toBuffer());
+        const gasLimitBN = new BN(gas.toBuffer());
+        const valueBN = new BN(value.toBuffer());
+
+        const inclusionFeePerGas = BN.min(
+          maxPriorityFeePerGasBN,
+          maxFeePerGasBN.sub(baseFee)
+        );
+        const gasPrice = inclusionFeePerGas.add(baseFee);
+
+        return gasLimitBN.mul(gasPrice).add(valueBN);
+      },
+      supports: (capability: Capability) => {
+        return CAPABILITIES.includes(capability);
+      }
+    };
+  }
+  /**
+   * sign a transaction with a given private key, then compute and set the `hash`.
+   *
+   * @param privateKey - Must be 32 bytes in length
+   */
+  public signAndHash(privateKey: Buffer) {
+    if (this.v != null) {
+      throw new Error(
+        "Internal Error: RuntimeTransaction `sign` called but transaction has already been signed"
+      );
+    }
+
+    const chainId = this.common.chainId();
+    const typeBuf = this.type.toBuffer();
+    const raw: EIP1559FeeMarketDatabaseTx = this.toEthRawTransaction(
+      Quantity.from(chainId).toBuffer(),
+      BUFFER_EMPTY,
+      BUFFER_EMPTY
+    );
+    const data = encodeRange(raw, 1, 9);
+    const dataLength = data.length;
+
+    const ending = encodeRange(raw, 10, 3);
+    const msg = Buffer.concat([
+      typeBuf,
+      digest([data.output, ending.output], dataLength + ending.length)
+    ]);
+    const msgHash = keccak(msg);
+    const sig = ecsign(msgHash, privateKey, chainId);
+    this.v = Quantity.from(sig.v);
+    this.r = Quantity.from(sig.r);
+    this.s = Quantity.from(sig.s);
+
+    raw[10] = this.v.toBuffer();
+    raw[11] = this.r.toBuffer();
+    raw[12] = this.s.toBuffer();
+
+    this.raw = raw;
+
+    const encodedSignature = encodeRange(raw, 10, 3);
+    // raw data is type concatenated with the rest of the data rlp encoded
+    this.serialized = Buffer.concat([
+      typeBuf,
+      digest(
+        [data.output, encodedSignature.output],
+        dataLength + encodedSignature.length
+      )
+    ]);
+    this.hash = Data.from(keccak(this.serialized));
+    this.encodedData = data;
+    this.encodedSignature = encodedSignature;
+  }
+
+  public toEthRawTransaction(
+    v: Buffer,
+    r: Buffer,
+    s: Buffer
+  ): EIP1559FeeMarketDatabaseTx {
+    return [
+      this.type.toBuffer(),
+      this.chainId.toBuffer(),
+      this.nonce.toBuffer(),
+      this.maxPriorityFeePerGas.toBuffer(),
+      this.maxFeePerGas.toBuffer(),
+      this.gas.toBuffer(),
+      this.to.toBuffer(),
+      this.value.toBuffer(),
+      this.data.toBuffer(),
+      this.accessList,
+      v,
+      r,
+      s
+    ];
+  }
+
+  public computeIntrinsics(
+    v: Quantity,
+    raw: TypedDatabaseTransaction,
+    chainId: number
+  ) {
+    return computeInstrinsicsFeeMarketTx(
+      v,
+      <EIP1559FeeMarketDatabaseTx>raw,
+      chainId
+    );
+  }
+
+  public getStandardizedGasPrice() {
+    return this.maxFeePerGas; // TODO
+  }
+}

--- a/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
@@ -265,14 +265,12 @@ export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
 
   public updateEffectiveGasPrice(baseFeePerGas?: Quantity) {
     if (baseFeePerGas) {
-      const baseFeePerGasNum = baseFeePerGas.toNumber();
-      const maxFeePerGasNum = this.maxFeePerGas.toNumber();
-      const maxPriorityFeePerGasNum = this.maxPriorityFeePerGas.toNumber();
-      const tip = Math.min(
-        maxFeePerGasNum - baseFeePerGasNum,
-        maxPriorityFeePerGasNum
-      );
-      this.effectiveGasPrice = Quantity.from(baseFeePerGasNum + tip);
+      const baseFeePerGasBigInt = baseFeePerGas.toBigInt();
+      const maxFeePerGas = this.maxFeePerGas.toBigInt();
+      const maxPriorityFeePerGas = this.maxPriorityFeePerGas.toBigInt();
+      const a = maxFeePerGas - baseFeePerGasBigInt;
+      const tip = a < maxPriorityFeePerGas ? a : maxPriorityFeePerGas;
+      this.effectiveGasPrice = Quantity.from(baseFeePerGasBigInt + tip);
     } else {
       // TODO, there could be a better way to handle this, but:
       // When the tx is first being constructed, we don't always have access to

--- a/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
@@ -43,6 +43,7 @@ function ecsign(msgHash: Uint8Array, privateKey: Uint8Array) {
 }
 
 const CAPABILITIES = [2718, 2930, 1559];
+
 export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
   public chainId: Quantity;
   public maxPriorityFeePerGas: Quantity;
@@ -83,7 +84,7 @@ export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
           hash,
           encodedData,
           encodedSignature
-        } = this.computeIntrinsics(this.v, this.raw, this.common.chainId());
+        } = this.computeIntrinsics(this.v, this.raw);
 
         this.from = from;
         this.serialized = serialized;
@@ -258,16 +259,8 @@ export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
     ];
   }
 
-  public computeIntrinsics(
-    v: Quantity,
-    raw: TypedDatabaseTransaction,
-    chainId: number
-  ) {
-    return computeInstrinsicsFeeMarketTx(
-      v,
-      <EIP1559FeeMarketDatabaseTx>raw,
-      chainId
-    );
+  public computeIntrinsics(v: Quantity, raw: TypedDatabaseTransaction) {
+    return computeInstrinsicsFeeMarketTx(v, <EIP1559FeeMarketDatabaseTx>raw);
   }
 
   public updateEffectiveGasPrice(baseFeePerGas?: Quantity) {

--- a/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
@@ -80,6 +80,7 @@ export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
       this.accessListJSON = accessListData.AccessListJSON;
       this.validateAndSetSignature(data);
     }
+    this.updateEffectiveGasPrice();
   }
 
   public toJSON(): EIP1559FeeMarketTransactionJSON {
@@ -260,9 +261,10 @@ export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
       );
       this.effectiveGasPrice = Quantity.from(baseFeePerGasNum + tip);
     } else {
-      // this can only happen if baseFeePerGas isn't set, which means
-      // we're pre eip-1559, which means we shouldn't be here in the
-      // first place. Might be safe to remove this case.
+      // TODO, there could be a better way to handle this, but:
+      // When the tx is first being constructed, we don't always have access to
+      // the block, so we don't have the baseFeePerGas. Instead, just default to
+      // the maxFeePerGas
       this.effectiveGasPrice = this.maxFeePerGas;
     }
   }

--- a/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
@@ -20,7 +20,7 @@ import {
 } from "./raw";
 import { AccessList, AccessListBuffer } from "@ethereumjs/tx";
 import { AccessLists } from "./access-lists";
-import { computeInstrinsicsFeeMarketTx } from "./signing";
+import { computeIntrinsicsFeeMarketTx } from "./signing";
 import {
   Capability,
   EIP1559FeeMarketTransactionJSON
@@ -260,7 +260,7 @@ export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
   }
 
   public computeIntrinsics(v: Quantity, raw: TypedDatabaseTransaction) {
-    return computeInstrinsicsFeeMarketTx(v, <EIP1559FeeMarketDatabaseTx>raw);
+    return computeIntrinsicsFeeMarketTx(v, <EIP1559FeeMarketDatabaseTx>raw);
   }
 
   public updateEffectiveGasPrice(baseFeePerGas?: Quantity) {

--- a/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
@@ -43,7 +43,7 @@ export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
     super(data, common, extra);
     if (Array.isArray(data)) {
       this.chainId = Quantity.from(data[0]);
-      this.nonce = Quantity.from(data[1], true);
+      this.nonce = Quantity.from(data[1]);
       this.maxPriorityFeePerGas = Quantity.from(data[2]);
       this.maxFeePerGas = Quantity.from(data[3]);
       this.gas = Quantity.from(data[4]);

--- a/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
@@ -2,7 +2,7 @@ import {
   Data,
   Quantity,
   keccak,
-  BUFFER_EMPTY,
+  BUFFER_ZERO,
   BUFFER_32_ZERO,
   RPCQUANTITY_EMPTY
 } from "@ganache/utils";
@@ -187,19 +187,17 @@ export class EIP2930AccessListTransaction extends RuntimeTransaction {
       );
     }
 
-    const chainId = this.common.chainId();
     const typeBuf = this.type.toBuffer();
     const raw: EIP2930AccessListDatabaseTx = this.toEthRawTransaction(
-      Quantity.from(chainId).toBuffer(),
-      BUFFER_EMPTY,
-      BUFFER_EMPTY
+      BUFFER_ZERO,
+      BUFFER_ZERO,
+      BUFFER_ZERO
     );
     const data = encodeRange(raw, 1, 8);
     const dataLength = data.length;
 
-    const ending = encodeRange(raw, 9, 3);
     const msgHash = keccak(
-      digest([data.output, ending.output], dataLength + ending.length)
+      Buffer.concat([typeBuf, digest([data.output], dataLength)])
     );
     const sig = ecsign(msgHash, privateKey);
     this.v = Quantity.from(sig.v);

--- a/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
@@ -20,7 +20,7 @@ import {
 } from "./raw";
 import { AccessList, AccessListBuffer } from "@ethereumjs/tx";
 import { AccessLists } from "./access-lists";
-import { computeInstrinsicsAccessListTx } from "./signing";
+import { computeIntrinsicsAccessListTx } from "./signing";
 import {
   Capability,
   EIP2930AccessListTransactionJSON
@@ -246,7 +246,7 @@ export class EIP2930AccessListTransaction extends RuntimeTransaction {
   }
 
   public computeIntrinsics(v: Quantity, raw: TypedDatabaseTransaction) {
-    return computeInstrinsicsAccessListTx(v, <EIP2930AccessListDatabaseTx>raw);
+    return computeIntrinsicsAccessListTx(v, <EIP2930AccessListDatabaseTx>raw);
   }
 
   public updateEffectiveGasPrice() {}

--- a/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
@@ -45,7 +45,7 @@ export class EIP2930AccessListTransaction extends RuntimeTransaction {
     if (Array.isArray(data)) {
       this.chainId = Quantity.from(data[0]);
       this.nonce = Quantity.from(data[1]);
-      this.gasPrice = Quantity.from(data[2]);
+      this.gasPrice = this.effectiveGasPrice = Quantity.from(data[2]);
       this.gas = Quantity.from(data[3]);
       this.to = data[4].length == 0 ? RPCQUANTITY_EMPTY : Address.from(data[4]);
       this.value = Quantity.from(data[5]);
@@ -78,7 +78,7 @@ export class EIP2930AccessListTransaction extends RuntimeTransaction {
       }
     } else {
       this.chainId = Quantity.from(data.chainId);
-      this.gasPrice = Quantity.from(data.gasPrice);
+      this.gasPrice = this.effectiveGasPrice = Quantity.from(data.gasPrice);
       const accessListData = AccessLists.getAccessListData(data.accessList);
       this.accessList = accessListData.accessList;
       this.accessListJSON = accessListData.AccessListJSON;
@@ -243,7 +243,5 @@ export class EIP2930AccessListTransaction extends RuntimeTransaction {
     );
   }
 
-  public getStandardizedGasPrice() {
-    return this.gasPrice;
-  }
+  public updateEffectiveGasPrice() {}
 }

--- a/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
@@ -242,4 +242,8 @@ export class EIP2930AccessListTransaction extends RuntimeTransaction {
       chainId
     );
   }
+
+  public getStandardizedGasPrice() {
+    return this.gasPrice;
+  }
 }

--- a/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
@@ -180,11 +180,9 @@ export class EIP2930AccessListTransaction extends RuntimeTransaction {
     const dataLength = data.length;
 
     const ending = encodeRange(raw, 9, 3);
-    const msg = Buffer.concat([
-      typeBuf,
+    const msgHash = keccak(
       digest([data.output, ending.output], dataLength + ending.length)
-    ]);
-    const msgHash = keccak(msg);
+    );
     const sig = ecsign(msgHash, privateKey, chainId);
     this.v = Quantity.from(sig.v);
     this.r = Quantity.from(sig.r);

--- a/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
@@ -59,7 +59,7 @@ export class EIP2930AccessListTransaction extends RuntimeTransaction {
       this.s = Quantity.from(data[10]);
       this.raw = [this.type.toBuffer(), ...data];
 
-      if (this.common) {
+      if (!extra) {
         // TODO(hack): Transactions that come from the database must not be
         // validated since they may come from a fork.
         const {
@@ -87,7 +87,7 @@ export class EIP2930AccessListTransaction extends RuntimeTransaction {
     }
   }
 
-  public toJSON(common?: Common): EIP2930AccessListTransactionJSON {
+  public toJSON(_common?: Common): EIP2930AccessListTransactionJSON {
     return {
       hash: this.hash,
       type: this.type,
@@ -183,7 +183,7 @@ export class EIP2930AccessListTransaction extends RuntimeTransaction {
     const msgHash = keccak(
       digest([data.output, ending.output], dataLength + ending.length)
     );
-    const sig = ecsign(msgHash, privateKey, chainId);
+    const sig = ecsign(msgHash, privateKey, null);
     this.v = Quantity.from(sig.v);
     this.r = Quantity.from(sig.r);
     this.s = Quantity.from(sig.s);

--- a/src/chains/ethereum/transaction/src/hardfork.ts
+++ b/src/chains/ethereum/transaction/src/hardfork.ts
@@ -4,4 +4,5 @@ export type Hardfork =
   | "petersburg"
   | "istanbul"
   | "muirGlacier"
-  | "berlin";
+  | "berlin"
+  | "london";

--- a/src/chains/ethereum/transaction/src/legacy-transaction.ts
+++ b/src/chains/ethereum/transaction/src/legacy-transaction.ts
@@ -14,7 +14,6 @@ import { BN } from "ethereumjs-util";
 import { RuntimeTransaction } from "./runtime-transaction";
 import { TypedRpcTransaction } from "./rpc-transaction";
 import {
-  EIP1559FeeMarketDatabasePayload,
   EIP2930AccessListDatabasePayload,
   GanacheRawExtraTx,
   LegacyDatabasePayload,

--- a/src/chains/ethereum/transaction/src/legacy-transaction.ts
+++ b/src/chains/ethereum/transaction/src/legacy-transaction.ts
@@ -45,7 +45,7 @@ export class LegacyTransaction extends RuntimeTransaction {
       this.s = Quantity.from(data[8]);
       this.raw = data;
 
-      if (this.common) {
+      if (!extra) {
         // TODO(hack): Transactions that come from the database must not be
         // validated since they may come from a fork.
         const {
@@ -112,29 +112,6 @@ export class LegacyTransaction extends RuntimeTransaction {
         common
       );
     }
-    return new LegacyTransaction(data, common);
-  }
-
-  public static fromEIP15590FeeMarketTransaction(
-    data: EIP1559FeeMarketDatabasePayload | TypedRpcTransaction,
-    common: Common
-  ) {
-    if (Array.isArray(data)) {
-      const rawLegacy: LegacyDatabasePayload = [
-        data[1], // nonce
-        data[3], // we'll use the max fee per gas as the gas price
-        data[4], // gas
-        data[5], // to
-        data[6], // value
-        data[7], // data
-        data[9], // v
-        data[10], // r
-        data[11] // s
-      ];
-      // remove 1st item, chainId, and 7th item, accessList
-      return new LegacyTransaction(rawLegacy, common);
-    }
-    data.gasPrice = data.maxFeePerGas;
     return new LegacyTransaction(data, common);
   }
 

--- a/src/chains/ethereum/transaction/src/legacy-transaction.ts
+++ b/src/chains/ethereum/transaction/src/legacy-transaction.ts
@@ -35,7 +35,7 @@ export class LegacyTransaction extends RuntimeTransaction {
     super(data, common, extra);
     if (Array.isArray(data)) {
       this.nonce = Quantity.from(data[0]);
-      this.gasPrice = Quantity.from(data[1]);
+      this.gasPrice = this.effectiveGasPrice = Quantity.from(data[1]);
       this.gas = Quantity.from(data[2]);
       this.to = data[3].length == 0 ? RPCQUANTITY_EMPTY : Address.from(data[3]);
       this.value = Quantity.from(data[4]);
@@ -63,7 +63,7 @@ export class LegacyTransaction extends RuntimeTransaction {
         this.encodedSignature = encodedSignature;
       }
     } else {
-      this.gasPrice = Quantity.from(data.gasPrice);
+      this.gasPrice = this.effectiveGasPrice = Quantity.from(data.gasPrice);
 
       this.validateAndSetSignature(data);
     }
@@ -248,8 +248,5 @@ export class LegacyTransaction extends RuntimeTransaction {
   ) {
     return computeInstrinsicsLegacyTx(v, <LegacyDatabasePayload>raw, chainId);
   }
-
-  public getStandardizedGasPrice() {
-    return this.gasPrice;
-  }
+  public updateEffectiveGasPrice() {}
 }

--- a/src/chains/ethereum/transaction/src/legacy-transaction.ts
+++ b/src/chains/ethereum/transaction/src/legacy-transaction.ts
@@ -19,7 +19,7 @@ import {
   LegacyDatabasePayload,
   TypedDatabaseTransaction
 } from "./raw";
-import { computeInstrinsicsLegacyTx } from "./signing";
+import { computeIntrinsicsLegacyTx } from "./signing";
 import { Capability, LegacyTransactionJSON } from "./transaction-types";
 
 export class LegacyTransaction extends RuntimeTransaction {
@@ -222,7 +222,7 @@ export class LegacyTransaction extends RuntimeTransaction {
     raw: TypedDatabaseTransaction,
     chainId: number
   ) {
-    return computeInstrinsicsLegacyTx(v, <LegacyDatabasePayload>raw, chainId);
+    return computeIntrinsicsLegacyTx(v, <LegacyDatabasePayload>raw, chainId);
   }
   public updateEffectiveGasPrice() {}
 }

--- a/src/chains/ethereum/transaction/src/legacy-transaction.ts
+++ b/src/chains/ethereum/transaction/src/legacy-transaction.ts
@@ -14,6 +14,7 @@ import { BN } from "ethereumjs-util";
 import { RuntimeTransaction } from "./runtime-transaction";
 import { TypedRpcTransaction } from "./rpc-transaction";
 import {
+  EIP1559FeeMarketDatabasePayload,
   EIP2930AccessListDatabasePayload,
   GanacheRawExtraTx,
   LegacyDatabasePayload,
@@ -113,6 +114,30 @@ export class LegacyTransaction extends RuntimeTransaction {
     }
     return new LegacyTransaction(data, common);
   }
+
+  public static fromEIP15590FeeMarketTransaction(
+    data: EIP1559FeeMarketDatabasePayload | TypedRpcTransaction,
+    common: Common
+  ) {
+    if (Array.isArray(data)) {
+      const rawLegacy: LegacyDatabasePayload = [
+        data[1], // nonce
+        data[3], // we'll use the max fee per gas as the gas price
+        data[4], // gas
+        data[5], // to
+        data[6], // value
+        data[7], // data
+        data[9], // v
+        data[10], // r
+        data[11] // s
+      ];
+      // remove 1st item, chainId, and 7th item, accessList
+      return new LegacyTransaction(rawLegacy, common);
+    }
+    data.gasPrice = data.maxFeePerGas;
+    return new LegacyTransaction(data, common);
+  }
+
   public toVmTransaction() {
     const sender = this.from.toBuffer();
     const to = this.to.toBuffer();

--- a/src/chains/ethereum/transaction/src/legacy-transaction.ts
+++ b/src/chains/ethereum/transaction/src/legacy-transaction.ts
@@ -113,7 +113,6 @@ export class LegacyTransaction extends RuntimeTransaction {
     }
     return new LegacyTransaction(data, common);
   }
-
   public toVmTransaction() {
     const sender = this.from.toBuffer();
     const to = this.to.toBuffer();

--- a/src/chains/ethereum/transaction/src/legacy-transaction.ts
+++ b/src/chains/ethereum/transaction/src/legacy-transaction.ts
@@ -223,4 +223,8 @@ export class LegacyTransaction extends RuntimeTransaction {
   ) {
     return computeInstrinsicsLegacyTx(v, <LegacyDatabasePayload>raw, chainId);
   }
+
+  public getStandardizedGasPrice() {
+    return this.gasPrice;
+  }
 }

--- a/src/chains/ethereum/transaction/src/params.ts
+++ b/src/chains/ethereum/transaction/src/params.ts
@@ -16,7 +16,8 @@ export const Params = {
     | "petersburg"
     | "istanbul"
     | "muirGlacier"
-    | "berlin",
+    | "berlin"
+    | "london",
     bigint
   >([
     ["constantinople", 68n],
@@ -24,7 +25,8 @@ export const Params = {
     ["petersburg", 68n],
     ["istanbul", 16n],
     ["muirGlacier", 16n],
-    ["berlin", 16n]
+    ["berlin", 16n],
+    ["london", 16n]
   ]),
 
   /**

--- a/src/chains/ethereum/transaction/src/raw.ts
+++ b/src/chains/ethereum/transaction/src/raw.ts
@@ -33,17 +33,39 @@ export type EIP2930AccessListDatabasePayload = [
   s: Buffer
 ];
 
+export type EIP1559FeeMarketDatabasePayload = [
+  chainId: Buffer,
+  nonce: Buffer,
+  maxPriorityFeePerGas: Buffer,
+  maxFeePerGas: Buffer,
+  gas: Buffer,
+  to: Buffer,
+  value: Buffer,
+  data: Buffer,
+  accessList: AccessListBuffer,
+  v: Buffer,
+  r: Buffer,
+  s: Buffer
+];
+
 export type EIP2930AccessListDatabaseTx = Concat<
   TxType,
   EIP2930AccessListDatabasePayload
 >;
 
+export type EIP1559FeeMarketDatabaseTx = Concat<
+  TxType,
+  EIP1559FeeMarketDatabasePayload
+>;
+
 export type TypedDatabaseTransaction =
   | LegacyDatabasePayload
-  | EIP2930AccessListDatabaseTx;
+  | EIP2930AccessListDatabaseTx
+  | EIP1559FeeMarketDatabaseTx;
 export type TypedDatabasePayload =
   | LegacyDatabasePayload
-  | EIP2930AccessListDatabasePayload;
+  | EIP2930AccessListDatabasePayload
+  | EIP1559FeeMarketDatabasePayload;
 
 /**
  * Extra data Ganache stores as part of a transaction in order to support

--- a/src/chains/ethereum/transaction/src/rpc-transaction.ts
+++ b/src/chains/ethereum/transaction/src/rpc-transaction.ts
@@ -26,29 +26,29 @@ export type TypedRpcTransaction =
   | EIP2930AccessListRpcTransaction
   | EIP1559FeeMarketRpcTransaction;
 
-export type LegacyRpcTransaction = RpcTransaction & {
-  gasPrice?: string;
-  chainId?: never;
-  accessList?: never;
-  maxPriorityFeePerGas?: never;
-  maxFeePerGas?: never;
+export type LegacyRpcTransaction = Readonly<RpcTransaction> & {
+  readonly gasPrice?: string;
+  readonly chainId?: never;
+  readonly accessList?: never;
+  readonly maxPriorityFeePerGas?: never;
+  readonly maxFeePerGas?: never;
 };
-export type EIP2930AccessListRpcTransaction = RpcTransaction & {
-  type: TxType;
-  chainId?: string;
-  gasPrice?: string;
-  accessList?: AccessList;
-  maxPriorityFeePerGas?: never;
-  maxFeePerGas?: never;
+export type EIP2930AccessListRpcTransaction = Readonly<RpcTransaction> & {
+  readonly type: TxType;
+  readonly chainId?: string;
+  readonly gasPrice?: string;
+  readonly accessList?: AccessList;
+  readonly maxPriorityFeePerGas?: never;
+  readonly maxFeePerGas?: never;
 };
 
-export type EIP1559FeeMarketRpcTransaction = RpcTransaction & {
-  type: TxType;
-  chainId?: string;
-  gasPrice?: never;
-  maxPriorityFeePerGas?: string;
-  maxFeePerGas?: string;
-  accessList?: AccessList;
+export type EIP1559FeeMarketRpcTransaction = Readonly<RpcTransaction> & {
+  readonly type: TxType;
+  readonly chainId?: string;
+  readonly gasPrice?: never;
+  readonly maxPriorityFeePerGas?: string;
+  readonly maxFeePerGas?: string;
+  readonly accessList?: AccessList;
 };
 
 export type RpcTransaction =

--- a/src/chains/ethereum/transaction/src/rpc-transaction.ts
+++ b/src/chains/ethereum/transaction/src/rpc-transaction.ts
@@ -22,21 +22,39 @@ type HexPair = `${oneThroughSeven}${HexChar}`;
 type TxType = `0x${HexChar}` | `0x${HexPair}`; // tx types are valid 0 through 7f
 
 export type TypedRpcTransaction =
-  | (RpcTransaction & {
-      chainId?: never;
-      accessList?: never;
-    })
-  | (RpcTransaction & {
-      type: TxType;
-      chainId?: string;
-      accessList?: AccessList;
-    });
+  | LegacyRpcTransaction
+  | EIP2930AccessListRpcTransaction
+  | EIP1559FeeMarketRpcTransaction;
+
+export type LegacyRpcTransaction = RpcTransaction & {
+  gasPrice?: string;
+  chainId?: never;
+  accessList?: never;
+  maxPriorityFeePerGas?: never;
+  maxFeePerGas?: never;
+};
+export type EIP2930AccessListRpcTransaction = RpcTransaction & {
+  type: TxType;
+  chainId?: string;
+  gasPrice?: string;
+  accessList?: AccessList;
+  maxPriorityFeePerGas?: never;
+  maxFeePerGas?: never;
+};
+
+export type EIP1559FeeMarketRpcTransaction = RpcTransaction & {
+  type: TxType;
+  chainId?: string;
+  gasPrice?: never;
+  maxPriorityFeePerGas?: string;
+  maxFeePerGas?: string;
+  accessList?: AccessList;
+};
 
 export type RpcTransaction =
   | {
       from: string;
       nonce?: string;
-      gasPrice?: string;
       gas?: string;
       gasLimit?: never;
       to?: string;
@@ -47,7 +65,6 @@ export type RpcTransaction =
   | {
       from: string;
       nonce?: string;
-      gasPrice?: string;
       /**
        * Alias for `gas`
        */
@@ -61,7 +78,6 @@ export type RpcTransaction =
   | {
       from: string;
       nonce?: string;
-      gasPrice?: string;
       gas?: string;
       gasLimit?: never;
       to?: string;
@@ -75,7 +91,6 @@ export type RpcTransaction =
   | {
       from: string;
       nonce?: string;
-      gasPrice?: string;
       /**
        * Alias for `gas`
        */
@@ -93,7 +108,6 @@ export type RpcTransaction =
   | {
       from?: string;
       nonce: string;
-      gasPrice?: string;
       gas?: string;
       gasLimit?: never;
       to?: string;
@@ -107,7 +121,6 @@ export type RpcTransaction =
   | {
       from?: string;
       nonce: string;
-      gasPrice?: string;
       /**
        * Alias for `gas`
        */
@@ -124,7 +137,6 @@ export type RpcTransaction =
   | {
       from?: string;
       nonce: string;
-      gasPrice?: string;
       gas?: string;
       gasLimit?: never;
       to?: string;
@@ -141,7 +153,6 @@ export type RpcTransaction =
   | {
       from?: string;
       nonce: string;
-      gasPrice?: string;
       /**
        * Alias for `gas`
        */

--- a/src/chains/ethereum/transaction/src/runtime-transaction.ts
+++ b/src/chains/ethereum/transaction/src/runtime-transaction.ts
@@ -125,7 +125,7 @@ export abstract class RuntimeTransaction extends BaseTransaction {
     return encode(txAndExtraData);
   }
 
-  abstract toJSON();
+  abstract toJSON(common: Common);
 
   /**
    * Initializes the receipt and logs
@@ -191,30 +191,32 @@ export abstract class RuntimeTransaction extends BaseTransaction {
         this.r.toBuffer(),
         this.s.toBuffer()
       );
-      const {
-        from,
-        serialized,
-        hash,
-        encodedData,
-        encodedSignature
-      } = this.computeIntrinsics(this.v, raw, this.common.chainId());
-
-      // if the user specified a `from` address in addition to the  `v`, `r`,
-      //  and `s` values, make sure the `from` address matches
-      if (data.from !== null) {
-        const userFrom = toValidLengthAddress(data.from, "from");
-        if (!from.toBuffer().equals(userFrom.toBuffer())) {
-          throw new Error(
-            "Transaction is signed and contains a `from` field, but the signature doesn't match."
-          );
-        }
-      }
-      this.from = from;
       this.raw = raw;
-      this.serialized = serialized;
-      this.hash = hash;
-      this.encodedData = encodedData;
-      this.encodedSignature = encodedSignature;
+      if (!this.from) {
+        const {
+          from,
+          serialized,
+          hash,
+          encodedData,
+          encodedSignature
+        } = this.computeIntrinsics(this.v, raw, this.common.chainId());
+
+        // if the user specified a `from` address in addition to the  `v`, `r`,
+        //  and `s` values, make sure the `from` address matches
+        if (data.from !== null) {
+          const userFrom = toValidLengthAddress(data.from, "from");
+          if (!from.toBuffer().equals(userFrom.toBuffer())) {
+            throw new Error(
+              "Transaction is signed and contains a `from` field, but the signature doesn't match."
+            );
+          }
+        }
+        this.from = from;
+        this.serialized = serialized;
+        this.hash = hash;
+        this.encodedData = encodedData;
+        this.encodedSignature = encodedSignature;
+      }
     } else if (data.from != null) {
       // we don't have a signature yet, so we just need to record the `from`
       // address for now. The TransactionPool will fill in the `hash` and

--- a/src/chains/ethereum/transaction/src/runtime-transaction.ts
+++ b/src/chains/ethereum/transaction/src/runtime-transaction.ts
@@ -34,8 +34,8 @@ export const toValidLengthAddress = (address: string, fieldName: string) => {
 };
 
 export const hasPartialSignature = (
-  data: RpcTransaction
-): data is RpcTransaction & {
+  data: TypedRpcTransaction
+): data is TypedRpcTransaction & {
   from?: string;
   v?: string;
   r?: string;
@@ -261,4 +261,5 @@ export abstract class RuntimeTransaction extends BaseTransaction {
   );
 
   protected abstract toVmTransaction();
+  protected abstract getStandardizedGasPrice();
 }

--- a/src/chains/ethereum/transaction/src/runtime-transaction.ts
+++ b/src/chains/ethereum/transaction/src/runtime-transaction.ts
@@ -261,5 +261,5 @@ export abstract class RuntimeTransaction extends BaseTransaction {
   );
 
   protected abstract toVmTransaction();
-  protected abstract getStandardizedGasPrice();
+  protected abstract updateEffectiveGasPrice(baseFeePerGas?: Quantity);
 }

--- a/src/chains/ethereum/transaction/src/signing.ts
+++ b/src/chains/ethereum/transaction/src/signing.ts
@@ -5,7 +5,11 @@ import {
   BUFFER_EMPTY,
   uintToBuffer
 } from "@ganache/utils";
-import { EIP2930AccessListDatabaseTx, LegacyDatabasePayload } from "./raw";
+import {
+  EIP1559FeeMarketDatabaseTx,
+  EIP2930AccessListDatabaseTx,
+  LegacyDatabasePayload
+} from "./raw";
 import { digest, encodeRange } from "@ganache/rlp";
 import { Address } from "@ganache/ethereum-address";
 
@@ -204,6 +208,36 @@ export const computeInstrinsicsAccessListTx = (
       v.toNumber(),
       raw[10],
       raw[11],
+      chainId
+    ),
+    hash: Data.from(keccak(serialized), 32),
+    serialized,
+    encodedData,
+    encodedSignature
+  };
+};
+
+export const computeInstrinsicsFeeMarketTx = (
+  v: Quantity,
+  raw: EIP1559FeeMarketDatabaseTx,
+  chainId: number
+) => {
+  const typeBuf = raw[0];
+  const encodedData = encodeRange(raw, 1, 9);
+  const encodedSignature = encodeRange(raw, 10, 3);
+  const serialized = Buffer.concat([
+    typeBuf,
+    digest(
+      [encodedData.output, encodedSignature.output],
+      encodedData.length + encodedSignature.length
+    )
+  ]);
+  return {
+    from: computeFromAddress(
+      encodedData,
+      v.toNumber(),
+      raw[11],
+      raw[12],
       chainId
     ),
     hash: Data.from(keccak(serialized), 32),

--- a/src/chains/ethereum/transaction/src/signing.ts
+++ b/src/chains/ethereum/transaction/src/signing.ts
@@ -97,9 +97,6 @@ export const ecdsaRecover = (
     data = digest([partialRlp.output], partialRlp.length);
     recid = v - 27;
   }
-  if (!isValidSigRecovery(recid)) {
-    throw new Error("Invalid signature v value");
-  }
 
   return _ecdsaRecover(data, sharedBuffer, rBuf, sBuf, recid);
 };
@@ -111,6 +108,10 @@ function _ecdsaRecover(
   sBuf: Buffer,
   recid: number
 ) {
+  if (!isValidSigRecovery(recid)) {
+    throw new Error("Invalid signature v value");
+  }
+
   const message = keccak(data);
 
   const signature = sharedBuffer.slice(0, 64);

--- a/src/chains/ethereum/transaction/src/signing.ts
+++ b/src/chains/ethereum/transaction/src/signing.ts
@@ -167,7 +167,7 @@ export const computeFromAddress = (
   return Address.from(keccak(publicKey.slice(1)).slice(-20));
 };
 
-export const computeInstrinsicsLegacyTx = (
+export const computeIntrinsicsLegacyTx = (
   v: Quantity,
   raw: LegacyDatabasePayload,
   chainId: number
@@ -193,7 +193,7 @@ export const computeInstrinsicsLegacyTx = (
   };
 };
 
-export const computeInstrinsicsAccessListTx = (
+export const computeIntrinsicsAccessListTx = (
   v: Quantity,
   raw: EIP2930AccessListDatabaseTx
 ) => {
@@ -232,7 +232,7 @@ export const computeInstrinsicsAccessListTx = (
   };
 };
 
-export const computeInstrinsicsFeeMarketTx = (
+export const computeIntrinsicsFeeMarketTx = (
   v: Quantity,
   raw: EIP1559FeeMarketDatabaseTx
 ) => {

--- a/src/chains/ethereum/transaction/src/transaction-factory.ts
+++ b/src/chains/ethereum/transaction/src/transaction-factory.ts
@@ -1,4 +1,9 @@
-import { Data, JsonRpcErrorCode } from "@ganache/utils";
+import {
+  Data,
+  JsonRpcErrorCode,
+  Quantity,
+  RPCQUANTITY_ZERO
+} from "@ganache/utils";
 import type Common from "@ethereumjs/common";
 import { LegacyTransaction } from "./legacy-transaction";
 import { EIP2930AccessListTransaction } from "./eip2930-access-list-transaction";
@@ -17,9 +22,12 @@ import { TypedTransaction } from "./transaction-types";
 import { EIP1559FeeMarketTransaction } from "./eip1559-fee-market-transaction";
 
 const UNTYPED_TX_START_BYTE = 0xc0; // all txs with first byte >= 0xc0 are untyped
-const LEGACY_TX_TYPE_ID = 0x0;
-const EIP2930_ACCESS_LIST_TX_TYPE_ID = 0x1;
-const EIP1559_FEE_MARKET_TX_TYPE_ID = 0x2;
+
+export enum TransactionType {
+  Legacy = 0x0,
+  EIP2930AccessList = 0x1,
+  EIP1559AccessList = 0x2
+}
 
 export class TransactionFactory {
   public tx: TypedTransaction;
@@ -32,42 +40,26 @@ export class TransactionFactory {
   }
   private static _fromData(
     txData: TypedRpcTransaction | TypedDatabasePayload,
-    txType:
-      | typeof EIP2930AccessListTransaction
-      | typeof LegacyTransaction
-      | typeof EIP1559FeeMarketTransaction,
+    txType: TransactionType,
     common: Common,
     extra?: GanacheRawExtraTx
   ) {
     // if tx type envelope isn't available yet on this HF,
     // return legacy txs as is and convert typed txs to legacy
     if (!common.isActivatedEIP(2718)) {
-      if (txType === LegacyTransaction) {
-        return LegacyTransaction.fromTxData(
-          <LegacyDatabasePayload | TypedRpcTransaction>txData,
-          common,
-          extra
-        );
-      }
-      if (txType === EIP2930AccessListTransaction) {
-        return LegacyTransaction.fromEIP2930AccessListTransaction(
-          <EIP2930AccessListDatabasePayload | TypedRpcTransaction>txData,
-          common
-        );
-      } else if (txType === EIP1559FeeMarketTransaction) {
-        return LegacyTransaction.fromEIP15590FeeMarketTransaction(
-          <EIP1559FeeMarketDatabasePayload | TypedRpcTransaction>txData,
-          common
-        );
-      }
+      return LegacyTransaction.fromTxData(
+        <LegacyDatabasePayload | TypedRpcTransaction>txData,
+        common,
+        extra
+      );
     } else if (!common.isActivatedEIP(1559)) {
-      if (txType === LegacyTransaction) {
+      if (txType === TransactionType.Legacy) {
         return LegacyTransaction.fromTxData(
           <TypedRpcTransaction>txData,
           common,
           extra
         );
-      } else if (txType === EIP2930AccessListTransaction) {
+      } else if (txType === TransactionType.EIP2930AccessList) {
         if (common.isActivatedEIP(2930)) {
           return EIP2930AccessListTransaction.fromTxData(
             <EIP2930AccessListDatabasePayload | TypedRpcTransaction>txData,
@@ -82,7 +74,7 @@ export class TransactionFactory {
             JsonRpcErrorCode.INVALID_PARAMS
           );
         }
-      } else if (txType === EIP1559FeeMarketTransaction) {
+      } else if (txType === TransactionType.EIP1559AccessList) {
         throw new CodedError(
           `EIP 1559 is not activated.`,
           JsonRpcErrorCode.INVALID_PARAMS
@@ -94,19 +86,19 @@ export class TransactionFactory {
       // we can assume that all database transactions came from us, so
       // the type doesn't need to be normalized.
       if (Array.isArray(txData)) {
-        if (txType === LegacyTransaction) {
+        if (txType === TransactionType.Legacy) {
           return LegacyTransaction.fromTxData(
             <LegacyDatabasePayload>txData,
             common,
             extra
           );
-        } else if (txType === EIP2930AccessListTransaction) {
+        } else if (txType === TransactionType.EIP2930AccessList) {
           return EIP2930AccessListTransaction.fromTxData(
             <EIP2930AccessListDatabasePayload>txData,
             common,
             extra
           );
-        } else if (txType === EIP1559FeeMarketTransaction) {
+        } else if (txType === TransactionType.EIP1559AccessList) {
           return EIP1559FeeMarketTransaction.fromTxData(
             <EIP1559FeeMarketDatabasePayload>txData,
             common,
@@ -115,18 +107,23 @@ export class TransactionFactory {
         }
       } else {
         const toEIP1559 =
-          (txType === LegacyTransaction ||
-            txType === EIP2930AccessListTransaction) &&
+          (txType === TransactionType.Legacy ||
+            txType === TransactionType.EIP2930AccessList) &&
           txData.gasPrice === undefined;
-        if (toEIP1559) {
-          txData.maxFeePerGas = null;
-          txData.maxPriorityFeePerGas = "0x0";
-        }
-        if (txType === EIP1559FeeMarketTransaction || toEIP1559) {
-          return EIP1559FeeMarketTransaction.fromTxData(txData, common, extra);
-        } else if (txType === LegacyTransaction) {
+        if (txType === TransactionType.EIP1559AccessList || toEIP1559) {
+          const tx = EIP1559FeeMarketTransaction.fromTxData(
+            txData,
+            common,
+            extra
+          );
+          if (toEIP1559) {
+            tx.maxFeePerGas = Quantity.from(null);
+            tx.maxPriorityFeePerGas = RPCQUANTITY_ZERO;
+          }
+          return tx;
+        } else if (txType === TransactionType.Legacy) {
           return LegacyTransaction.fromTxData(txData, common, extra);
-        } else if (txType === EIP2930AccessListTransaction) {
+        } else if (txType === TransactionType.EIP2930AccessList) {
           // if no access list is provided, we convert to legacy
           if (txData.accessList === undefined) {
             return LegacyTransaction.fromTxData(txData, common, extra);
@@ -151,10 +148,14 @@ export class TransactionFactory {
    * @param txData - The rpc transaction data. The `type` field will determine which transaction type is returned (if undefined, creates a legacy transaction)
    * @param common - Options to pass on to the constructor of the transaction
    */
-  public static fromRpc(txData: TypedRpcTransaction, common: Common) {
+  public static fromRpc(
+    txData: TypedRpcTransaction,
+    common: Common,
+    extra?: GanacheRawExtraTx
+  ) {
     const txType = this.typeOfRPC(txData);
 
-    return this._fromData(txData, txType, common);
+    return this._fromData(txData, txType, common, extra);
   }
   /**
    * Create a transaction from a `txData` object
@@ -168,17 +169,40 @@ export class TransactionFactory {
     extra?: GanacheRawExtraTx
   ) {
     const txType = this.typeOfRaw(txData);
-    return this._fromData(
-      <TypedDatabasePayload>(
-        (txType === LegacyTransaction ? txData : txData.slice(1)) // if the type is at the front, remove it
-      ),
-      txType,
-      common,
-      extra
-    );
+    switch (txType) {
+      case TransactionType.EIP1559AccessList:
+        return EIP1559FeeMarketTransaction.fromTxData(
+          txData.slice(1) as EIP1559FeeMarketDatabasePayload,
+          common,
+          extra
+        );
+      case TransactionType.Legacy:
+        return LegacyTransaction.fromTxData(
+          txData as LegacyDatabasePayload,
+          common,
+          extra
+        );
+      case TransactionType.EIP2930AccessList:
+        return EIP2930AccessListTransaction.fromTxData(
+          txData.slice(1) as EIP2930AccessListDatabasePayload,
+          common,
+          extra
+        );
+      default:
+        throw new CodedError(
+          `Transactions with supplied type ${txType} not supported`,
+          JsonRpcErrorCode.METHOD_NOT_FOUND
+        );
+    }
   }
   /**
    * Create a transaction from a `txData` object
+   *
+   * When transaction types are activated (EIP 2718) the txData will be checked
+   * for a transaction envelope (first byte < 192) before determining the
+   * decoding strategy, otherwise it will be decoded as a Legacy Transaction. If
+   * the transaction contains a transaction envelop, but EIP 2718 is not active
+   * decoding will fail and an exception will be thrown.
    *
    * @param txData - The raw hex string transaction data. The `type` field will determine which transaction type is returned (if undefined, creates a legacy transaction)
    * @param common - Options to pass on to the constructor of the transaction
@@ -187,30 +211,38 @@ export class TransactionFactory {
     let data = Data.from(txData).toBuffer();
     const type = data[0];
     const txType = this.typeOf(type);
-    const raw = decode<TypedDatabasePayload>(
-      txType === LegacyTransaction ? data : data.slice(1)
-    );
-    return this._fromData(raw, txType, common);
+    if (common.isActivatedEIP(2718)) {
+      const raw = decode<TypedDatabasePayload>(
+        txType === TransactionType.Legacy ? data : data.slice(1)
+      );
+      return this._fromData(raw, txType, common);
+    } else {
+      const raw = decode<TypedDatabasePayload>(data);
+      return this._fromData(raw, TransactionType.Legacy, common);
+    }
   }
 
-  public static typeOf(type: number) {
+  private static typeOf(type: number) {
     if (
+      type === TransactionType.EIP1559AccessList ||
+      type === TransactionType.EIP2930AccessList
+    ) {
+      return type;
+    } else if (
       type >= UNTYPED_TX_START_BYTE ||
-      type === LEGACY_TX_TYPE_ID ||
+      type === TransactionType.Legacy ||
       type === undefined
     ) {
-      return LegacyTransaction;
-    } else if (type === EIP2930_ACCESS_LIST_TX_TYPE_ID) {
-      return EIP2930AccessListTransaction;
-    } else if (type === EIP1559_FEE_MARKET_TX_TYPE_ID) {
-      return EIP1559FeeMarketTransaction;
+      return TransactionType.Legacy;
+    } else {
+      throw new Error(`Invalid transaction type: ${type}`);
     }
   }
 
   public static typeOfRaw(raw: TypedDatabaseTransaction) {
     // LegacyTransactions won't have the type up front to parse
     if (raw.length === 9) {
-      return LegacyTransaction;
+      return TransactionType.Legacy;
     }
     const type = raw[0][0];
     return this.typeOf(type);
@@ -218,9 +250,10 @@ export class TransactionFactory {
 
   public static typeOfRPC(rpc: TypedRpcTransaction) {
     if (!("type" in rpc) || rpc.type === undefined) {
-      return LegacyTransaction;
+      return TransactionType.Legacy;
     } else {
-      const txType = parseInt(rpc.type);
+      // The type must be a hex value
+      const txType = parseInt(rpc.type, 16);
       return this.typeOf(txType);
     }
   }

--- a/src/chains/ethereum/transaction/src/transaction-factory.ts
+++ b/src/chains/ethereum/transaction/src/transaction-factory.ts
@@ -212,12 +212,22 @@ export class TransactionFactory {
     const type = data[0];
     const txType = this.typeOf(type);
     if (common.isActivatedEIP(2718)) {
-      const raw = decode<TypedDatabasePayload>(
-        txType === TransactionType.Legacy ? data : data.slice(1)
-      );
+      let raw: TypedDatabasePayload;
+      try {
+        raw = decode<TypedDatabasePayload>(
+          txType === TransactionType.Legacy ? data : data.slice(1)
+        );
+      } catch (e) {
+        throw new Error("Could not decode transaction: " + e.message);
+      }
       return this._fromData(raw, txType, common);
     } else {
-      const raw = decode<TypedDatabasePayload>(data);
+      let raw: TypedDatabasePayload;
+      try {
+        raw = decode<LegacyDatabasePayload>(data);
+      } catch (e) {
+        throw new Error("Could not decode transaction: " + e.message);
+      }
       return this._fromData(raw, TransactionType.Legacy, common);
     }
   }

--- a/src/chains/ethereum/transaction/src/transaction-factory.ts
+++ b/src/chains/ethereum/transaction/src/transaction-factory.ts
@@ -47,14 +47,17 @@ export class TransactionFactory {
       );
     }
     if (!common.isActivatedEIP(2718)) {
+      // normalize tx to legacy because typed tx envelope is not available on this HF
       if (txType === EIP2930AccessListTransaction) {
-        // normalize tx to legacy
         return LegacyTransaction.fromEIP2930AccessListTransaction(
           <EIP2930AccessListDatabasePayload | TypedRpcTransaction>txData,
           common
         );
       } else if (txType === EIP1559FeeMarketTransaction) {
-        return; // TODO
+        return LegacyTransaction.fromEIP15590FeeMarketTransaction(
+          <EIP1559FeeMarketDatabasePayload | TypedRpcTransaction>txData,
+          common
+        );
       }
     } else {
       if (txType === EIP2930AccessListTransaction) {

--- a/src/chains/ethereum/transaction/src/transaction-receipt.ts
+++ b/src/chains/ethereum/transaction/src/transaction-receipt.ts
@@ -168,12 +168,6 @@ export class TransactionReceipt {
     if (transaction.type && common.isActivatedEIP(2718)) {
       json.type = transaction.type;
     }
-    if ("chainId" in transaction) {
-      json.chainId = transaction.chainId;
-    }
-    if ("chainId" in transaction) {
-      json.accessList = transaction.accessListJSON;
-    }
     return json;
   }
 }

--- a/src/chains/ethereum/transaction/src/transaction-types.ts
+++ b/src/chains/ethereum/transaction/src/transaction-types.ts
@@ -1,15 +1,21 @@
 import { Data, Quantity } from "@ganache/utils";
 import { Address } from "@ganache/ethereum-address";
+import { EIP1559FeeMarketTransaction } from "./eip1559-fee-market-transaction";
 import { EIP2930AccessListTransaction } from "./eip2930-access-list-transaction";
 import { LegacyTransaction } from "./legacy-transaction";
 import { EIP2930AccessListDatabaseTx } from "./raw";
 import { AccessList } from "@ethereumjs/tx";
 
-export type TypedTransaction = LegacyTransaction | EIP2930AccessListTransaction;
-export type Capability = 2718 | 2930;
+export type TypedTransaction =
+  | LegacyTransaction
+  | EIP2930AccessListTransaction
+  | EIP1559FeeMarketTransaction;
+
+export type Capability = 2718 | 2930 | 1559;
 export type TypedTransactionJSON =
   | LegacyTransactionJSON
-  | EIP2930AccessListDatabaseTx;
+  | EIP2930AccessListDatabaseTx
+  | EIP1559FeeMarketTransactionJSON;
 
 export type LegacyTransactionJSON = {
   hash: Data;
@@ -42,6 +48,27 @@ export type EIP2930AccessListTransactionJSON = {
   value: Quantity;
   gas: Quantity;
   gasPrice: Quantity;
+  input: Data;
+  accessList: AccessList;
+  v: Quantity;
+  r: Quantity;
+  s: Quantity;
+};
+
+export type EIP1559FeeMarketTransactionJSON = {
+  hash: Data;
+  type: Quantity;
+  chainId: Quantity;
+  nonce: Quantity;
+  blockHash: Data;
+  blockNumber: Quantity;
+  transactionIndex: Quantity;
+  from: Data;
+  to: Address;
+  value: Quantity;
+  maxPriorityFeePerGas: Quantity;
+  maxFeePerGas: Quantity;
+  gas: Quantity;
   input: Data;
   accessList: AccessList;
   v: Quantity;

--- a/src/chains/ethereum/transaction/src/transaction-types.ts
+++ b/src/chains/ethereum/transaction/src/transaction-types.ts
@@ -68,6 +68,7 @@ export type EIP1559FeeMarketTransactionJSON = {
   value: Quantity;
   maxPriorityFeePerGas: Quantity;
   maxFeePerGas: Quantity;
+  effectiveGasPrice: Quantity;
   gas: Quantity;
   input: Data;
   accessList: AccessList;

--- a/src/chains/ethereum/transaction/src/transaction-types.ts
+++ b/src/chains/ethereum/transaction/src/transaction-types.ts
@@ -68,7 +68,7 @@ export type EIP1559FeeMarketTransactionJSON = {
   value: Quantity;
   maxPriorityFeePerGas: Quantity;
   maxFeePerGas: Quantity;
-  effectiveGasPrice: Quantity;
+  gasPrice: Quantity;
   gas: Quantity;
   input: Data;
   accessList: AccessList;

--- a/src/chains/ethereum/transaction/src/vm-transaction.ts
+++ b/src/chains/ethereum/transaction/src/vm-transaction.ts
@@ -1,13 +1,29 @@
 import type { BN } from "ethereumjs-util";
 
-export interface VmTransaction {
-  nonce: BN;
-  gasPrice: BN;
-  gasLimit: BN;
-  to: { buf: Buffer };
-  value: BN;
-  data: Buffer;
-  getSenderAddress: () => { buf: Buffer };
-  getBaseFee: () => BN;
-  getUpfrontCost: () => BN;
-}
+export type VmTransaction =
+  | {
+      nonce: BN;
+      gasPrice?: BN;
+      gasLimit: BN;
+      maxPriorityFeePerGas?: never;
+      maxFeePerGas?: never;
+      to: { buf: Buffer };
+      value: BN;
+      data: Buffer;
+      getSenderAddress: () => { buf: Buffer };
+      getBaseFee: () => BN;
+      getUpfrontCost: () => BN;
+    }
+  | {
+      nonce: BN;
+      gasPrice?: never;
+      gasLimit: BN;
+      maxPriorityFeePerGas?: BN;
+      maxFeePerGas?: BN;
+      to: { buf: Buffer };
+      value: BN;
+      data: Buffer;
+      getSenderAddress: () => { buf: Buffer };
+      getBaseFee: () => BN;
+      getUpfrontCost: () => BN;
+    };

--- a/src/chains/ethereum/transaction/tests/index.test.ts
+++ b/src/chains/ethereum/transaction/tests/index.test.ts
@@ -544,7 +544,7 @@ describe("@ganache/ethereum-transaction", async () => {
                 rawEIP2930StringData,
                 preBerlin
               ) as any,
-            { message: "invalid remainder" }
+            { message: "Could not decode transaction: invalid remainder" }
           );
         });
 
@@ -570,7 +570,7 @@ describe("@ganache/ethereum-transaction", async () => {
           assert.throws(
             () =>
               TransactionFactory.fromString(rawEIP1559StringData, preBerlin),
-            { message: "invalid remainder" }
+            { message: "Could not decode transaction: invalid remainder" }
           );
         });
       });

--- a/src/chains/ethereum/transaction/tests/index.test.ts
+++ b/src/chains/ethereum/transaction/tests/index.test.ts
@@ -86,7 +86,7 @@ describe("@ganache/ethereum-transaction", async () => {
   };
 
   const rawEIP2930StringData =
-    "0x01f89c808082ffff80945a17650be84f28ed583e93e6ed0c99b1d1fc1b348080f838f7940efbd0bec0da8dcc0ad442a7d337e9cdc2dd6a54e1a00000000000000000000000000000000000000000000000000000000000000004820a96a0afba87c71565e226bd7b9fbab5234ce62ec479f356f98aad96f811420ea448f7a006ec0a09f508da4c12e52d3f984998e54dfa082e6b796050a73a8a01bb9dc10e";
+    "0x01f89a808082ffff80945a17650be84f28ed583e93e6ed0c99b1d1fc1b348080f838f7940efbd0bec0da8dcc0ad442a7d337e9cdc2dd6a54e1a0000000000000000000000000000000000000000000000000000000000000000480a0afba87c71565e226bd7b9fbab5234ce62ec479f356f98aad96f811420ea448f7a006ec0a09f508da4c12e52d3f984998e54dfa082e6b796050a73a8a01bb9dc10e";
   const eip2930Buf = Buffer.from(rawEIP2930StringData.slice(2), "hex");
   const rawEIP2930DBData: EIP2930AccessListDatabaseTx = [
     eip2930Buf.slice(0, 1),
@@ -110,8 +110,7 @@ describe("@ganache/ethereum-transaction", async () => {
   };
 
   const rawEIP1559StringData =
-    "0x02f89e808081ff82ffff80945a17650be84f28ed583e93e6ed0c99b1d1fc1b348080f838f7940efbd0bec0da8dcc0ad442a7d337e9cdc2dd6a54e1a00000000000000000000000000000000000000000000000000000000000000004820a96a02ccd79d8d8da2c2fa22ffaf74abfd995142745ede371d4061581aebc17a17319a0774def35a8a81b04506ed0676e0ddf391859ab86e33c8b484d945ab89ddf8a56";
-
+    "0x02f89c808081ff82ffff80945a17650be84f28ed583e93e6ed0c99b1d1fc1b348080f838f7940efbd0bec0da8dcc0ad442a7d337e9cdc2dd6a54e1a0000000000000000000000000000000000000000000000000000000000000000480a02ccd79d8d8da2c2fa22ffaf74abfd995142745ede371d4061581aebc17a17319a0774def35a8a81b04506ed0676e0ddf391859ab86e33c8b484d945ab89ddf8a56";
   const eip1559Buf = Buffer.from(rawEIP1559StringData.slice(2), "hex");
   const rawEIP1559DBData: EIP1559FeeMarketDatabaseTx = [
     eip1559Buf.slice(0, 1),
@@ -187,21 +186,21 @@ describe("@ganache/ethereum-transaction", async () => {
 
     describe("EIP1559FeeMarketTransaction type from factory", () => {
       it("generates eip1559 fee market transactions from rpc data", async () => {
-        const txFromRpc = <EIP2930AccessListTransaction>(
+        const txFromRpc = <EIP1559FeeMarketTransaction>(
           TransactionFactory.fromRpc(feeMarketTx, common)
         );
         const key = txFromRpc.accessListJSON[0].storageKeys[0];
         assert.strictEqual(txFromRpc.type.toString(), "0x2");
       });
       it("generates eip1559 fee market transactions from raw buffer data", async () => {
-        const txFromDb = <EIP2930AccessListTransaction>(
+        const txFromDb = <EIP1559FeeMarketTransaction>(
           TransactionFactory.fromDatabaseTx(rawEIP1559DBData, common)
         );
         const key = txFromDb.accessListJSON[0].storageKeys[0];
         assert.strictEqual(txFromDb.type.toString(), "0x2");
       });
       it("generates eip1559 fee market transactions from raw string", async () => {
-        const txFromString = <EIP2930AccessListTransaction>(
+        const txFromString = <EIP1559FeeMarketTransaction>(
           TransactionFactory.fromString(rawEIP1559StringData, common)
         );
         assert.strictEqual(txFromString.type.toString(), "0x2");
@@ -300,7 +299,7 @@ describe("@ganache/ethereum-transaction", async () => {
       tx.signAndHash(privKeyBuf);
       assert.strictEqual(
         tx.hash.toString(),
-        "0x9d26a8ab765ad7fe2a8c93b7b9e03054fe8161de3db6552b41e4958e38ac40e5"
+        "0x017e5ed133db246767bfa2acb0f3e3ddfc5f0511adcdbf35d9e26fc01b9c4b0b"
       );
     });
     describe("toVmTransaction", () => {
@@ -372,7 +371,7 @@ describe("@ganache/ethereum-transaction", async () => {
       tx.signAndHash(privKeyBuf);
       assert.strictEqual(
         tx.hash.toString(),
-        "0xb8f4376bff37e91788986999073f81a9997efa72eb8d3a9d6c61d7f909c16731"
+        "0xabe11ba446440bd0ea9b9e9de9eb479ae4555455ec2244a80ef7a72eddf6fe17"
       );
     });
     describe("toVmTransaction", () => {

--- a/src/chains/ethereum/transaction/tests/index.test.ts
+++ b/src/chains/ethereum/transaction/tests/index.test.ts
@@ -8,6 +8,7 @@ import {
   LegacyDatabasePayload,
   LegacyTransaction,
   TransactionFactory,
+  TransactionType,
   TypedDatabaseTransaction,
   TypedRpcTransaction
 } from "../../transaction";
@@ -492,7 +493,7 @@ describe("@ganache/ethereum-transaction", async () => {
       ];
       assert.strictEqual(
         TransactionFactory.typeOfRaw(db as TypedDatabaseTransaction),
-        LegacyTransaction
+        TransactionType.Legacy
       );
     });
 
@@ -526,24 +527,25 @@ describe("@ganache/ethereum-transaction", async () => {
           assert.strictEqual(txFromRpc.accessList, undefined);
         });
 
-        it("converts EIP2930AccessList raw database data to LegacyTransaction before berlin hardfork", () => {
+        it("does not convert EIP2930AccessList raw database data to LegacyTransaction before berlin hardfork", () => {
           const txFromDb = TransactionFactory.fromDatabaseTx(
             rawEIP2930DBData,
-            preBerlin
+            common
           ) as any;
 
-          assert.strictEqual(txFromDb.type.toString(), "0x0");
-          assert.strictEqual(txFromDb.accessList, undefined);
+          assert.strictEqual(txFromDb.type.toString(), "0x1");
+          assert.deepStrictEqual(txFromDb.accessList.length, 1);
         });
 
-        it("converts EIP2930AccessList raw string data to LegacyTransaction before berlin hardfork", () => {
-          const txFromString = TransactionFactory.fromString(
-            rawEIP2930StringData,
-            preBerlin
-          ) as any;
-
-          assert.strictEqual(txFromString.type.toString(), "0x0");
-          assert.strictEqual(txFromString.accessList, undefined);
+        it("does not convert EIP2930AccessList raw string data to LegacyTransaction before berlin hardfork", () => {
+          assert.throws(
+            () =>
+              TransactionFactory.fromString(
+                rawEIP2930StringData,
+                preBerlin
+              ) as any,
+            { message: "invalid remainder" }
+          );
         });
 
         it("converts EIP1559FeeMarket RPC data to LegacyTransaction before berlin hardfork", () => {
@@ -555,23 +557,21 @@ describe("@ganache/ethereum-transaction", async () => {
           assert.strictEqual(txFromRpc.type.toString(), "0x0");
           assert.strictEqual(txFromRpc.accessList, undefined);
         });
-        it("converts EIP1559FeeMarket raw database data to LegacyTransaction before berlin hardfork", () => {
+        it("does not convert EIP1559FeeMarket raw database data to LegacyTransaction", () => {
           const txFromDb = TransactionFactory.fromDatabaseTx(
             rawEIP1559DBData,
-            preBerlin
+            common
           ) as any;
 
-          assert.strictEqual(txFromDb.type.toString(), "0x0");
-          assert.strictEqual(txFromDb.accessList, undefined);
+          assert.strictEqual(txFromDb.type.toString(), "0x2");
+          assert.strictEqual(txFromDb.accessList.length, 1);
         });
-        it("converts EIP1559FeeMarket raw string data to LegacyTransaction before berlin hardfork", () => {
-          const txFromString = TransactionFactory.fromString(
-            rawEIP1559StringData,
-            preBerlin
-          ) as any;
-
-          assert.strictEqual(txFromString.type.toString(), "0x0");
-          assert.strictEqual(txFromString.accessList, undefined);
+        it("does not convert EIP1559FeeMarket raw string data to LegacyTransaction", () => {
+          assert.throws(
+            () =>
+              TransactionFactory.fromString(rawEIP1559StringData, preBerlin),
+            { message: "invalid remainder" }
+          );
         });
       });
 

--- a/src/chains/ethereum/transaction/tests/index.test.ts
+++ b/src/chains/ethereum/transaction/tests/index.test.ts
@@ -299,7 +299,7 @@ describe("@ganache/ethereum-transaction", async () => {
       tx.signAndHash(privKeyBuf);
       assert.strictEqual(
         tx.hash.toString(),
-        "0xf99c33b548c1ee4a4602398b67f25675f74ea37bedb9d3d69aeea65b60186a98"
+        "0x9d26a8ab765ad7fe2a8c93b7b9e03054fe8161de3db6552b41e4958e38ac40e5"
       );
     });
     describe("toVmTransaction", () => {
@@ -371,7 +371,7 @@ describe("@ganache/ethereum-transaction", async () => {
       tx.signAndHash(privKeyBuf);
       assert.strictEqual(
         tx.hash.toString(),
-        "0x01cb0d22f115f3ced3d4a3d25480b8307048458d04c7f207ae48c9d5b94b62dc"
+        "0xb8f4376bff37e91788986999073f81a9997efa72eb8d3a9d6c61d7f909c16731"
       );
     });
     describe("toVmTransaction", () => {

--- a/src/chains/ethereum/transaction/tests/index.test.ts
+++ b/src/chains/ethereum/transaction/tests/index.test.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 import {
   EIP1559FeeMarketDatabasePayload,
   EIP1559FeeMarketDatabaseTx,
+  EIP1559FeeMarketTransaction,
   EIP2930AccessListDatabasePayload,
   EIP2930AccessListDatabaseTx,
   EIP2930AccessListTransaction,
@@ -18,7 +19,6 @@ import { decode } from "@ganache/rlp";
 import { EthereumOptionsConfig } from "../../options";
 import { BUFFER_EMPTY, Quantity } from "@ganache/utils";
 import { Buffer } from "buffer";
-import { EIP1559FeeMarketTransaction } from "../typings/src/eip1559-fee-market-transaction";
 
 describe("@ganache/ethereum-transaction", async () => {
   const common = Common.forCustomChain(
@@ -123,7 +123,7 @@ describe("@ganache/ethereum-transaction", async () => {
   describe("TransactionFactory", () => {
     describe("LegacyTransaction type from factory", () => {
       let txFromRpc: LegacyTransaction;
-      it("infers legacy transaction if type ommitted", () => {
+      it("infers legacy transaction if type omitted", () => {
         txFromRpc = <LegacyTransaction>(
           TransactionFactory.fromRpc(untypedTx, common)
         );
@@ -149,7 +149,7 @@ describe("@ganache/ethereum-transaction", async () => {
         );
         assert.strictEqual(txFromString.type.toString(), "0x0");
       });
-      it("normalizes an eip-2930 transaction to legacy when access list is ommited", async () => {
+      it("normalizes an eip-2930 transaction to legacy when access list is omitted", async () => {
         const tempAccessListTx = JSON.parse(JSON.stringify(accessListTx)); // don't want to alter accessListTx
         tempAccessListTx.accessList = undefined;
         const txFromRpc = TransactionFactory.fromRpc(tempAccessListTx, common);
@@ -206,13 +206,13 @@ describe("@ganache/ethereum-transaction", async () => {
         );
         assert.strictEqual(txFromString.type.toString(), "0x2");
       });
-      it("normalizes a legacy transaction to eip-1559 when gas price is ommited", async () => {
+      it("normalizes a legacy transaction to eip-1559 when gas price is omitted", async () => {
         const tempLegacyTx = JSON.parse(JSON.stringify(typedLegacyTx)); // don't want to alter accessListTx
         tempLegacyTx.gasPrice = undefined;
         const txFromRpc = TransactionFactory.fromRpc(tempLegacyTx, common);
         assert.strictEqual(txFromRpc.type.toString(), "0x2");
       });
-      it("normalizes an eip-2930 transaction to eip-1559 when gas price is ommited", async () => {
+      it("normalizes an eip-2930 transaction to eip-1559 when gas price is omitted", async () => {
         const tempAccessListTx = JSON.parse(JSON.stringify(accessListTx)); // don't want to alter accessListTx
         tempAccessListTx.gasPrice = undefined;
         const txFromRpc = TransactionFactory.fromRpc(tempAccessListTx, common);

--- a/src/chains/ethereum/transaction/tests/index.test.ts
+++ b/src/chains/ethereum/transaction/tests/index.test.ts
@@ -45,6 +45,7 @@ describe("@ganache/ethereum-transaction", async () => {
   });
   const wallet = new Wallet(options.wallet);
   const [from, to, accessListAcc] = wallet.addresses;
+
   // #endregion configure accounts and private keys in wallet
 
   // #region configure transaction constants
@@ -299,7 +300,7 @@ describe("@ganache/ethereum-transaction", async () => {
       tx.signAndHash(privKeyBuf);
       assert.strictEqual(
         tx.hash.toString(),
-        "0x017e5ed133db246767bfa2acb0f3e3ddfc5f0511adcdbf35d9e26fc01b9c4b0b"
+        "0x078395f79508111c9061f9983d387c8b7bfed990dfa098497aa4d34b0e47b265"
       );
     });
     describe("toVmTransaction", () => {

--- a/src/chains/ethereum/transaction/tsconfig.json
+++ b/src/chains/ethereum/transaction/tsconfig.json
@@ -25,6 +25,10 @@
     {
       "name": "@ganache/ethereum-utils",
       "path": "../utils"
+    },
+    {
+      "name": "@ganache/secp256k1",
+      "path": "../../../packages/secp256k1"
     }
   ]
 }

--- a/src/packages/secp256k1/.npmignore
+++ b/src/packages/secp256k1/.npmignore
@@ -1,0 +1,8 @@
+/index.ts
+/tests
+/.nyc_output
+/coverage
+/scripts
+/src
+/tsconfig.json
+/typedoc.json

--- a/src/packages/secp256k1/LICENSE
+++ b/src/packages/secp256k1/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Iuri Matias
+Copyright (c) 2019 ConsenSys Software Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of 
+this software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights to 
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+of the Software, and to permit persons to whom the Software is furnished to do 
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.

--- a/src/packages/secp256k1/README.md
+++ b/src/packages/secp256k1/README.md
@@ -1,0 +1,3 @@
+# `@ganache/secp256k1`
+
+> TODO: description

--- a/src/packages/secp256k1/index.ts
+++ b/src/packages/secp256k1/index.ts
@@ -1,0 +1,32 @@
+/*!
+ * @ganache/secp256k1
+ *
+ * @author David Murdoch
+ * @license MIT
+ */
+
+import { dirname } from "path";
+
+let secp256k1: {
+  ecdsaRecover: (
+    output: Uint8Array,
+    signature: Uint8Array,
+    recid: number,
+    message: Uint8Array
+  ) => 0 | 1;
+  publicKeyConvert: (output: Uint8Array, senderPubKey: Uint8Array) => 0 | 1 | 2;
+  ecdsaSign: (
+    output: { signature: Uint8Array; recid: number },
+    msgHash: Uint8Array,
+    privateKey: Uint8Array
+  ) => 0 | 1;
+};
+try {
+  // load native secp256k1, if possible
+  secp256k1 = new (require("node-gyp-build")(
+    dirname(require.resolve("secp256k1/package.json"))
+  ).Secp256k1)();
+} catch (err) {
+  secp256k1 = require("secp256k1/lib/elliptic");
+}
+export default secp256k1;

--- a/src/packages/secp256k1/package-lock.json
+++ b/src/packages/secp256k1/package-lock.json
@@ -1,0 +1,2147 @@
+{
+	"name": "@ganache/secp256k1",
+	"version": "0.1.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+			"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "^7.14.5"
+			}
+		},
+		"@babel/compat-data": {
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+			"integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+			"dev": true
+		},
+		"@babel/core": {
+			"version": "7.15.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
+			"integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.14.5",
+				"@babel/generator": "^7.15.4",
+				"@babel/helper-compilation-targets": "^7.15.4",
+				"@babel/helper-module-transforms": "^7.15.4",
+				"@babel/helpers": "^7.15.4",
+				"@babel/parser": "^7.15.5",
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.1.2",
+				"semver": "^6.3.0",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+			"integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.15.4",
+				"jsesc": "^2.5.1",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+			"integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
+			"dev": true,
+			"requires": {
+				"@babel/compat-data": "^7.15.0",
+				"@babel/helper-validator-option": "^7.14.5",
+				"browserslist": "^4.16.6",
+				"semver": "^6.3.0"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+			"integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.15.4",
+				"@babel/template": "^7.15.4",
+				"@babel/types": "^7.15.4"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+			"integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.15.4"
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+			"integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.15.4"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+			"integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.15.4"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+			"integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.15.4"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
+			"integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.15.4",
+				"@babel/helper-replace-supers": "^7.15.4",
+				"@babel/helper-simple-access": "^7.15.4",
+				"@babel/helper-split-export-declaration": "^7.15.4",
+				"@babel/helper-validator-identifier": "^7.14.9",
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4"
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+			"integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.15.4"
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+			"integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.15.4",
+				"@babel/helper-optimise-call-expression": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+			"integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.15.4"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+			"integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.15.4"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.14.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+			"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+			"dev": true
+		},
+		"@babel/helper-validator-option": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+			"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+			"dev": true
+		},
+		"@babel/helpers": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+			"integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+			"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.14.5",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@babel/parser": {
+			"version": "7.15.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
+			"integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
+			"dev": true
+		},
+		"@babel/template": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+			"integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.14.5",
+				"@babel/parser": "^7.15.4",
+				"@babel/types": "^7.15.4"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+			"integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.14.5",
+				"@babel/generator": "^7.15.4",
+				"@babel/helper-function-name": "^7.15.4",
+				"@babel/helper-hoist-variables": "^7.15.4",
+				"@babel/helper-split-export-declaration": "^7.15.4",
+				"@babel/parser": "^7.15.4",
+				"@babel/types": "^7.15.4",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0"
+			}
+		},
+		"@babel/types": {
+			"version": "7.15.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+			"integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.14.9",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@istanbuljs/load-nyc-config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^5.3.1",
+				"find-up": "^4.1.0",
+				"get-package-type": "^0.1.0",
+				"js-yaml": "^3.13.1",
+				"resolve-from": "^5.0.0"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"dev": true,
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				}
+			}
+		},
+		"@istanbuljs/schema": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+			"dev": true
+		},
+		"@types/mocha": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.2.tgz",
+			"integrity": "sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==",
+			"dev": true
+		},
+		"@ungap/promise-all-settled": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+			"dev": true
+		},
+		"aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dev": true,
+			"requires": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			}
+		},
+		"ansi-colors": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^2.0.1"
+			}
+		},
+		"anymatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"dev": true,
+			"requires": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			}
+		},
+		"append-transform": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+			"integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+			"dev": true,
+			"requires": {
+				"default-require-extensions": "^3.0.0"
+			}
+		},
+		"archy": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+			"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+			"dev": true
+		},
+		"arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true
+		},
+		"argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
+		},
+		"balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
+		},
+		"binary-extensions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+			"dev": true
+		},
+		"bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"dev": true,
+			"requires": {
+				"fill-range": "^7.0.1"
+			}
+		},
+		"brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+		},
+		"browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"dev": true
+		},
+		"browserslist": {
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
+			"integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
+			"dev": true,
+			"requires": {
+				"caniuse-lite": "^1.0.30001254",
+				"colorette": "^1.3.0",
+				"electron-to-chromium": "^1.3.830",
+				"escalade": "^3.1.1",
+				"node-releases": "^1.1.75"
+			}
+		},
+		"buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true
+		},
+		"caching-transform": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+			"integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+			"dev": true,
+			"requires": {
+				"hasha": "^5.0.0",
+				"make-dir": "^3.0.0",
+				"package-hash": "^4.0.0",
+				"write-file-atomic": "^3.0.0"
+			}
+		},
+		"camelcase": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+			"dev": true
+		},
+		"caniuse-lite": {
+			"version": "1.0.30001257",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz",
+			"integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==",
+			"dev": true
+		},
+		"chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"chokidar": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+			"integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+			"dev": true,
+			"requires": {
+				"anymatch": "~3.1.1",
+				"braces": "~3.0.2",
+				"fsevents": "~2.3.1",
+				"glob-parent": "~5.1.0",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.5.0"
+			}
+		},
+		"clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true
+		},
+		"cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
+			"requires": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
+			}
+		},
+		"color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"requires": {
+				"color-name": "~1.1.4"
+			}
+		},
+		"color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"colorette": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+			"integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+			"dev": true
+		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"convert-source-map": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+			"integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
+			}
+		},
+		"create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true
+		},
+		"cross-env": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+			"integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.1"
+			}
+		},
+		"cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dev": true,
+			"requires": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			}
+		},
+		"debug": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+			"dev": true,
+			"requires": {
+				"ms": "2.1.2"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
+		},
+		"decamelize": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+			"dev": true
+		},
+		"default-require-extensions": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
+			"integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+			"dev": true,
+			"requires": {
+				"strip-bom": "^4.0.0"
+			}
+		},
+		"diff": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+			"dev": true
+		},
+		"electron-to-chromium": {
+			"version": "1.3.839",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.839.tgz",
+			"integrity": "sha512-0O7uPs9LJNjQ/U5mW78qW8gXv9H6Ba3DHZ5/yt8aBsvomOWDkV3MddT7enUYvLQEUVOURjWmgJJWVZ3K98tIwQ==",
+			"dev": true
+		},
+		"elliptic": {
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+			"requires": {
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"es6-error": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+			"dev": true
+		},
+		"escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"dev": true
+		},
+		"escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
+		},
+		"fill-range": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"dev": true,
+			"requires": {
+				"to-regex-range": "^5.0.1"
+			}
+		},
+		"find-cache-dir": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+			"dev": true,
+			"requires": {
+				"commondir": "^1.0.1",
+				"make-dir": "^3.0.2",
+				"pkg-dir": "^4.1.0"
+			}
+		},
+		"find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"requires": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			}
+		},
+		"flat": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+			"dev": true
+		},
+		"foreground-child": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+			"integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"fromentries": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+			"integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+			"dev": true
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"optional": true
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true
+		},
+		"get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true
+		},
+		"get-package-type": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+			"dev": true
+		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"requires": {
+				"is-glob": "^4.0.1"
+			}
+		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true
+		},
+		"graceful-fs": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+			"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+			"dev": true
+		},
+		"growl": {
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true
+		},
+		"hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"hasha": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+			"integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+			"dev": true,
+			"requires": {
+				"is-stream": "^2.0.0",
+				"type-fest": "^0.8.0"
+			}
+		},
+		"he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"requires": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"is-binary-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
+			"requires": {
+				"binary-extensions": "^2.0.0"
+			}
+		},
+		"is-core-module": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+			"integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3"
+			}
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
+		},
+		"is-glob": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+			"dev": true,
+			"requires": {
+				"is-extglob": "^2.1.1"
+			}
+		},
+		"is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true
+		},
+		"is-plain-obj": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"dev": true
+		},
+		"is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"istanbul-lib-coverage": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+			"integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+			"dev": true
+		},
+		"istanbul-lib-hook": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+			"integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+			"dev": true,
+			"requires": {
+				"append-transform": "^2.0.0"
+			}
+		},
+		"istanbul-lib-instrument": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+			"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.7.5",
+				"@istanbuljs/schema": "^0.1.2",
+				"istanbul-lib-coverage": "^3.0.0",
+				"semver": "^6.3.0"
+			}
+		},
+		"istanbul-lib-processinfo": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
+			"integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+			"dev": true,
+			"requires": {
+				"archy": "^1.0.0",
+				"cross-spawn": "^7.0.0",
+				"istanbul-lib-coverage": "^3.0.0-alpha.1",
+				"make-dir": "^3.0.0",
+				"p-map": "^3.0.0",
+				"rimraf": "^3.0.0",
+				"uuid": "^3.3.3"
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+			"integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+			"dev": true,
+			"requires": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^3.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+			"integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^3.0.0",
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"istanbul-reports": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+			"integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+			"dev": true,
+			"requires": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			}
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+			"integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+			"dev": true,
+			"requires": {
+				"argparse": "^2.0.1"
+			}
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
+		},
+		"json5": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.5"
+			}
+		},
+		"locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"requires": {
+				"p-locate": "^5.0.0"
+			}
+		},
+		"lodash.flattendeep": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+			"dev": true
+		},
+		"log-symbols": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+			"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.0.0"
+			}
+		},
+		"make-dir": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+			"dev": true,
+			"requires": {
+				"semver": "^6.0.0"
+			}
+		},
+		"make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true
+		},
+		"minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"dev": true
+		},
+		"mocha": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
+			"integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
+			"dev": true,
+			"requires": {
+				"@ungap/promise-all-settled": "1.1.2",
+				"ansi-colors": "4.1.1",
+				"browser-stdout": "1.3.1",
+				"chokidar": "3.5.1",
+				"debug": "4.3.1",
+				"diff": "5.0.0",
+				"escape-string-regexp": "4.0.0",
+				"find-up": "5.0.0",
+				"glob": "7.1.6",
+				"growl": "1.10.5",
+				"he": "1.2.0",
+				"js-yaml": "4.0.0",
+				"log-symbols": "4.0.0",
+				"minimatch": "3.0.4",
+				"ms": "2.1.3",
+				"nanoid": "3.1.20",
+				"serialize-javascript": "5.0.1",
+				"strip-json-comments": "3.1.1",
+				"supports-color": "8.1.1",
+				"which": "2.0.2",
+				"wide-align": "1.1.3",
+				"workerpool": "6.1.0",
+				"yargs": "16.2.0",
+				"yargs-parser": "20.2.4",
+				"yargs-unparser": "2.0.0"
+			}
+		},
+		"ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true
+		},
+		"nanoid": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+			"integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+			"dev": true
+		},
+		"node-addon-api": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+		},
+		"node-gyp-build": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+			"integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
+		},
+		"node-preload": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+			"integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+			"dev": true,
+			"requires": {
+				"process-on-spawn": "^1.0.0"
+			}
+		},
+		"node-releases": {
+			"version": "1.1.75",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+			"integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+			"dev": true
+		},
+		"normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
+		},
+		"nyc": {
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+			"integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
+			"dev": true,
+			"requires": {
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.2",
+				"caching-transform": "^4.0.0",
+				"convert-source-map": "^1.7.0",
+				"decamelize": "^1.2.0",
+				"find-cache-dir": "^3.2.0",
+				"find-up": "^4.1.0",
+				"foreground-child": "^2.0.0",
+				"get-package-type": "^0.1.0",
+				"glob": "^7.1.6",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-hook": "^3.0.0",
+				"istanbul-lib-instrument": "^4.0.0",
+				"istanbul-lib-processinfo": "^2.0.2",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^4.0.0",
+				"istanbul-reports": "^3.0.2",
+				"make-dir": "^3.0.0",
+				"node-preload": "^0.2.1",
+				"p-map": "^3.0.0",
+				"process-on-spawn": "^1.0.0",
+				"resolve-from": "^5.0.0",
+				"rimraf": "^3.0.0",
+				"signal-exit": "^3.0.2",
+				"spawn-wrap": "^2.0.0",
+				"test-exclude": "^6.0.0",
+				"yargs": "^15.0.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
+					}
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+					"dev": true
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"string-width": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"y18n": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+					"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+					"dev": true,
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"requires": {
+				"yocto-queue": "^0.1.0"
+			}
+		},
+		"p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"requires": {
+				"p-limit": "^3.0.2"
+			}
+		},
+		"p-map": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+			"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+			"dev": true,
+			"requires": {
+				"aggregate-error": "^3.0.0"
+			}
+		},
+		"p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true
+		},
+		"package-hash": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+			"integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.15",
+				"hasha": "^5.0.0",
+				"lodash.flattendeep": "^4.4.0",
+				"release-zalgo": "^1.0.0"
+			}
+		},
+		"path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true
+		},
+		"picomatch": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+			"dev": true
+		},
+		"pkg-dir": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
+			"requires": {
+				"find-up": "^4.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				}
+			}
+		},
+		"process-on-spawn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+			"integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+			"dev": true,
+			"requires": {
+				"fromentries": "^1.2.0"
+			}
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"readdirp": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+			"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+			"dev": true,
+			"requires": {
+				"picomatch": "^2.2.1"
+			}
+		},
+		"release-zalgo": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+			"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+			"dev": true,
+			"requires": {
+				"es6-error": "^4.0.1"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
+		},
+		"require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+			"dev": true
+		},
+		"resolve": {
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"dev": true,
+			"requires": {
+				"is-core-module": "^2.2.0",
+				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true
+		},
+		"rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true
+		},
+		"secp256k1": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+			"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+			"requires": {
+				"elliptic": "^6.5.2",
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
+			}
+		},
+		"semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true
+		},
+		"serialize-javascript": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+			"integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.1.0"
+			}
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
+		},
+		"shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "^3.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true
+		},
+		"signal-exit": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+			"dev": true
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
+		},
+		"source-map-support": {
+			"version": "0.5.20",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
+			"integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"spawn-wrap": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+			"integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+			"dev": true,
+			"requires": {
+				"foreground-child": "^2.0.0",
+				"is-windows": "^1.0.2",
+				"make-dir": "^3.0.0",
+				"rimraf": "^3.0.0",
+				"signal-exit": "^3.0.2",
+				"which": "^2.0.1"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			}
+		},
+		"strip-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^3.0.0"
+			}
+		},
+		"strip-bom": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+			"dev": true
+		},
+		"strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^4.0.0"
+			}
+		},
+		"test-exclude": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+			"dev": true,
+			"requires": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^7.1.4",
+				"minimatch": "^3.0.4"
+			}
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true
+		},
+		"to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
+			"requires": {
+				"is-number": "^7.0.0"
+			}
+		},
+		"ts-node": {
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+			"integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+			"dev": true,
+			"requires": {
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"source-map-support": "^0.5.17",
+				"yn": "3.1.1"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+					"dev": true
+				}
+			}
+		},
+		"ttypescript": {
+			"version": "1.5.12",
+			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
+			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
+			"dev": true,
+			"requires": {
+				"resolve": ">=1.9.0"
+			}
+		},
+		"type-fest": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"dev": true
+		},
+		"typedarray-to-buffer": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"dev": true,
+			"requires": {
+				"is-typedarray": "^1.0.0"
+			}
+		},
+		"typescript": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+			"dev": true
+		},
+		"uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"dev": true
+		},
+		"which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
+		},
+		"wide-align": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.2 || 2"
+			}
+		},
+		"workerpool": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+			"integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+			"dev": true
+		},
+		"wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"write-file-atomic": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+			"dev": true,
+			"requires": {
+				"imurmurhash": "^0.1.4",
+				"is-typedarray": "^1.0.0",
+				"signal-exit": "^3.0.2",
+				"typedarray-to-buffer": "^3.1.5"
+			}
+		},
+		"y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true
+		},
+		"yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
+			"requires": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
+			}
+		},
+		"yargs-parser": {
+			"version": "20.2.4",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+			"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+			"dev": true
+		},
+		"yargs-unparser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^6.0.0",
+				"decamelize": "^4.0.0",
+				"flat": "^5.0.2",
+				"is-plain-obj": "^2.1.0"
+			}
+		},
+		"yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true
+		}
+	}
+}

--- a/src/packages/secp256k1/package.json
+++ b/src/packages/secp256k1/package.json
@@ -1,19 +1,16 @@
 {
-  "name": "@ganache/ethereum-transaction",
-  "publishConfig": {
-    "access": "public"
-  },
-  "version": "0.1.1-alpha.0",
+  "name": "@ganache/secp256k1",
+  "version": "0.1.0",
   "description": "",
   "author": "David Murdoch",
-  "homepage": "https://github.com/trufflesuite/ganache/tree/develop/src/chains/ethereum/transaction#readme",
+  "homepage": "https://github.com/trufflesuite/ganache/tree/develop/src/packages/secp256k1#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "typings": "typings",
   "source": "index.ts",
   "directories": {
     "lib": "lib",
-    "test": "test"
+    "test": "tests"
   },
   "files": [
     "lib",
@@ -22,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/ganache.git",
-    "directory": "src/chains/ethereum/transaction"
+    "directory": "src/packages/secp256k1"
   },
   "scripts": {
     "tsc": "ttsc --build",
@@ -34,7 +31,7 @@
   },
   "keywords": [
     "ganache",
-    "ganache-ethereum-transaction",
+    "ganache-secp256k1",
     "ethereum",
     "evm",
     "blockchain",
@@ -47,24 +44,17 @@
     "tooling",
     "truffle"
   ],
-  "dependencies": {
-    "@ethereumjs/common": "2.4.0",
-    "@ganache/ethereum-address": "0.1.1-alpha.0",
-    "@ganache/ethereum-utils": "0.1.1-alpha.0",
-    "@ganache/rlp": "0.1.1-alpha.0",
-    "@ganache/secp256k1": "0.1.0",
-    "@ganache/utils": "0.1.1-alpha.0",
-    "ethereumjs-util": "7.1.0",
-    "node-gyp-build": "4.2.3"
-  },
   "devDependencies": {
-    "@ethereumjs/vm": "5.5.0",
     "@types/mocha": "8.2.2",
-    "cross-env": "7.0.3",
+    "cross-env": "7.0.2",
     "mocha": "8.4.0",
     "nyc": "15.1.0",
     "ts-node": "9.1.1",
     "ttypescript": "1.5.12",
     "typescript": "4.1.3"
+  },
+  "dependencies": {
+    "node-gyp-build": "4.3.0",
+    "secp256k1": "4.0.2"
   }
 }

--- a/src/packages/secp256k1/tests/index.test.ts
+++ b/src/packages/secp256k1/tests/index.test.ts
@@ -1,0 +1,6 @@
+import assert from "assert";
+import secp256K1 from "../";
+
+describe("@ganache/secp256k1", () => {
+  it("needs tests");
+});

--- a/src/packages/secp256k1/tsconfig.json
+++ b/src/packages/secp256k1/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig-base.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "declarationDir": "typings",
+    "composite": true
+  },
+  "include": [
+    "src",
+    "index.ts"
+  ]
+}

--- a/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
@@ -31,11 +31,22 @@ export class Quantity extends BaseJsonRpcType {
       return super.toString();
     }
   }
-  public toBuffer(byteLength: number | null = null): Buffer {
+  public toBuffer(_test?: any): Buffer {
+    if (_test !== undefined)
+      throw new Error(
+        "byte length was used, dummy! you probably shouldn't have removed it"
+      );
     // 0x0, 0x00, 0x000, etc should return BUFFER_EMPTY
     if (Buffer.isBuffer(this.value)) {
-      return this.value;
-    } else if (typeof this.value === "string" && byteLength == null) {
+      // trim zeros from start
+      let best = 0;
+      for (best = 0; best < this.value.length; best++) {
+        if (this.value[best] !== 0) break;
+      }
+      if (best > 0) {
+        return this.value.slice(best);
+      }
+    } else if (typeof this.value === "string") {
       let val = this.value.slice(2).replace(/^(?:0+(.+?))?$/, "$1");
       if (val === "" || val === "0") {
         return BUFFER_EMPTY;

--- a/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
@@ -31,11 +31,7 @@ export class Quantity extends BaseJsonRpcType {
       return super.toString();
     }
   }
-  public toBuffer(_test?: any): Buffer {
-    if (_test !== undefined)
-      throw new Error(
-        "byte length was used, dummy! you probably shouldn't have removed it"
-      );
+  public toBuffer(): Buffer {
     // 0x0, 0x00, 0x000, etc should return BUFFER_EMPTY
     if (Buffer.isBuffer(this.value)) {
       // trim zeros from start

--- a/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
@@ -41,6 +41,8 @@ export class Quantity extends BaseJsonRpcType {
       }
       if (best > 0) {
         return this.value.slice(best);
+      } else {
+        return this.value;
       }
     } else if (typeof this.value === "string") {
       let val = this.value.slice(2).replace(/^(?:0+(.+?))?$/, "$1");

--- a/src/packages/utils/src/utils/constants.ts
+++ b/src/packages/utils/src/utils/constants.ts
@@ -1,3 +1,4 @@
+import { Data } from "../things/json-rpc/json-rpc-data";
 import { Quantity } from "../things/json-rpc/json-rpc-quantity";
 
 export const BUFFER_256_ZERO = Buffer.allocUnsafe(256).fill(0);
@@ -7,6 +8,7 @@ export const BUFFER_ZERO = BUFFER_256_ZERO.slice(0, 1);
 export const BUFFER_32_ZERO = BUFFER_256_ZERO.slice(0, 32);
 export const BUFFER_8_ZERO = BUFFER_256_ZERO.slice(0, 8);
 
+export const DATA_EMPTY = Data.from(BUFFER_EMPTY);
 export const RPCQUANTITY_EMPTY = Quantity.from(BUFFER_EMPTY, true);
 export const RPCQUANTITY_ZERO = Quantity.from(BUFFER_ZERO);
 export const RPCQUANTITY_ONE = Quantity.from(1n);

--- a/src/packages/utils/src/utils/heap.ts
+++ b/src/packages/utils/src/utils/heap.ts
@@ -1,9 +1,10 @@
 type Comparator<T> = (values: T[], a: number, b: number) => boolean;
 
-export class Heap<T> {
+export class Heap<T, U = any> {
   public length: number = 0;
   public array: T[] = [];
-  protected readonly less: Comparator<T>;
+  protected less: Comparator<T>;
+  protected refresher: (item: T, context: U) => void;
 
   /**
    * Creates a priority-queue heap where the highest priority element,
@@ -13,14 +14,27 @@ export class Heap<T> {
    * @param size the size of the heap
    * @param less the comparator function
    */
-  constructor(less: Comparator<T>) {
+  constructor(less: Comparator<T>, refresher?: (item: T, context: U) => void) {
     this.less = less;
+    this.refresher = refresher;
   }
 
   public init(array: T[]) {
     this.array = array;
     const length = (this.length = array.length);
     for (let i = ((length / 2) | 0) - 1; i >= 0; ) {
+      this.down(i--, length);
+    }
+  }
+
+  public refresh(context: U) {
+    const length = this.length;
+    const mid = (length / 2) | 0;
+    for (let i = mid; i < length; i++) {
+      this.refresher(this.array[i], context);
+    }
+    for (let i = mid - 1; i >= 0; ) {
+      this.refresher(this.array[i], context);
       this.down(i--, length);
     }
   }
@@ -201,8 +215,12 @@ export class Heap<T> {
    * @param item
    * @param less
    */
-  public static from<T>(item: T, less: Comparator<T>) {
-    const heap = new Heap<T>(less);
+  public static from<T, U>(
+    item: T,
+    less: Comparator<T>,
+    refresher?: (item: T, context: U) => void
+  ) {
+    const heap = new Heap<T, U>(less, refresher);
     heap.array = [item];
     heap.length = 1;
     return heap;

--- a/src/packages/utils/src/utils/heap.ts
+++ b/src/packages/utils/src/utils/heap.ts
@@ -32,6 +32,11 @@ export class Heap<T, U = any> {
    * item in the heap and then re-sorting.
    * @param context
    */
+  /**
+   * Updates all entries by calling the Heap's `refresher` function for each
+   * item in the heap and then re-sorting.
+   * @param context
+   */
   public refresh(context: U) {
     const length = this.length;
     const mid = (length / 2) | 0;

--- a/src/packages/utils/src/utils/heap.ts
+++ b/src/packages/utils/src/utils/heap.ts
@@ -11,8 +11,8 @@ export class Heap<T, U = any> {
    * as determined by the `less` function, is at the tip/root of the heap.
    * To read the highest priority element without removing it call peek(). To
    * read and remove the element call `shift()`
-   * @param size the size of the heap
    * @param less the comparator function
+   * @param refresher the refresher function
    */
   constructor(less: Comparator<T>, refresher?: (item: T, context: U) => void) {
     this.less = less;
@@ -27,6 +27,11 @@ export class Heap<T, U = any> {
     }
   }
 
+  /**
+   * Updates all entries by calling the Heap's `refresher` function for each
+   * item in the heap and then re-sorting.
+   * @param context
+   */
   public refresh(context: U) {
     const length = this.length;
     const mid = (length / 2) | 0;
@@ -214,6 +219,7 @@ export class Heap<T, U = any> {
    * heap.
    * @param item
    * @param less
+   * @param refresher
    */
   public static from<T, U>(
     item: T,


### PR DESCRIPTION
- Addition of EIP-1559 transactions.
- Added `baseFeePerGas` to a `block`
- When London is activated, use `baseFeePerGas` as the block's `gasPrice`
- When London is activated, re-prioritize the txPool based off of the transaction's new `effectiveGasPrice`
- Write tests for miner and txPool reordering
- Fix some instamine behavior
  - Added a `DESIGN-DECISIONS.md` to explain the change
 - Set london as the default hard fork
 - Fixed bug in how typed transactions are signed (no longer including the tx type)
