### PR TITLE
drop support for ubuntu 16.04

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
         # monorepo we want to use 10.7.0 (earliest version the Ethereum side
         # supports) or 10.13.0 (first node 10 LTS version).
         node: [10.18.0, 10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x]
-        os: [windows-2019, ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-11.0]
+        os: [windows-2019, ubuntu-18.04, ubuntu-20.04, macos-11.0]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,7 +40,7 @@ jobs:
         # monorepo we want to use 10.7.0 (earliest version the Ethereum side
         # supports) or 10.13.0 (first node 10 LTS version).
         node: [10.18.0, 10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x]
-        os: [windows-2019, ubuntu-16.04, ubuntu-18.04]
+        os: [windows-2019, ubuntu-18.04, ubuntu-20.04]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
GitHub Actions is disabling Ubuntu 16.04 on September 20th. I'm removing it from our test matrices ahead of that change.