### PR TITLE
Fix/same nonce replacement txs

### DIFF
--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -130,9 +130,6 @@ export default class TransactionPool extends Emittery.Typed<{}, "drain"> {
     let txNonce: bigint;
     if (!transaction.nonce.isNull()) {
       txNonce = transaction.nonce.toBigInt();
-      if (txNonce < 0n) {
-        throw new CodedError(NONCE_TOO_LOW, JsonRpcErrorCode.INVALID_INPUT);
-      }
     }
 
     const origin = from.toString();

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -364,49 +364,6 @@ export default class TransactionPool extends Emittery.Typed<{}, "drain"> {
     }
   }
 
-  public getReplacerFunction(heap, index, option, transactionPlacement) {
-    return transaction => {
-      return this.replacerFunction(
-        heap,
-        option,
-        index,
-        transaction,
-        transactionPlacement
-      );
-    };
-  }
-
-  public replacerFunction(
-    heap,
-    option,
-    index,
-    transaction,
-    transactionPlacement
-  ) {
-    heap[index] = transaction;
-    transactionPlacement = option;
-  }
-
-  public loopTxs(
-    txHeapToLoop: Heap<TypedTransaction, any>,
-    fnsToCall: ((
-      tx: TypedTransaction,
-      nonce: bigint,
-      index: number
-    ) => boolean | void)[]
-  ) {
-    const length = txHeapToLoop.length;
-    const txsToLoop = txHeapToLoop.array;
-    for (let i = 0; i < length; i++) {
-      const currentTx = txsToLoop[i];
-      const thisNonce = currentTx.nonce.toBigInt();
-      for (let j = 0, l = fnsToCall.length; j < l; j++) {
-        // if a function returns false we can exit early without continuing to loop
-        if (!fnsToCall[j](currentTx, thisNonce, i)) return;
-      }
-    }
-  }
-
   public clear() {
     this.#origins.clear();
     this.#accountPromises.clear();

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -172,12 +172,14 @@ export default class TransactionPool extends Emittery.Typed<{}, "drain"> {
 
     const priceBump = this.#priceBump;
     const newGasPrice = transaction.effectiveGasPrice.toBigInt();
-
-    if (executableOriginTransactions) {
+    let length: number;
+    if (
+      executableOriginTransactions &&
+      (length = executableOriginTransactions.length)
+    ) {
       // check if a transaction with the same nonce is in the origin's
       // executables queue already. Replace the matching transaction or throw this
       // new transaction away as necessary.
-      const length = executableOriginTransactions.length;
       const pendingArray = executableOriginTransactions.array;
       // Notice: we're iterating over the raw heap array, which isn't
       // necessarily sorted
@@ -251,12 +253,13 @@ export default class TransactionPool extends Emittery.Typed<{}, "drain"> {
     if (
       queuedOriginTransactions &&
       transactionPlacement !== TriageOption.Executable &&
-      transactionPlacement !== TriageOption.ReplacesPendingExecutable
+      transactionPlacement !== TriageOption.ReplacesPendingExecutable &&
+      (length = queuedOriginTransactions.length)
     ) {
       // check if a transaction with the same nonce is in the origin's
       // future queue already. Replace the matching transaction or throw this
       // new transaction away as necessary.
-      const length = queuedOriginTransactions.length;
+
       const queuedArray = queuedOriginTransactions.array;
       // Notice: we're iterating over the raw heap array, which isn't
       // necessarily sorted

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -92,17 +92,19 @@ export default class TransactionPool extends Emittery.Typed<{}, "drain"> {
   #blockchain: Blockchain;
   constructor(
     options: EthereumInternalOptions["miner"],
-    blockchain: Blockchain
+    blockchain: Blockchain,
+    origins: Map<string, Heap<TypedTransaction>> = new Map()
   ) {
     super();
     this.#blockchain = blockchain;
     this.#options = options;
+    this.#origins = origins;
   }
   public readonly executables: Executables = {
     inProgress: new Set(),
     pending: new Map()
   };
-  readonly #origins: Map<string, Heap<TypedTransaction>> = new Map();
+  readonly #origins: Map<string, Heap<TypedTransaction>>;
   readonly #accountPromises = new Map<string, Promise<Quantity>>();
 
   /**

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -226,7 +226,7 @@ export default class TransactionPool extends Emittery.Typed<{}, "drain"> {
     }
 
     if (transactionIsAlreadyQueued) {
-      return false;
+      return true;
     } else if (isExecutableTransaction) {
       // if it is executable add it to the executables queue
       if (executableOriginTransactions) {

--- a/src/chains/ethereum/ethereum/tests/api/evm/snapshot.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/evm/snapshot.test.ts
@@ -437,7 +437,7 @@ describe("api", () => {
             { from, to, value: value++, nonce: accountNonce + 3 }
           ]),
           send("eth_sendTransaction", [
-            { from, to, value: value++, nonce: accountNonce + 3 }
+            { from, to, value: value++, nonce: accountNonce + 4 }
           ])
         ];
 

--- a/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
+++ b/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
@@ -97,7 +97,7 @@ describe("transaction pool", async () => {
         code: -32000,
         message: "exceeds block gas limit"
       },
-      "test"
+      "transaction with gas limit higher than block gas limit should have been rejected"
     );
   });
   it("rejects transactions whose gasLimit is not enough to run the transaction", async () => {
@@ -116,7 +116,7 @@ describe("transaction pool", async () => {
         code: -32000,
         message: "intrinsic gas too low"
       },
-      "test"
+      "transaction with gas limit that is too low to run the transaction should have been rejected"
     );
   });
 
@@ -138,7 +138,7 @@ describe("transaction pool", async () => {
       {
         message: `the tx doesn't have the correct nonce. account has nonce of: 1 tx has nonce of: ${executableTx.nonce.toBigInt()}`
       },
-      "test"
+      "transaction with nonce lower than account nonce should have been rejected"
     );
   });
 
@@ -164,7 +164,7 @@ describe("transaction pool", async () => {
         code: -32003,
         message: "transaction underpriced"
       },
-      "test"
+      "replacement transaction with insufficient gas price to replace should have been rejected"
     );
   });
 
@@ -190,7 +190,7 @@ describe("transaction pool", async () => {
         code: -32003,
         message: "transaction underpriced"
       },
-      "test"
+      "replacement transaction with insufficient gas price to replace should have been rejected"
     );
   });
 

--- a/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
+++ b/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
@@ -1,0 +1,430 @@
+import assert from "assert";
+import Common from "@ethereumjs/common";
+import {
+  TransactionFactory,
+  TypedRpcTransaction,
+  TypedTransaction
+} from "@ganache/ethereum-transaction";
+import { EthereumOptionsConfig } from "@ganache/ethereum-options";
+import { Data, Heap, Quantity } from "@ganache/utils";
+import Wallet from "../src/wallet";
+import TransactionPool from "../src/transaction-pool";
+
+function findIn(
+  transactionHash: Buffer,
+  list: Map<string, Heap<TypedTransaction, any>>
+) {
+  for (let [_, transactions] of list) {
+    if (transactions === undefined) continue;
+    const arr = transactions.array;
+    for (let i = 0; i < transactions.length; i++) {
+      const tx = arr[i];
+      if (tx.hash.toBuffer().equals(transactionHash)) {
+        return tx;
+      }
+    }
+  }
+}
+
+describe("transaction pool", async () => {
+  let rpcTx: TypedRpcTransaction;
+  let from: string;
+  let secretKey: Data;
+  let common: Common;
+  let blockchain: any;
+  let origins: Map<string, Heap<TypedTransaction>>;
+  const optionsJson = { wallet: { deterministic: true } };
+  const options = EthereumOptionsConfig.normalize(optionsJson);
+  let futureNonceRpc, executableRpc: TypedRpcTransaction;
+  before(function () {
+    const wallet = new Wallet(options.wallet);
+    [from] = wallet.addresses;
+    secretKey = wallet.unlockedAccounts.get(from);
+    rpcTx = {
+      from: from,
+      type: "0x2",
+      maxFeePerGas: "0xffffffff",
+      gasLimit: "0xffff"
+    };
+    executableRpc = {
+      from: from,
+      type: "0x2",
+      maxFeePerGas: "0xffffffff",
+      gasLimit: "0xffff",
+      nonce: "0x0"
+    };
+    futureNonceRpc = {
+      from: from,
+      type: "0x2",
+      maxFeePerGas: "0xffffff",
+      gasLimit: "0xffff",
+      nonce: "0x2"
+    };
+    // we're spoofing a minimial fake blockchain for the tx pool that just
+    // returns an account's nonce
+    blockchain = {
+      accounts: {
+        getNonce: async () => {
+          return Quantity.from("0x0");
+        }
+      }
+    };
+    common = Common.forCustomChain(
+      "mainnet",
+      {
+        name: "ganache",
+        chainId: 1337,
+        comment: "Local test network",
+        bootstrapNodes: []
+      },
+      "london"
+    );
+  });
+  beforeEach(async function () {
+    // for each test, we'll need a fresh set of origins
+    origins = new Map();
+  });
+
+  it("rejects transactions whose gasLimit is greater than the block gas limit", async () => {
+    // for this tx pool, we'll have the block gas limit low
+    const optionsJson = { miner: { blockGasLimit: "0xff" } };
+    const options = EthereumOptionsConfig.normalize(optionsJson);
+    const txPool = new TransactionPool(options.miner, blockchain, origins);
+    const executableTx = TransactionFactory.fromRpc(executableRpc, common);
+    assert.rejects(
+      txPool.prepareTransaction(executableTx, secretKey),
+      {
+        code: -32000,
+        message: "exceeds block gas limit"
+      },
+      "test"
+    );
+  });
+  it("rejects transactions whose gasLimit is not enough to run the transaction", async () => {
+    const txPool = new TransactionPool(options.miner, blockchain);
+    // the tx should have a very low gas limit to be rejected
+    const lowGasRpc: TypedRpcTransaction = {
+      from: from,
+      type: "0x2",
+      maxFeePerGas: "0xffffffff",
+      gasLimit: "0xff"
+    };
+    const lowGasTx = TransactionFactory.fromRpc(lowGasRpc, common);
+    assert.rejects(
+      txPool.prepareTransaction(lowGasTx, secretKey),
+      {
+        code: -32000,
+        message: "intrinsic gas too low"
+      },
+      "test"
+    );
+  });
+
+  it("rejects transactions whose nonce is lower than the account nonce", async () => {
+    const options = EthereumOptionsConfig.normalize({});
+    // when the tx pool requests a nonce for an account, we'll always respond 1
+    // so if we send a tx with nonce 0, it should reject
+    const fakeNonceChain = {
+      accounts: {
+        getNonce: async () => {
+          return Quantity.from(1);
+        }
+      }
+    } as any;
+    const txPool = new TransactionPool(options.miner, fakeNonceChain, origins);
+    const executableTx = TransactionFactory.fromRpc(executableRpc, common);
+    assert.rejects(
+      txPool.prepareTransaction(executableTx, secretKey),
+      {
+        message: `the tx doesn't have the correct nonce. account has nonce of: 1 tx has nonce of: ${executableTx.nonce}`
+      },
+      "test"
+    );
+  });
+
+  it("rejects executable replacement transactions whose gas price isn't sufficiently high", async () => {
+    const txPool = new TransactionPool(options.miner, blockchain, origins);
+    const executableTx = TransactionFactory.fromRpc(executableRpc, common);
+    const isExecutable = await txPool.prepareTransaction(
+      executableTx,
+      secretKey
+    );
+    assert(isExecutable); // our first transaction is executable
+    const { pending } = txPool.executables;
+    // our executable transaction should be found in the pending queue
+    const found = findIn(executableTx.hash.toBuffer(), pending);
+    assert.strictEqual(
+      found.serialized.toString(),
+      executableTx.serialized.toString()
+    );
+    // the second time around, the gas price won't be high enough to replace, so it'll throw
+    assert.rejects(
+      txPool.prepareTransaction(executableTx, secretKey),
+      {
+        code: -32003,
+        message: "transaction underpriced"
+      },
+      "test"
+    );
+  });
+
+  it("rejects future nonce replacement transactions whose gas price isn't sufficiently high", async () => {
+    const txPool = new TransactionPool(options.miner, blockchain, origins);
+    const futureNonceTx = TransactionFactory.fromRpc(futureNonceRpc, common);
+    const isExecutable = await txPool.prepareTransaction(
+      futureNonceTx,
+      secretKey
+    );
+    assert(!isExecutable); // our transaction is not executable
+    // our non executable transaction should be found in the origins queue
+    const found = findIn(futureNonceTx.hash.toBuffer(), origins);
+    assert.strictEqual(
+      found.serialized.toString(),
+      futureNonceTx.serialized.toString()
+    );
+    // now, if we resend the same transaction, since the gas price isn't higher,
+    // it should be rejected
+    assert.rejects(
+      txPool.prepareTransaction(futureNonceTx, secretKey),
+      {
+        code: -32003,
+        message: "transaction underpriced"
+      },
+      "test"
+    );
+  });
+
+  it("adds immediately executable transactions to the pending queue", async () => {
+    const txPool = new TransactionPool(options.miner, blockchain, origins);
+    const executableTx = TransactionFactory.fromRpc(executableRpc, common);
+    // we aren't passing in the secretKey just for code coverage. this causes
+    // a code path where a fake key is made to signAndHash
+    const isExecutable = await txPool.prepareTransaction(executableTx);
+    assert(isExecutable); // our first transaction is executable
+    const { pending } = txPool.executables;
+    // our executable transaction should be found in the pending queue
+    const found = findIn(executableTx.hash.toBuffer(), pending);
+    assert.strictEqual(
+      found.serialized.toString(),
+      executableTx.serialized.toString()
+    );
+  });
+
+  it("adds future nonce transactions to the future queue", async () => {
+    const txPool = new TransactionPool(options.miner, blockchain, origins);
+    const futureNonceTx = TransactionFactory.fromRpc(futureNonceRpc, common);
+    const isExecutable = await txPool.prepareTransaction(
+      futureNonceTx,
+      secretKey
+    );
+    assert(!isExecutable); // our transaction is not executable
+    // our non executable transaction should be found in the origins queue
+    const found = findIn(futureNonceTx.hash.toBuffer(), origins);
+    assert.strictEqual(
+      found.serialized.toString(),
+      futureNonceTx.serialized.toString()
+    );
+  });
+
+  it("replaces immediately executable transactions in the pending queue", async () => {
+    const txPool = new TransactionPool(options.miner, blockchain, origins);
+    const executableTx = TransactionFactory.fromRpc(executableRpc, common);
+    const isExecutable = await txPool.prepareTransaction(
+      executableTx,
+      secretKey
+    );
+    assert(isExecutable); // our first transaction is executable
+    const { pending } = txPool.executables;
+    // our executable transaction should be found in the pending queue
+    const found = findIn(executableTx.hash.toBuffer(), pending);
+    assert.strictEqual(
+      found.serialized.toString(),
+      executableTx.serialized.toString()
+    );
+
+    // our replacement transaction needs to have a sufficiently higher gasPrice
+    const replacementRpc: TypedRpcTransaction = {
+      from: from,
+      type: "0x2",
+      maxFeePerGas: "0xffffffffff",
+      gasLimit: "0xffff",
+      nonce: "0x0"
+    };
+    const replacementTx = TransactionFactory.fromRpc(replacementRpc, common);
+    const replacementIsExecutable = await txPool.prepareTransaction(
+      replacementTx,
+      secretKey
+    );
+    assert(replacementIsExecutable); // our replacement transaction is executable
+    // our replacement transaction should be found in the pending queue
+    const replacementFound = findIn(replacementTx.hash.toBuffer(), pending);
+    assert.strictEqual(
+      replacementFound.serialized.toString(),
+      replacementTx.serialized.toString()
+    );
+
+    // our replaced transaction should not be found anywhere in the pool
+    const originalFound = txPool.find(executableTx.hash.toBuffer());
+    assert.strictEqual(originalFound, null);
+  });
+
+  it("replaces future nonce transactions in the future queue", async () => {
+    const txPool = new TransactionPool(options.miner, blockchain, origins);
+    const futureNonceTx = TransactionFactory.fromRpc(futureNonceRpc, common);
+    const isExecutable = await txPool.prepareTransaction(
+      futureNonceTx,
+      secretKey
+    );
+    assert(!isExecutable); // our transaction is not executable
+    // our non executable transaction should be found in the origins queue
+    const found = findIn(futureNonceTx.hash.toBuffer(), origins);
+    assert.strictEqual(
+      found.serialized.toString(),
+      futureNonceTx.serialized.toString()
+    );
+
+    // our replacement transaction needs to have a sufficiently higher gasPrice
+    const replacementRpc: TypedRpcTransaction = {
+      from: from,
+      type: "0x2",
+      maxFeePerGas: "0xffffffffff",
+      gasLimit: "0xffff",
+      nonce: "0x2"
+    };
+    const replacementTx = TransactionFactory.fromRpc(replacementRpc, common);
+    const replacementIsExecutable = await txPool.prepareTransaction(
+      replacementTx,
+      secretKey
+    );
+    assert(!replacementIsExecutable); // our replacement transaction is also not executable
+    // our replacement transaction should be found in the origins queue
+    const replacementFound = findIn(replacementTx.hash.toBuffer(), origins);
+    assert.strictEqual(
+      replacementFound.serialized.toString(),
+      replacementTx.serialized.toString()
+    );
+
+    // our replaced transaction should not be found anywhere in the pool
+    const originalFound = txPool.find(futureNonceTx.hash.toBuffer());
+    assert.strictEqual(originalFound, null);
+  });
+
+  it("executes future transactions when the nonce gap is fiiled", async () => {
+    const txPool = new TransactionPool(options.miner, blockchain, origins);
+    const futureNonceTx = TransactionFactory.fromRpc(futureNonceRpc, common);
+    const futureIsExecutable = await txPool.prepareTransaction(
+      futureNonceTx,
+      secretKey
+    );
+    assert(!futureIsExecutable); // our transaction is not executable
+    // our non executable transaction should be found in the origins queue
+    const foundInOrigins = findIn(futureNonceTx.hash.toBuffer(), origins);
+    assert.strictEqual(
+      foundInOrigins.serialized.toString(),
+      futureNonceTx.serialized.toString()
+    );
+
+    // since the "future nonce" is 0x2, we need a 0x0 and a 0x1 nonce transaction
+    // from this origin. queue up the 0x0 one now
+    const executableTx = TransactionFactory.fromRpc(executableRpc, common);
+    const isExecutable = await txPool.prepareTransaction(
+      executableTx,
+      secretKey
+    );
+    assert(isExecutable); // our first transaction is executable
+    const { pending } = txPool.executables;
+    // our executable transaction should be found in the pending queue
+    const found = findIn(executableTx.hash.toBuffer(), pending);
+    assert.strictEqual(
+      found.serialized.toString(),
+      executableTx.serialized.toString()
+    );
+
+    // now we'll send in transaction that will fill the gap between the queued
+    // tx and the account's nonce
+    // note, we're sending a transaction that doesn't have a nonce just for
+    // code coverage, to hit the lines where there 1. is an executable tx already
+    // and 2. a no-nonce tx is sent so the next highest nonce needs to be used
+    const tx = TransactionFactory.fromRpc(rpcTx, common);
+    const txIsExecutable = await txPool.prepareTransaction(tx, secretKey);
+    assert(txIsExecutable); // our next transaction is executable
+    // our executable transaction should be found in the pending queue
+    const txFound = findIn(tx.hash.toBuffer(), pending);
+    assert.strictEqual(txFound.serialized.toString(), tx.serialized.toString());
+
+    // now, the tx pool should have automatically marked our previously "future"
+    // tx as executable and moved it out of the origins queue.
+    const futureInPending = findIn(futureNonceTx.hash.toBuffer(), pending);
+    assert.strictEqual(
+      futureInPending.serialized.toString(),
+      futureNonceTx.serialized.toString()
+    );
+    const futureInOrigin = findIn(futureNonceTx.hash.toBuffer(), origins);
+    assert.strictEqual(futureInOrigin, undefined);
+  });
+
+  it("sets the transactions nonce appropriately if omitted from the transaction", async () => {
+    const txPool = new TransactionPool(options.miner, blockchain, origins);
+    // we're copying the rpcTx but using the 0 address just for code coverage
+    // we'll also omit the secretKey below. This will force a code path where
+    // a fake key is generated for the zero address
+    const newTx = JSON.parse(JSON.stringify(rpcTx));
+    newTx.from = `0x0000000000000000000000000000000000000000`;
+    const transaction = TransactionFactory.fromRpc(newTx, common);
+
+    // our transaction doesn't have a nonce up front.
+    assert.strictEqual(transaction.nonce.valueOf(), undefined);
+    await txPool.prepareTransaction(transaction);
+    // after it's prepared by the txPool, an appropriate nonce for the account is set
+    assert.strictEqual(transaction.nonce.valueOf(), Quantity.from(0).valueOf());
+  });
+
+  it("can be cleared/emptied", async () => {
+    const txPool = new TransactionPool(options.miner, blockchain, origins);
+    const transaction = TransactionFactory.fromRpc(rpcTx, common);
+
+    await txPool.prepareTransaction(transaction);
+    const { pending } = txPool.executables;
+    // our executable transaction should be found in the pending queue
+    const found = findIn(transaction.hash.toBuffer(), pending);
+    assert.strictEqual(
+      found.serialized.toString(),
+      transaction.serialized.toString()
+    );
+
+    const futureNonceTx = TransactionFactory.fromRpc(futureNonceRpc, common);
+    const futureIsExecutable = await txPool.prepareTransaction(
+      futureNonceTx,
+      secretKey
+    );
+    assert(!futureIsExecutable); // our transaction is not executable
+    // our non executable transaction should be found in the origins queue
+    const foundInOrigins = findIn(futureNonceTx.hash.toBuffer(), origins);
+    assert.strictEqual(
+      foundInOrigins.serialized.toString(),
+      futureNonceTx.serialized.toString()
+    );
+
+    txPool.clear();
+    // both queues should be empty
+    assert.strictEqual(pending.values.length, 0);
+    assert.strictEqual(origins.values.length, 0);
+  });
+
+  it("emits an event when a transaction is ready to be mined", async () => {
+    const txPool = new TransactionPool(options.miner, blockchain, origins);
+    const transaction = TransactionFactory.fromRpc(rpcTx, common);
+
+    await txPool.prepareTransaction(transaction);
+    txPool.on("drain", () => {
+      const { pending } = txPool.executables;
+      // our executable transaction should be found in the pending queue after the drain event
+      const found = findIn(transaction.hash.toBuffer(), pending);
+      assert.strictEqual(
+        found.serialized.toString(),
+        transaction.serialized.toString()
+      );
+    });
+    txPool.drain();
+  });
+});

--- a/src/chains/ethereum/utils/src/errors/errors.ts
+++ b/src/chains/ethereum/utils/src/errors/errors.ts
@@ -14,6 +14,11 @@ export const NONCE_TOO_LOW = "nonce too low";
 export const UNDERPRICED = "transaction underpriced";
 
 /**
+ * Returned if a transaction's gas price is below the minimum configured for the transaction pool.
+ */
+export const REPLACED = "transaction replaced by better transaction";
+
+/**
  * Returned if the transaction is specified to use less gas than required to start the invocation.
  */
 export const INTRINSIC_GAS_TOO_LOW = "intrinsic gas too low";


### PR DESCRIPTION
Prevents a transaction that replaces a previously queued transaction from being re-added to the transaction pool and thus run twice.

Previously when a transaction was sent we checked:
- do we have executable transactions in the transaction pool from the same origin?
- does this new transaction have the same nonce as one of those?
- if so, is this new transaction's gas price better?
- if so, replace the previous transaction with this new one.

We now perform all of those same checks against the future-nonce transactions (transactions whose nonce is higher than the sender account's nonce) in the transaction pool, not just the executable transactions.

Fixes #1219 and #1218