### PR TITLE
Update community link in README.md

### DIFF
--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -194,8 +194,7 @@ New RPC documentation coming soon! See https://github.com/trufflesuite/ganache/t
 
 ## Community
 
-- [Discord](https://trfl.co/truffle-community)
-- [Reddit](https://www.reddit.com/r/Truffle/)
+- [Truffle community page](https://www.trufflesuite.com/community)
 
 ## Contributing
 


### PR DESCRIPTION
The Discord link was broken and Reddit doesn't seem to be very
active. Also it's not mentioned on the Truffle community page. So I
thought it best to just point to the Truffle community page.