### PR TITLE
fix: make docker publish work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,11 +103,18 @@ jobs:
             trufflesuite/ganache
             ghcr.io/${{ github.repository}}
 
+      - name: Set TAG and VERSION
+        run: |
+          echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          echo "VERSION=$(node -e 'console.log(require("./src/packages/ganache/package.json").version)')" >> $GITHUB_ENV
+
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
           file: ./src/packages/ganache/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ format('trufflesuite/ganache:{0}, trufflesuite/ganache:v{1}', env.TAG, env.VERSION) }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            INFURA_KEY=${{ secrets.INFURA_KEY }}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "postinstall": "ts-node scripts/postinstall",
     "reinstall": "npm run clean && npm install",
     "prepublishOnly": "ts-node ./scripts/filter-shrinkwrap.ts \"$(lerna list --parseable --scope ganache)\"/npm-shrinkwrap.json",
+    "postpublish": "git restore \"$(lerna list --parseable --scope ganache)\"/npm-shrinkwrap.json",
     "start": "lerna exec --loglevel=silent --scope ganache -- npm run start --silent -- ",
     "test": "lerna exec --concurrency 1 -- npm run test",
     "tsc": "ttsc --build src",

--- a/src/packages/ganache/Dockerfile
+++ b/src/packages/ganache/Dockerfile
@@ -9,6 +9,9 @@ COPY . .
 RUN npm run clean
 RUN npm ci --unsafe-perm
 
+# import INFURA_KEY environment variable (build-arg)
+ARG INFURA_KEY
+
 # build application
 RUN npm run build
 


### PR DESCRIPTION
A couple of things were happening:

1. The npm-shrinkwrap.json file is pruned during publish, but wasn't restored after publish
2. The INFURA_KEY env var wasn't passed to Docker
3. The INFURA_KEY env var wasn't added as an "ARG" within docker
4. The published tags were quite right; it will not be published with a tag of the version and the branch name (alpha, beta)*

Before we switch to stable (master) we'll need to change the TAG from using the branch name ("master") to "latest" everywhere (including the npm-related scripts)