### PR TITLE
fix: update equality checks for replacement transactions to prevent erroneous underpriced errors

### DIFF
--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -111,6 +111,9 @@ export enum TriageOption {
 export default class TransactionPool extends Emittery.Typed<{}, "drain"> {
   #options: EthereumInternalOptions["miner"];
 
+  /**
+   * Minimum price bump percentage needed to replace a transaction that already exists in the transaction pool.
+   */
   #priceBump: bigint;
 
   #blockchain: Blockchain;

--- a/src/chains/ethereum/options/src/miner-options.ts
+++ b/src/chains/ethereum/options/src/miner-options.ts
@@ -158,6 +158,18 @@ export type MinerConfig = {
       type: Data;
       hasDefault: true;
     };
+
+    /**
+     * Minimum price bump percentage needed to replace a transaction that already exists in the transaction pool.
+     *
+     * @defaultValue ""
+     */
+    priceBump: {
+      type: bigint;
+      rawType: number | bigint;
+      hasDefault: true;
+      cliType: string;
+    };
   };
 };
 
@@ -261,6 +273,13 @@ export const MinerOptions: Definitions<MinerConfig> = {
     },
     cliDescription: "Set the extraData block header field a miner can include.",
     default: () => DATA_EMPTY,
+    cliType: "string"
+  },
+  priceBump: {
+    normalize: BigInt,
+    cliDescription:
+      "Minimum price bump percentage needed to replace a transaction that already exists in the transaction pool.",
+    default: () => 10n,
     cliType: "string"
   }
 };

--- a/src/chains/ethereum/options/src/miner-options.ts
+++ b/src/chains/ethereum/options/src/miner-options.ts
@@ -166,7 +166,7 @@ export type MinerConfig = {
      */
     priceBump: {
       type: bigint;
-      rawType: number | bigint;
+      rawType: string | number | bigint;
       hasDefault: true;
       cliType: string;
     };

--- a/src/chains/ethereum/utils/src/errors/errors.ts
+++ b/src/chains/ethereum/utils/src/errors/errors.ts
@@ -43,4 +43,4 @@ export const VM_EXCEPTIONS =
  * Returned if a replacement transaction is sent while the potentially replaced transaction is being mined.
  */
 export const TRANSACTION_LOCKED =
-  "transaction can't be replaced, mining has already started. (we don't really know how you got here, couldy you open an issue with reproduction steps? https://github.com/trufflesuite/ganache/issues/new)";
+  "transaction can't be replaced, mining has already started. (please open an issue with reproduction steps: https://github.com/trufflesuite/ganache/issues/new)";

--- a/src/chains/ethereum/utils/src/errors/errors.ts
+++ b/src/chains/ethereum/utils/src/errors/errors.ts
@@ -38,3 +38,9 @@ export const VM_EXCEPTION = "VM Exception while processing transaction: ";
  */
 export const VM_EXCEPTIONS =
   "Multiple VM Exceptions while processing transactions: : \n\n";
+
+/**
+ * Returned if a replacement transaction is sent while the potentially replaced transaction is being mined.
+ */
+export const TRANSACTION_LOCKED =
+  "transaction can't be replaced, mining has already started. (we don't really know how you got here, couldy you open an issue with reproduction steps? https://github.com/trufflesuite/ganache/issues/new)";


### PR DESCRIPTION
Fixes bug where replacement transactions with `effectiveGasPrice = previousTxGasPrice + (previousTxGasPrice * priceBumpPercent` are not viable replacements (essentially a `<` to a `<=`). This edge case is actually pretty common because metamasks "Cancel transaction" functionality sets to this exact value.

Updates logic to verify replacement transactions so that `maxFeePerGas` and `maxPriorityFeePerGas` are both always checked against the previous transaction if the transactions have those fields. If not, those fields are defaulted to `gasPrice`. This is in line with geth's implementation.

Adds `--miner.priceBump` option to make the priceBump requirement configurable.