### PR TITLE
Feat/add eth sign typed data v4

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -1858,7 +1858,7 @@ export default class EthereumApi implements Api {
    * ```
    */
   @assertArgLength(2)
-  async eth_signTypedData(address: DATA, typedData: TypedData | string) {
+  async eth_signTypedData(address: DATA, typedData: TypedData) {
     return this.eth_signTypedData_v4(address, typedData);
   }
 
@@ -1918,16 +1918,16 @@ export default class EthereumApi implements Api {
    * ```
    */
   @assertArgLength(2)
-  async eth_signTypedData_v4(address: DATA, typedData: TypedData | string) {
+  async eth_signTypedData_v4(address: DATA, typedData: TypedData) {
     const account = Address.from(address).toString().toLowerCase();
 
     const privateKey = this.#wallet.unlockedAccounts.get(account);
     if (privateKey == null) {
       throw new Error("cannot sign data; no private key");
     }
-    // TODO
+
     if (typeof typedData === "string") {
-      typedData = JSON.parse(typedData) as TypedData;
+      throw new Error("cannot sign data; string sent, expected object");
     }
 
     if (!typedData.types) {

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -1802,6 +1802,7 @@ export default class EthereumApi implements Api {
   }
 
   /**
+   * Identical to eth_signTypedData_v4.
    *
    * @param address Address of the account that will sign the messages.
    * @param typedData Typed structured data to be signed.
@@ -1857,12 +1858,76 @@ export default class EthereumApi implements Api {
    * ```
    */
   @assertArgLength(2)
-  async eth_signTypedData(address: DATA, typedData: TypedData) {
+  async eth_signTypedData(address: DATA, typedData: TypedData | string) {
+    return this.eth_signTypedData_v4(address, typedData);
+  }
+
+  /**
+   *
+   * @param address Address of the account that will sign the messages.
+   * @param typedData Typed structured data to be signed.
+   * @returns Signature. As in `eth_sign`, it is a hex encoded 129 byte array
+   * starting with `0x`. It encodes the `r`, `s`, and `v` parameters from
+   * appendix F of the [yellow paper](https://ethereum.github.io/yellowpaper/paper.pdf)
+   *  in big-endian format. Bytes 0...64 contain the `r` parameter, bytes
+   * 64...128 the `s` parameter, and the last byte the `v` parameter. Note
+   * that the `v` parameter includes the chain id as specified in [EIP-155](https://eips.ethereum.org/EIPS/eip-155).
+   * @EIP [712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md)
+   * @example
+   * ```javascript
+   * const [account] = await provider.request({ method: "eth_accounts", params: [] });
+   * const typedData = {
+   *  types: {
+   *    EIP712Domain: [
+   *      { name: 'name', type: 'string' },
+   *      { name: 'version', type: 'string' },
+   *      { name: 'chainId', type: 'uint256' },
+   *      { name: 'verifyingContract', type: 'address' },
+   *    ],
+   *    Person: [
+   *      { name: 'name', type: 'string' },
+   *      { name: 'wallet', type: 'address' }
+   *    ],
+   *    Mail: [
+   *      { name: 'from', type: 'Person' },
+   *      { name: 'to', type: 'Person' },
+   *      { name: 'contents', type: 'string' }
+   *    ],
+   *  },
+   *  primaryType: 'Mail',
+   *  domain: {
+   *    name: 'Ether Mail',
+   *    version: '1',
+   *    chainId: 1,
+   *    verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+   *  },
+   *  message: {
+   *    from: {
+   *      name: 'Cow',
+   *      wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+   *    },
+   *    to: {
+   *      name: 'Bob',
+   *      wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+   *    },
+   *    contents: 'Hello, Bob!',
+   *  },
+   * };
+   * const signature = await provider.request({ method: "eth_signTypedData_v4", params: [account, typedData] });
+   * console.log(signature);
+   * ```
+   */
+  @assertArgLength(2)
+  async eth_signTypedData_v4(address: DATA, typedData: TypedData | string) {
     const account = Address.from(address).toString().toLowerCase();
 
     const privateKey = this.#wallet.unlockedAccounts.get(account);
     if (privateKey == null) {
       throw new Error("cannot sign data; no private key");
+    }
+    // TODO
+    if (typeof typedData === "string") {
+      typedData = JSON.parse(typedData) as TypedData;
     }
 
     if (!typedData.types) {


### PR DESCRIPTION
Add `eth_signTypedData_v4` to the api. The existing `eth_signTypedData` already used the `signTypedData_v4` functionality, this just gives it another alias to be called by.

Also, both `eth_signTypedData` and `eth_signTypedData_v4` error if a string is sent rather than an object.