### PR TITLE
fix: handle initialization errors on server.listen, handle fallback rejections

### DIFF
--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -395,9 +395,12 @@ export default class Blockchain extends Emittery.Typed<
         this.once("stop").then(() => miner.clearListeners());
       }
     } catch (e) {
-      // we failed to start up. bail! :-(
+      // we failed to start up :-( bail!
       this.#state = Status.stopping;
-      this.stop();
+      // ignore errors while stopping here, since we are already in an
+      // exceptional case
+      await this.stop().catch(_ => {});
+
       throw e;
     }
 

--- a/src/chains/ethereum/ethereum/src/forking/fork.ts
+++ b/src/chains/ethereum/ethereum/src/forking/fork.ts
@@ -91,7 +91,7 @@ export class Fork {
             // TODO: remove support for legacy providers
             // legacy `.send`
             console.warn(
-              "WARNING: Ganache forking only supports EIP-1193-compliant providers. Legacy support for send is currently enabled, but will be removed in a future version _without_ a breaking change. To remove this warning, switch to an EIP-1193 provider. This error is probably caused by an old version of Web3's HttpProvider (or an ganache < v7)"
+              "WARNING: Ganache forking only supports EIP-1193-compliant providers. Legacy support for send is currently enabled, but will be removed in a future version _without_ a breaking change. To remove this warning, switch to an EIP-1193 provider. This error is probably caused by an old version of Web3's HttpProvider (or ganache < v7)"
             );
             return new Promise<T>((resolve, reject) => {
               (forkingOptions.provider as any).send(

--- a/src/chains/ethereum/ethereum/src/forking/handlers/http-handler.ts
+++ b/src/chains/ethereum/ethereum/src/forking/handlers/http-handler.ts
@@ -1,6 +1,6 @@
 import { EthereumInternalOptions } from "@ganache/ethereum-options";
 import { JsonRpcResponse, JsonRpcError } from "@ganache/utils";
-import { AbortError } from "@ganache/ethereum-utils";
+import { AbortError, CodedError } from "@ganache/ethereum-utils";
 // TODO: support http2
 import http, { RequestOptions, Agent as HttpAgent } from "http";
 import https, { Agent as HttpsAgent } from "https";
@@ -172,7 +172,7 @@ export class HttpHandler extends BaseHandler implements Handler {
       if ("result" in result) {
         return result.result;
       } else if ("error" in result) {
-        throw result.error;
+        throw new CodedError(result.error.message, result.error.code);
       }
     });
     this.requestCache.set(data, promise);

--- a/src/packages/core/index.ts
+++ b/src/packages/core/index.ts
@@ -44,8 +44,8 @@ const Ganache = {
   provider: <T extends FlavorName = typeof DefaultFlavor>(
     options?: ProviderOptions<T>
   ): ConnectorsByName[T]["provider"] => {
-    const connector = ConnectorLoader.initialize<T>(options);
-    return connector.provider;
+    const loader = ConnectorLoader.initialize<T>(options);
+    return loader.connector.provider;
   }
 };
 

--- a/src/packages/core/src/connector-loader.ts
+++ b/src/packages/core/src/connector-loader.ts
@@ -36,14 +36,16 @@ const initialize = <T extends FlavorName = typeof DefaultFlavor>(
   // connector.connect interface
   const connectPromise = connector.connect
     ? connector.connect()
-    : (connector as any).initialize();
+    : ((connector as any).initialize() as Promise<void>);
 
   // The request coordinator is initialized in a "paused" state; when the
   // provider is ready we unpause.. This lets us accept queue requests before
   // we've even fully initialized.
-  connectPromise.then(requestCoordinator.resume);
 
-  return connector;
+  return {
+    connector,
+    promise: connectPromise.then(requestCoordinator.resume)
+  };
 };
 
 /**

--- a/src/packages/core/tests/server.test.ts
+++ b/src/packages/core/tests/server.test.ts
@@ -71,6 +71,16 @@ describe("server", () => {
       return response;
     }
 
+    it("handles connector initialization errors by rejecting on .listen", async () => {
+      // This Ganache.server({...}) here will cause an internal error in the
+      // Ethereum provider initialization. We don't want to throw an unhandled
+      // promise reject; so we handle it in the `listen` method.
+      const s = Ganache.server({
+        fork: { url: "https://mainnet.infura.io/v3/INVALID_URL" }
+      });
+      await assert.rejects(s.listen(port));
+    });
+
     it("returns its status", async () => {
       const s = Ganache.server();
       try {


### PR DESCRIPTION
fixes https://github.com/trufflesuite/ganache/issues/938

This is a all weird because I want users to be able to do const provider = Ganache.provider()... notice there is no await here! :eyes:  Ganache.provider does approx 3,452,345 async things on start up though, and if any of these promises reject no one is there to listen to that rejection; so node complains (but doesn't crash in Node v10-14).

Unfortunately, this PR does not fix this problem for Ganache.provider(), but does fix it for Ganache.server() by having the server.listen function, which is async, handle promise rejections "eventually".

In order to get the provider to handle these errors we'd have to hook into the first async method the user calls after we have finished (failing) initialization... which would probably be something like await provider.request({method:"eth_accounts", params: []})... which is a weird place to throw an initialization error :confused:.