### PR TITLE
Add `eth_maxPriorityFeePerGas` RPC Method

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -1361,7 +1361,7 @@ export default class EthereumApi implements Api {
 
   /**
    * Returns a `maxPriorityFeePerGas` value suitable for quick transaction inclusion.
-   * @returns Integer of the maxPriorityFeePerGas in wei.
+   * @returns The maxPriorityFeePerGas in wei.
    * @example
    * ```javascript
    * const suggestedTip = await provider.request({ method: "eth_maxPriorityFeePerGas", params: [] });

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -36,7 +36,8 @@ import {
   keccak,
   RPCQUANTITY_ZERO,
   RPCQUANTITY_EMPTY,
-  JsonRpcErrorCode
+  JsonRpcErrorCode,
+  RPCQUANTITY_GWEI
 } from "@ganache/utils";
 import Blockchain from "./blockchain";
 import { EthereumInternalOptions } from "@ganache/ethereum-options";
@@ -58,6 +59,7 @@ async function autofillDefaultTransactionValues(
     tx: TypedRpcTransaction,
     tag: QUANTITY | Tag
   ) => Promise<Quantity>,
+  eth_maxPriorityFeePerGas: () => Promise<Quantity>,
   transaction: TypedRpcTransaction,
   blockchain: Blockchain,
   options: EthereumInternalOptions
@@ -80,6 +82,10 @@ async function autofillDefaultTransactionValues(
     tx.maxFeePerGas = Quantity.from(
       Block.calcNBlocksMaxBaseFee(3, <BaseFeeHeader>block.header)
     );
+  }
+
+  if ("maxPriorityFeePerGas" in tx && tx.maxPriorityFeePerGas.isNull()) {
+    tx.maxPriorityFeePerGas = await eth_maxPriorityFeePerGas();
   }
 }
 
@@ -1354,6 +1360,20 @@ export default class EthereumApi implements Api {
   }
 
   /**
+   * Returns a `maxPriorityFeePerGas` value suitable for quick transaction inclusion.
+   * @returns Integer of the maxPriorityFeePerGas in wei.
+   * @example
+   * ```javascript
+   * const suggestedTip = await provider.request({ method: "eth_maxPriorityFeePerGas", params: [] });
+   * console.log(suggestedTip);
+   * ```
+   */
+  @assertArgLength(0)
+  async eth_maxPriorityFeePerGas() {
+    return RPCQUANTITY_GWEI;
+  }
+
+  /**
    * Returns a list of addresses owned by client.
    * @returns Array of 20 Bytes - addresses owned by the client.
    * @example
@@ -1689,6 +1709,7 @@ export default class EthereumApi implements Api {
     await autofillDefaultTransactionValues(
       tx,
       this.eth_estimateGas.bind(this),
+      this.eth_maxPriorityFeePerGas,
       transaction,
       blockchain,
       this.#options
@@ -2886,6 +2907,7 @@ export default class EthereumApi implements Api {
     await autofillDefaultTransactionValues(
       tx,
       this.eth_estimateGas.bind(this),
+      this.eth_maxPriorityFeePerGas,
       transaction,
       blockchain,
       this.#options

--- a/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
@@ -1,3 +1,4 @@
+import { RPCQUANTITY_GWEI } from "@ganache/utils";
 import assert from "assert";
 import EthereumProvider from "../../../src/provider";
 import getProvider from "../../helpers/getProvider";
@@ -42,6 +43,13 @@ describe("api", () => {
       it("should return hashrate of zero", async () => {
         const result = await provider.send("eth_hashrate");
         assert.deepStrictEqual(result, "0x0");
+      });
+    });
+
+    describe("eth_maxPriorityFeePerGas", () => {
+      it("should return 1 GWEI", async () => {
+        const tip = await provider.send("eth_maxPriorityFeePerGas");
+        assert.strictEqual(tip, RPCQUANTITY_GWEI.toString());
       });
     });
 

--- a/src/chains/ethereum/transaction/src/transaction-factory.ts
+++ b/src/chains/ethereum/transaction/src/transaction-factory.ts
@@ -2,7 +2,7 @@ import {
   Data,
   JsonRpcErrorCode,
   Quantity,
-  RPCQUANTITY_ZERO
+  RPCQUANTITY_GWEI
 } from "@ganache/utils";
 import type Common from "@ethereumjs/common";
 import { LegacyTransaction } from "./legacy-transaction";
@@ -124,7 +124,7 @@ export class TransactionFactory {
               tx.maxFeePerGas = Quantity.from(null);
             }
             if (!txData.maxPriorityFeePerGas) {
-              tx.maxPriorityFeePerGas = RPCQUANTITY_ZERO;
+              tx.maxPriorityFeePerGas = RPCQUANTITY_GWEI;
             }
           }
           return tx;

--- a/src/packages/utils/src/utils/constants.ts
+++ b/src/packages/utils/src/utils/constants.ts
@@ -12,6 +12,7 @@ export const DATA_EMPTY = Data.from(BUFFER_EMPTY);
 export const RPCQUANTITY_EMPTY = Quantity.from(BUFFER_EMPTY, true);
 export const RPCQUANTITY_ZERO = Quantity.from(BUFFER_ZERO);
 export const RPCQUANTITY_ONE = Quantity.from(1n);
+export const RPCQUANTITY_GWEI = Quantity.from(1000000000);
 export const WEI = 1000000000000000000n as const;
 
 export const KNOWN_CHAINIDS = new Set([1, 3, 4, 5, 42]);


### PR DESCRIPTION
 - Adds `eth_maxPriorityFeePerGas` RPC Method which always returns 1 GWEI.
 - Defaults type 2 transactions with no user-set `maxPriorityFeePerGas` to 1 GWEI.
Fixes #1632 
