### PR TITLE
use new @trufflesuite/bigint-buffer

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,7 +61,7 @@ jobs:
       #   if: startsWith(matrix.os, 'windows-')
       #   run: npm config set msvs_version 2019 --global
 
-      - run: npm ci
+      - run: npm install
       - run: npm run tsc
       - run: npm test
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
         # monorepo we want to use 10.7.0 (earliest version the Ethereum side
         # supports) or 10.13.0 (first node 10 LTS version).
         node: [10.18.0, 10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x]
-        os: [windows-latest, ubuntu-18.04, ubuntu-20.04, macos-11.0]
+        os: [windows-2019, ubuntu-18.04, ubuntu-20.04, macos-11.0]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
         # monorepo we want to use 10.7.0 (earliest version the Ethereum side
         # supports) or 10.13.0 (first node 10 LTS version).
         node: [10.18.0, 10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x]
-        os: [windows-2019, ubuntu-18.04, ubuntu-20.04, macos-11.0]
+        os: [windows-latest, ubuntu-18.04, ubuntu-20.04, macos-11.0]
 
     runs-on: ${{ matrix.os }}
 
@@ -60,7 +60,9 @@ jobs:
       # - name: Set node config to set msvs_version to 2019
       #   if: startsWith(matrix.os, 'windows-')
       #   run: npm config set msvs_version 2019 --global
-
+      - run: python -c "import sys; print(sys.version)"
+      - run: npm unisntall -g windows-build-tools
+      - run: npm unisntall -g node-gyp
       - run: npm install
       - run: npm run tsc
       - run: npm test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      # - name: Add msbuild to PATH
-      # we need msbuild tools for the `bigint-buffer` module
-      # if: startsWith(matrix.os, 'windows-')
-      # uses: microsoft/setup-msbuild@v1.0.2
+      - name: Add msbuild to PATH
+        # we need msbuild tools for the `bigint-buffer` module
+        if: startsWith(matrix.os, 'windows-')
+        uses: microsoft/setup-msbuild@v1.0.2
 
       # - name: install node tools
       #   # we don't need to install the windows-build-tools package, as we
@@ -60,10 +60,7 @@ jobs:
       # - name: Set node config to set msvs_version to 2019
       #   if: startsWith(matrix.os, 'windows-')
       #   run: npm config set msvs_version 2019 --global
-      - run: python -c "import sys; print(sys.version)"
-      - run: npm uninstall -g windows-build-tools
-      - run: npm uninstall -g node-gyp
-      - run: npm install
+      - run: npm ci
       - run: npm run tsc
       - run: npm test
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,32 +34,10 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Add msbuild to PATH
-        # we need msbuild tools for the `bigint-buffer` module
+        # we need msbuild tools for the `bcrypto` module
         if: startsWith(matrix.os, 'windows-')
         uses: microsoft/setup-msbuild@v1.0.2
 
-      # - name: install node tools
-      #   # we don't need to install the windows-build-tools package, as we
-      #   # already have almost everything we need. We only need to install
-      #   # python 2.7. Also windows-build-tools@4 fails to install because some
-      #   # resources it downloads no longer exist, and windows-build-tools@5
-      #   # fails to install Python (it will wait on the python installer forever)
-      #   if: startsWith(matrix.os, 'windows-')
-      #   uses: actions/setup-python@v2
-      #   with:
-      #     python-version: "2.7"
-
-      # - name: install node-gyp
-      #   if: startsWith(matrix.os, 'windows-')
-      #   run: npm install --global node-gyp@7.1.2
-
-      # - name: Set node config to use python2.7
-      #   if: startsWith(matrix.os, 'windows-')
-      #   run: npm config set python python2.7
-
-      # - name: Set node config to set msvs_version to 2019
-      #   if: startsWith(matrix.os, 'windows-')
-      #   run: npm config set msvs_version 2019 --global
       - run: npm ci
       - run: npm run tsc
       - run: npm test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,8 +61,8 @@ jobs:
       #   if: startsWith(matrix.os, 'windows-')
       #   run: npm config set msvs_version 2019 --global
       - run: python -c "import sys; print(sys.version)"
-      - run: npm unisntall -g windows-build-tools
-      - run: npm unisntall -g node-gyp
+      - run: npm uninstall -g windows-build-tools
+      - run: npm uninstall -g node-gyp
       - run: npm install
       - run: npm run tsc
       - run: npm test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,28 +38,28 @@ jobs:
         if: startsWith(matrix.os, 'windows-')
         uses: microsoft/setup-msbuild@v1.0.2
 
-      - name: install node tools
-        # we don't need to install the windows-build-tools package, as we
-        # already have almost everything we need. We only need to install
-        # python 2.7. Also windows-build-tools@4 fails to install because some
-        # resources it downloads no longer exist, and windows-build-tools@5
-        # fails to install Python (it will wait on the python installer forever)
-        if: startsWith(matrix.os, 'windows-')
-        uses: actions/setup-python@v2
-        with:
-          python-version: "2.7"
+      # - name: install node tools
+      #   # we don't need to install the windows-build-tools package, as we
+      #   # already have almost everything we need. We only need to install
+      #   # python 2.7. Also windows-build-tools@4 fails to install because some
+      #   # resources it downloads no longer exist, and windows-build-tools@5
+      #   # fails to install Python (it will wait on the python installer forever)
+      #   if: startsWith(matrix.os, 'windows-')
+      #   uses: actions/setup-python@v2
+      #   with:
+      #     python-version: "2.7"
 
-      - name: install node-gyp
-        if: startsWith(matrix.os, 'windows-')
-        run: npm install --global node-gyp@7.1.2
+      # - name: install node-gyp
+      #   if: startsWith(matrix.os, 'windows-')
+      #   run: npm install --global node-gyp@7.1.2
 
-      - name: Set node config to use python2.7
-        if: startsWith(matrix.os, 'windows-')
-        run: npm config set python python2.7
+      # - name: Set node config to use python2.7
+      #   if: startsWith(matrix.os, 'windows-')
+      #   run: npm config set python python2.7
 
-      - name: Set node config to set msvs_version to 2019
-        if: startsWith(matrix.os, 'windows-')
-        run: npm config set msvs_version 2019 --global
+      # - name: Set node config to set msvs_version to 2019
+      #   if: startsWith(matrix.os, 'windows-')
+      #   run: npm config set msvs_version 2019 --global
 
       - run: npm ci
       - run: npm run tsc

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: Add msbuild to PATH
-        # we need msbuild tools for the `bigint-buffer` module
-        # if: startsWith(matrix.os, 'windows-')
-        # uses: microsoft/setup-msbuild@v1.0.2
+      # - name: Add msbuild to PATH
+      # we need msbuild tools for the `bigint-buffer` module
+      # if: startsWith(matrix.os, 'windows-')
+      # uses: microsoft/setup-msbuild@v1.0.2
 
       # - name: install node tools
       #   # we don't need to install the windows-build-tools package, as we

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Add msbuild to PATH
         # we need msbuild tools for the `bigint-buffer` module
-        if: startsWith(matrix.os, 'windows-')
-        uses: microsoft/setup-msbuild@v1.0.2
+        # if: startsWith(matrix.os, 'windows-')
+        # uses: microsoft/setup-msbuild@v1.0.2
 
       # - name: install node tools
       #   # we don't need to install the windows-build-tools package, as we

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2078,6 +2078,14 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@trufflesuite/bigint-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.6.tgz",
+      "integrity": "sha512-W3rgwVW7gRewB8GHt31UUnQYVRvLEogic1T0CVoSYoSe55nsS/PIMDpgA0S0P3JovjbEL8nfdtXdiI3PuH1Mhg==",
+      "requires": {
+        "bindings": "^1.3.0"
+      }
+    },
     "@types/fs-extra": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.7.tgz",
@@ -2430,6 +2438,14 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -3511,6 +3527,11 @@
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2078,14 +2078,6 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
-    "@trufflesuite/bigint-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.6.tgz",
-      "integrity": "sha512-W3rgwVW7gRewB8GHt31UUnQYVRvLEogic1T0CVoSYoSe55nsS/PIMDpgA0S0P3JovjbEL8nfdtXdiI3PuH1Mhg==",
-      "requires": {
-        "bindings": "^1.3.0"
-      }
-    },
     "@types/fs-extra": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.7.tgz",
@@ -2438,14 +2430,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -3527,11 +3511,6 @@
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fill-range": {
       "version": "7.0.1",

--- a/src/packages/ganache/npm-shrinkwrap.json
+++ b/src/packages/ganache/npm-shrinkwrap.json
@@ -10,14 +10,6 @@
 			"integrity": "sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==",
 			"dev": true
 		},
-		"@trufflesuite/bigint-buffer": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.6.tgz",
-			"integrity": "sha512-W3rgwVW7gRewB8GHt31UUnQYVRvLEogic1T0CVoSYoSe55nsS/PIMDpgA0S0P3JovjbEL8nfdtXdiI3PuH1Mhg==",
-			"requires": {
-				"bindings": "^1.3.0"
-			}
-		},
 		"@types/eslint": {
 			"version": "7.28.0",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
@@ -383,6 +375,14 @@
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
 			"dev": true
+		},
+		"bigint-buffer": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+			"integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+			"requires": {
+				"bindings": "^1.3.0"
+			}
 		},
 		"binary-extensions": {
 			"version": "2.2.0",

--- a/src/packages/ganache/npm-shrinkwrap.json
+++ b/src/packages/ganache/npm-shrinkwrap.json
@@ -10,6 +10,21 @@
 			"integrity": "sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==",
 			"dev": true
 		},
+		"@trufflesuite/bigint-buffer": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.9.tgz",
+			"integrity": "sha512-bdM5cEGCOhDSwminryHJbRmXc1x7dPKg6Pqns3qyTwFlxsqUgxE29lsERS3PlIW1HTjoIGMUqsk1zQQwST1Yxw==",
+			"requires": {
+				"node-gyp-build": "4.3.0"
+			},
+			"dependencies": {
+				"node-gyp-build": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+					"integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
+				}
+			}
+		},
 		"@types/eslint": {
 			"version": "7.28.0",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
@@ -376,27 +391,11 @@
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
 			"dev": true
 		},
-		"bigint-buffer": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
-			"integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
-			"requires": {
-				"bindings": "^1.3.0"
-			}
-		},
 		"binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
 			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
 			"dev": true
-		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
 		},
 		"bn.js": {
 			"version": "4.12.0",
@@ -1070,11 +1069,6 @@
 			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
 			"integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
 			"dev": true
-		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"fill-range": {
 			"version": "7.0.1",

--- a/src/packages/ganache/npm-shrinkwrap.json
+++ b/src/packages/ganache/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
 	"name": "ganache",
-	"version": "7.0.0-alpha.0",
+	"version": "7.0.0-alpha.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -9,6 +9,14 @@
 			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz",
 			"integrity": "sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==",
 			"dev": true
+		},
+		"@trufflesuite/bigint-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.6.tgz",
+			"integrity": "sha512-W3rgwVW7gRewB8GHt31UUnQYVRvLEogic1T0CVoSYoSe55nsS/PIMDpgA0S0P3JovjbEL8nfdtXdiI3PuH1Mhg==",
+			"requires": {
+				"bindings": "^1.3.0"
+			}
 		},
 		"@types/eslint": {
 			"version": "7.28.0",
@@ -375,14 +383,6 @@
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
 			"dev": true
-		},
-		"bigint-buffer": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
-			"integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
-			"requires": {
-				"bindings": "^1.3.0"
-			}
 		},
 		"binary-extensions": {
 			"version": "2.2.0",

--- a/src/packages/ganache/package.json
+++ b/src/packages/ganache/package.json
@@ -83,7 +83,7 @@
     "webpack-cli": "4.5.0"
   },
   "dependencies": {
-    "bigint-buffer": "1.1.5",
+    "@trufflesuite/bigint-buffer": "1.1.6",
     "bufferutil": "4.0.3",
     "keccak": "3.0.1",
     "leveldown": "5.6.0",

--- a/src/packages/ganache/package.json
+++ b/src/packages/ganache/package.json
@@ -83,7 +83,7 @@
     "webpack-cli": "4.5.0"
   },
   "dependencies": {
-    "bigint-buffer": "1.1.5",
+    "@trufflesuite/bigint-buffer": "1.1.9",
     "bufferutil": "4.0.3",
     "keccak": "3.0.1",
     "leveldown": "5.6.0",

--- a/src/packages/ganache/package.json
+++ b/src/packages/ganache/package.json
@@ -83,7 +83,7 @@
     "webpack-cli": "4.5.0"
   },
   "dependencies": {
-    "@trufflesuite/bigint-buffer": "1.1.6",
+    "bigint-buffer": "1.1.5",
     "bufferutil": "4.0.3",
     "keccak": "3.0.1",
     "leveldown": "5.6.0",

--- a/src/packages/ganache/webpack/webpack.node.config.ts
+++ b/src/packages/ganache/webpack/webpack.node.config.ts
@@ -35,7 +35,7 @@ const config: webpack.Configuration = merge({}, base, {
   },
   externals: [
     //#region dependencies that have the potential to compile something at install time
-    "bigint-buffer",
+    "@trufflesuite/bigint-buffer",
     "leveldown",
     "secp256k1",
     "keccak",

--- a/src/packages/utils/package-lock.json
+++ b/src/packages/utils/package-lock.json
@@ -39,6 +39,23 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@trufflesuite/bigint-buffer": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.9.tgz",
+      "integrity": "sha512-bdM5cEGCOhDSwminryHJbRmXc1x7dPKg6Pqns3qyTwFlxsqUgxE29lsERS3PlIW1HTjoIGMUqsk1zQQwST1Yxw==",
+      "optional": true,
+      "requires": {
+        "node-gyp-build": "4.3.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+          "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+          "optional": true
+        }
+      }
+    },
     "@trufflesuite/uws-js-unofficial": {
       "version": "18.14.0-unofficial.12",
       "resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.12.tgz",

--- a/src/packages/utils/package-lock.json
+++ b/src/packages/utils/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@trufflesuite/bigint-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.6.tgz",
+      "integrity": "sha512-W3rgwVW7gRewB8GHt31UUnQYVRvLEogic1T0CVoSYoSe55nsS/PIMDpgA0S0P3JovjbEL8nfdtXdiI3PuH1Mhg==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.3.0"
+      }
+    },
     "@trufflesuite/uws-js-unofficial": {
       "version": "18.14.0-unofficial.12",
       "resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.12.tgz",
@@ -81,15 +90,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "bigint-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
-      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
-      "optional": true,
-      "requires": {
-        "bindings": "^1.3.0"
-      }
     },
     "binary-extensions": {
       "version": "2.2.0",

--- a/src/packages/utils/package-lock.json
+++ b/src/packages/utils/package-lock.json
@@ -117,29 +117,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "bigint-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
-      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
-      "optional": true,
-      "requires": {
-        "bindings": "^1.3.0"
-      }
-    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -351,12 +333,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",

--- a/src/packages/utils/package-lock.json
+++ b/src/packages/utils/package-lock.json
@@ -4,6 +4,41 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
+      "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@trufflesuite/uws-js-unofficial": {
       "version": "18.14.0-unofficial.12",
       "resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.12.tgz",
@@ -490,6 +525,12 @@
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -504,6 +545,12 @@
       "requires": {
         "argparse": "^2.0.1"
       }
+    },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
     },
     "keccak": {
       "version": "3.0.1",
@@ -522,6 +569,12 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "log-symbols": {
       "version": "4.0.0",
@@ -611,6 +664,19 @@
       "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
       "dev": true
     },
+    "nise": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
+      "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^7.0.4",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node-addon-api": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
@@ -677,6 +743,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
     },
     "picomatch": {
       "version": "2.3.0",
@@ -752,6 +827,31 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "sinon": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^7.1.2",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -842,6 +942,12 @@
       "requires": {
         "resolve": ">=1.9.0"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "typescript": {
       "version": "4.1.3",

--- a/src/packages/utils/package-lock.json
+++ b/src/packages/utils/package-lock.json
@@ -4,15 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@trufflesuite/bigint-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.6.tgz",
-      "integrity": "sha512-W3rgwVW7gRewB8GHt31UUnQYVRvLEogic1T0CVoSYoSe55nsS/PIMDpgA0S0P3JovjbEL8nfdtXdiI3PuH1Mhg==",
-      "optional": true,
-      "requires": {
-        "bindings": "^1.3.0"
-      }
-    },
     "@trufflesuite/uws-js-unofficial": {
       "version": "18.14.0-unofficial.12",
       "resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-18.14.0-unofficial.12.tgz",
@@ -90,6 +81,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "bigint-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.3.0"
+      }
     },
     "binary-extensions": {
       "version": "2.2.0",

--- a/src/packages/utils/package.json
+++ b/src/packages/utils/package.json
@@ -63,6 +63,6 @@
     "typescript": "4.1.3"
   },
   "optionalDependencies": {
-    "bigint-buffer": "1.1.5"
+    "@trufflesuite/bigint-buffer": "1.1.9"
   }
 }

--- a/src/packages/utils/package.json
+++ b/src/packages/utils/package.json
@@ -61,6 +61,6 @@
     "typescript": "4.1.3"
   },
   "optionalDependencies": {
-    "bigint-buffer": "1.1.5"
+    "@trufflesuite/bigint-buffer": "1.1.6"
   }
 }

--- a/src/packages/utils/package.json
+++ b/src/packages/utils/package.json
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "tsc": "ttsc --build",
-    "test": "echo 'no tests'"
+    "test": "npm run mocha",
+    "mocha": "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha -s 0 -t 0 --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"

--- a/src/packages/utils/package.json
+++ b/src/packages/utils/package.json
@@ -61,6 +61,6 @@
     "typescript": "4.1.3"
   },
   "optionalDependencies": {
-    "@trufflesuite/bigint-buffer": "1.1.6"
+    "bigint-buffer": "1.1.5"
   }
 }

--- a/src/packages/utils/package.json
+++ b/src/packages/utils/package.json
@@ -57,6 +57,7 @@
     "@types/seedrandom": "3.0.1",
     "cross-env": "7.0.3",
     "mocha": "8.4.0",
+    "sinon": "11.1.2",
     "ts-node": "9.1.1",
     "ttypescript": "1.5.12",
     "typescript": "4.1.3"

--- a/src/packages/utils/src/common.ts
+++ b/src/packages/utils/src/common.ts
@@ -1,1 +1,1 @@
-export { toBufferBE, toBigIntBE } from "@trufflesuite/bigint-buffer";
+export { toBufferBE, toBigIntBE } from "bigint-buffer";

--- a/src/packages/utils/src/common.ts
+++ b/src/packages/utils/src/common.ts
@@ -1,1 +1,1 @@
-export { toBufferBE, toBigIntBE } from "bigint-buffer";
+export { toBufferBE, toBigIntBE } from "@trufflesuite/bigint-buffer";

--- a/src/packages/utils/src/utils/buffer-to-bigint.ts
+++ b/src/packages/utils/src/utils/buffer-to-bigint.ts
@@ -1,4 +1,4 @@
-import { toBigIntBE } from "@trufflesuite/bigint-buffer";
+import { toBigIntBE } from "bigint-buffer";
 /**
  * note: this doesn't handle negative values
  * @param value Buffer representation of a bigint, most-significant bit first (Big-endian)

--- a/src/packages/utils/src/utils/buffer-to-bigint.ts
+++ b/src/packages/utils/src/utils/buffer-to-bigint.ts
@@ -1,4 +1,4 @@
-import { toBigIntBE } from "bigint-buffer";
+import { toBigIntBE } from "@trufflesuite/bigint-buffer";
 /**
  * note: this doesn't handle negative values
  * @param value Buffer representation of a bigint, most-significant bit first (Big-endian)

--- a/src/packages/utils/tests/utils.test.ts
+++ b/src/packages/utils/tests/utils.test.ts
@@ -3,7 +3,7 @@ import sinon from "sinon";
 const BIGINT_ERROR =
   "bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)";
 
-describe("@ganache/utils", () => {
+describe.only("@ganache/utils", () => {
   describe("bigint-buffer library", () => {
     let spy: any;
     before(() => {
@@ -16,6 +16,7 @@ describe("@ganache/utils", () => {
       // if prebuilt binaries aren't properly installed, we'll get a warning from
       // this lib saying that the JS fallback is being used.
       require("bigint-buffer");
+      console.warn(BIGINT_ERROR);
       // so we'll spy on console.warn to ensure that our bigint-buffer warning
       // is never called when loading this library
       assert.strictEqual(spy.withArgs(BIGINT_ERROR).callCount, 0);

--- a/src/packages/utils/tests/utils.test.ts
+++ b/src/packages/utils/tests/utils.test.ts
@@ -16,7 +16,6 @@ describe.only("@ganache/utils", () => {
       // if prebuilt binaries aren't properly installed, we'll get a warning from
       // this lib saying that the JS fallback is being used.
       require("bigint-buffer");
-      console.warn(BIGINT_ERROR);
       // so we'll spy on console.warn to ensure that our bigint-buffer warning
       // is never called when loading this library
       assert.strictEqual(spy.withArgs(BIGINT_ERROR).callCount, 0);

--- a/src/packages/utils/tests/utils.test.ts
+++ b/src/packages/utils/tests/utils.test.ts
@@ -12,10 +12,10 @@ describe.only("@ganache/utils", () => {
 
     it("loads without warnings", () => {
       // make sure we're actually loading this module and not using a cached version
-      delete require.cache[require.resolve("bigint-buffer")];
+      delete require.cache[require.resolve("@trufflesuite/bigint-buffer")];
       // if prebuilt binaries aren't properly installed, we'll get a warning from
       // this lib saying that the JS fallback is being used.
-      require("bigint-buffer");
+      require("@trufflesuite/bigint-buffer");
       // so we'll spy on console.warn to ensure that our bigint-buffer warning
       // is never called when loading this library
       assert.strictEqual(spy.withArgs(BIGINT_ERROR).callCount, 0);

--- a/src/packages/utils/tests/utils.test.ts
+++ b/src/packages/utils/tests/utils.test.ts
@@ -3,7 +3,7 @@ import sinon from "sinon";
 const BIGINT_ERROR =
   "bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)";
 
-describe.only("@ganache/utils", () => {
+describe("@ganache/utils", () => {
   describe("bigint-buffer library", () => {
     let spy: any;
     before(() => {

--- a/src/packages/utils/tests/utils.test.ts
+++ b/src/packages/utils/tests/utils.test.ts
@@ -21,9 +21,7 @@ describe("@ganache/utils", () => {
     it("loads binaries on all platforms", () => {
       const buf = Buffer.from([255, 0]);
       const bigint = bufferToBigInt(buf);
-      console.warn(
-        "bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)"
-      );
+      console.warn("test warn");
       assert.strictEqual(bigint, 65280n);
     });
     after(() => {

--- a/src/packages/utils/tests/utils.test.ts
+++ b/src/packages/utils/tests/utils.test.ts
@@ -1,27 +1,28 @@
 "use strict";
 const oldWarn = console.warn;
+let failedToLoad = false;
+console.warn = e => {
+  console.log(e);
+  if (
+    e ===
+    "bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)"
+  ) {
+    failedToLoad = true;
+  }
+};
+
 import { bufferToBigInt } from "../src/utils/buffer-to-bigint";
-import "assert";
 import assert from "assert";
 
 const utils = require("..");
 
-describe("@ganache/utils", () => {
+describe.only("@ganache/utils", () => {
   describe("bigint-buffer library", () => {
-    before(() => {
-      console.warn = e => {
-        if (
-          e ===
-          "bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)"
-        ) {
-          assert.fail(e);
-        }
-      };
-    });
+    before(() => {});
     it("loads binaries on all platforms", () => {
       const buf = Buffer.from([255, 0]);
       const bigint = bufferToBigInt(buf);
-      console.warn("test warn");
+      assert.strictEqual(failedToLoad, false);
       assert.strictEqual(bigint, 65280n);
     });
     after(() => {

--- a/src/packages/utils/tests/utils.test.ts
+++ b/src/packages/utils/tests/utils.test.ts
@@ -1,7 +1,30 @@
 "use strict";
+const oldWarn = console.warn;
+import { bufferToBigInt } from "../src/utils/buffer-to-bigint";
+import "assert";
+import assert from "assert";
 
 const utils = require("..");
 
 describe("@ganache/utils", () => {
-  it("needs tests");
+  describe("bigint-buffer library", () => {
+    before(() => {
+      console.warn = e => {
+        if (
+          e ===
+          "bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)"
+        ) {
+          assert.fail(e);
+        }
+      };
+    });
+    it("loads binaries on all platforms", () => {
+      const buf = Buffer.from([255, 0]);
+      const bigint = bufferToBigInt(buf);
+      assert.strictEqual(bigint, 65280n);
+    });
+    after(() => {
+      console.warn = oldWarn;
+    });
+  });
 });

--- a/src/packages/utils/tests/utils.test.ts
+++ b/src/packages/utils/tests/utils.test.ts
@@ -21,6 +21,9 @@ describe("@ganache/utils", () => {
     it("loads binaries on all platforms", () => {
       const buf = Buffer.from([255, 0]);
       const bigint = bufferToBigInt(buf);
+      console.warn(
+        "bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)"
+      );
       assert.strictEqual(bigint, 65280n);
     });
     after(() => {


### PR DESCRIPTION
Previously the bigint-buffer library used by Ganache would fail to build on Windows unless `windows-build-tools` was installed. This would cause the (slower) JS fallback to be used and would display an ugly warning in the console on startup of Ganache. This PR's main objective is to use trufflesuite's new [bigint-buffer](https://github.com/trufflesuite/bigint-buffer) library, which prebuilds all binaries during CI to prevent this warning.

Additionally, this PR:
- removes unnecessary CI installations when Github runs the PR action
- Adds very basic test to check if fallback for bigint-buffer is used.
  - Note: the original bigint-buffer library does NOT fail to build and use the JS fallback in our CI tests. This is because the windows version used by Github actions has the necessary dependencies (python) installed by default. So while the test should accurately tell us if the fallback is used, it shouldn't ever happen in CI so it's not particularly useful.

Closes #1080 