### PR TITLE
fix: make forking chainId aware

### DIFF
--- a/src/chains/ethereum/ethereum/src/forking/fork.ts
+++ b/src/chains/ethereum/ethereum/src/forking/fork.ts
@@ -91,6 +91,8 @@ export class Fork {
       fetchNetworkId(this)
     ]);
 
+    this.chainId = chainId;
+
     this.common = Common.forCustomChain(
       KNOWN_CHAINIDS.has(chainId) ? chainId : 1,
       {
@@ -237,8 +239,8 @@ export class Fork {
    */
   public getCommonForBlockNumber(common: Common, blockNumber: BN) {
     const bigIntBlockNumber = Quantity.from(blockNumber.toBuffer()).toBigInt();
-    if (bigIntBlockNumber < this.blockNumber.toBigInt()) {
-      // we are before our fork block
+    if (bigIntBlockNumber <= this.blockNumber.toBigInt()) {
+      // we are at or before our fork block
 
       if (KNOWN_CHAINIDS.has(this.chainId)) {
         // we support this chain id, so let's use its rules

--- a/src/chains/ethereum/ethereum/src/forking/fork.ts
+++ b/src/chains/ethereum/ethereum/src/forking/fork.ts
@@ -12,6 +12,7 @@ import { Account } from "@ganache/ethereum-utils";
 import BlockManager from "../data-managers/block-manager";
 import { ProviderHandler } from "./handlers/provider-handler";
 import { PersistentCache } from "./persistent-cache/persistent-cache";
+import { BN } from "ethereumjs-util";
 
 async function fetchChainId(fork: Fork) {
   const chainIdHex = await fork.request<string>("eth_chainId", []);
@@ -41,16 +42,18 @@ export class Fork {
   public common: Common;
   #abortController = new AbortController();
   #handler: Handler;
-  #options: EthereumInternalOptions["fork"];
+  #options: EthereumInternalOptions;
   #accounts: Account[];
   #hardfork: string;
 
   public blockNumber: Quantity;
   public stateRoot: Data;
   public block: Block;
+  public chainId: number;
 
   constructor(options: EthereumInternalOptions, accounts: Account[]) {
-    const forkingOptions = (this.#options = options.fork);
+    this.#options = options;
+    const forkingOptions = options.fork;
     this.#hardfork = options.chain.hardfork;
     this.#accounts = accounts;
 
@@ -94,7 +97,7 @@ export class Fork {
         name: "ganache-fork",
         defaultHardfork: this.#hardfork,
         networkId,
-        chainId,
+        chainId: this.#options.chain.chainId,
         comment: "Local test network fork"
       }
     );
@@ -104,7 +107,7 @@ export class Fork {
   #setBlockDataFromChainAndOptions = async (
     chainIdPromise: Promise<number>
   ) => {
-    const options = this.#options;
+    const { fork: options } = this.#options;
     if (options.blockNumber === Tag.LATEST) {
       const [latestBlock, chainId] = await Promise.all([
         fetchBlock(this, Tag.LATEST),
@@ -221,5 +224,37 @@ export class Fork {
     return this.isValidForkBlockNumber(blockNumber)
       ? blockNumber
       : this.blockNumber;
+  }
+
+  /**
+   * If the blockNumber is before our fork.blockNumber return a Common instance
+   * applying the rules from the remote chain's via it's original chainId. If
+   * the remote chain's chain id is now "known", return a common with our local
+   * common's rules applied, but with the remote chain's chainId. If the block
+   * is greater than or equal to our fork.blockNumber returns `common`.
+   * @param common
+   * @param blockNumber
+   */
+  public getCommonForBlockNumber(common: Common, blockNumber: BN) {
+    const bigIntBlockNumber = Quantity.from(blockNumber.toBuffer()).toBigInt();
+    if (bigIntBlockNumber < this.blockNumber.toBigInt()) {
+      // we are before our fork block
+
+      if (KNOWN_CHAINIDS.has(this.chainId)) {
+        // we support this chain id, so let's use its rules
+        const common = new Common({ chain: this.chainId });
+        common.setHardforkByBlockNumber(blockNumber);
+        return common;
+      } else {
+        // we don't know about this chain, so just carry on per usual
+        return Common.forCustomChain(
+          1,
+          { chainId: this.chainId },
+          common.hardfork()
+        );
+      }
+    } else {
+      return common;
+    }
   }
 }

--- a/src/chains/ethereum/ethereum/src/forking/fork.ts
+++ b/src/chains/ethereum/ethereum/src/forking/fork.ts
@@ -228,12 +228,13 @@ export class Fork {
       : this.blockNumber;
   }
 
-  /**
-   * If the blockNumber is before our fork.blockNumber return a Common instance
-   * applying the rules from the remote chain's via it's original chainId. If
-   * the remote chain's chain id is now "known", return a common with our local
-   * common's rules applied, but with the remote chain's chainId. If the block
-   * is greater than or equal to our fork.blockNumber returns `common`.
+ /**
+   * If the `blockNumber` is before our `fork.blockNumber`, return a `Common`
+   * instance, applying the rules from the remote chain's `common` via its
+   * original `chainId`. If the remote chain's `chainId` is now "known", return
+   * a `Common` with our local `common`'s rules applied, but with the remote
+   * chain's `chainId`. If the block is greater than or equal to our
+   * `fork.blockNumber` return `common`.
    * @param common
    * @param blockNumber
    */

--- a/src/chains/ethereum/ethereum/src/forking/fork.ts
+++ b/src/chains/ethereum/ethereum/src/forking/fork.ts
@@ -170,7 +170,7 @@ export class Fork {
 
   public async initialize() {
     let cacheProm: Promise<PersistentCache>;
-    const options = this.#options;
+    const { fork: options } = this.#options;
     if (options.deleteCache) await PersistentCache.deleteDb();
     if (options.disableCache === false) {
       // ignore cache start up errors as it is possible there is an `open`

--- a/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
@@ -1,22 +1,25 @@
 import assert from "assert";
 import EthereumProvider from "../../../src/provider";
 import getProvider from "../../helpers/getProvider";
-import compile from "../../helpers/compile";
+import compile, { CompileOutput } from "../../helpers/compile";
 import { join } from "path";
 import { BUFFER_EMPTY, Quantity, RPCQUANTITY_EMPTY } from "@ganache/utils";
 import { RETURN_TYPES, RuntimeError } from "@ganache/ethereum-utils";
 
-const contract = compile(join(__dirname, "./contracts/EthCall.sol"), {
-  contractName: "EthCall"
-});
-
 describe("api", () => {
   describe("eth", () => {
     describe("call", () => {
+      let contract: CompileOutput;
       let provider: EthereumProvider;
       let from, to: string;
       let contractAddress: string;
       let tx: object;
+
+      before("compile", () => {
+        contract = compile(join(__dirname, "./contracts/EthCall.sol"), {
+          contractName: "EthCall"
+        });
+      });
 
       before(async () => {
         provider = await getProvider({ wallet: { deterministic: true } });

--- a/src/chains/ethereum/ethereum/tests/api/eth/contracts/EthCall.sol
+++ b/src/chains/ethereum/ethereum/tests/api/eth/contracts/EthCall.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.7.4;
 
 contract EthCall {

--- a/src/chains/ethereum/ethereum/tests/forking/contracts/Forking.sol
+++ b/src/chains/ethereum/ethereum/tests/forking/contracts/Forking.sol
@@ -61,4 +61,10 @@ contract Forking {
   function destruct() public {
     selfdestruct(payable(address(msg.sender)));
   }
+
+  function getChainId() private view returns (uint256 chainId) {
+    assembly {
+      chainId := chainid()
+    }
+  }
 }

--- a/src/chains/ethereum/ethereum/tests/forking/contracts/Forking.sol
+++ b/src/chains/ethereum/ethereum/tests/forking/contracts/Forking.sol
@@ -32,7 +32,7 @@ contract Forking {
   // initial value is 0, set to 1 in constructor
   uint public value4 = 0;
 
-  constructor() public payable {
+  constructor() payable {
     value1 = 2;
     value3 = 0;
     value4 = 1;
@@ -62,7 +62,7 @@ contract Forking {
     selfdestruct(payable(address(msg.sender)));
   }
 
-  function getChainId() private view returns (uint256 chainId) {
+  function getChainId() public pure returns (uint256 chainId) {
     assembly {
       chainId := chainid()
     }

--- a/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
@@ -1036,7 +1036,7 @@ describe("forking", () => {
     });
 
     before("fork from mainnet at contractBlockNum + 1", async () => {
-      // progress the remote provider forward 1 additional block so we can call
+      // progress the remote provider forward 2 additional blocks so we can call
       // `eth_call` with the `contractBlockNum` as the _parent_. This will
       // ensure that the block number of the _transaction_ runs in a block
       // context _before_ our fork point

--- a/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
@@ -105,12 +105,12 @@ export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
     } else {
       if (data.chainId) {
         this.chainId = Quantity.from(data.chainId);
-        if (this.common.chainId() !== this.chainId.toNumber()) {
-          throw new CodedError(
-            `Invalid chain id (${this.chainId.toNumber()}) for chain with id ${common.chainId()}.`,
-            JsonRpcErrorCode.INVALID_INPUT
-          );
-        }
+        // if (this.common.chainId() !== this.chainId.toNumber()) {
+        //   throw new CodedError(
+        //     `Invalid chain id (${this.chainId.toNumber()}) for chain with id ${common.chainId()}.`,
+        //     JsonRpcErrorCode.INVALID_INPUT
+        //   );
+        // }
       } else {
         this.chainId = Quantity.from(common.chainIdBN().toArrayLike(Buffer));
       }

--- a/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
@@ -105,12 +105,6 @@ export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
     } else {
       if (data.chainId) {
         this.chainId = Quantity.from(data.chainId);
-        // if (this.common.chainId() !== this.chainId.toNumber()) {
-        //   throw new CodedError(
-        //     `Invalid chain id (${this.chainId.toNumber()}) for chain with id ${common.chainId()}.`,
-        //     JsonRpcErrorCode.INVALID_INPUT
-        //   );
-        // }
       } else {
         this.chainId = Quantity.from(common.chainIdBN().toArrayLike(Buffer));
       }

--- a/src/chains/ethereum/transaction/src/params.ts
+++ b/src/chains/ethereum/transaction/src/params.ts
@@ -9,10 +9,18 @@ export const Params = {
 
   /**
    * Per byte of data attached to a transaction that is not equal to zero. NOTE: Not payable on data of calls between transactions.
+   * Ganache supports eth_call and debuging old transactions that should be run
+   * in the context of their original hardfork, so hardforks we don't support
+   * are listed here.
    */
   TRANSACTION_DATA_NON_ZERO_GAS: new Map<
-    | "constantinople"
+    | "chainstart"
+    | "homestead"
+    | "dao"
+    | "tangerineWhistle"
+    | "spuriousDragon"
     | "byzantium"
+    | "constantinople"
     | "petersburg"
     | "istanbul"
     | "muirGlacier"
@@ -20,8 +28,13 @@ export const Params = {
     | "london",
     bigint
   >([
-    ["constantinople", 68n],
+    ["chainstart", 68n],
+    ["homestead", 68n],
+    ["dao", 68n],
+    ["tangerineWhistle", 68n],
+    ["spuriousDragon", 68n],
     ["byzantium", 68n],
+    ["constantinople", 68n],
     ["petersburg", 68n],
     ["istanbul", 16n],
     ["muirGlacier", 16n],
@@ -39,7 +52,6 @@ export const Params = {
    */
   TRANSACTION_CREATION: 32000n,
 
-  /* ... */
   /**
    * Gas cost per address in an EIP-2930 Access List transaction
    */


### PR DESCRIPTION
fixes #628


This change causes ganache to use its default chainId instead of the fork's chainId. This prevents replay attacks, but breaks `debug_traceTransaction` and `eth_call`. So this PR also makes `debug_traceTransaction` and `eth_call` "aware" of the chainId of the original chain so that they can use the correct chainId in block contexts that require it (on or before the fork block number).