### PR TITLE
Fix Transaction Default Values

### DIFF
--- a/src/chains/ethereum/transaction/src/runtime-transaction.ts
+++ b/src/chains/ethereum/transaction/src/runtime-transaction.ts
@@ -94,8 +94,14 @@ export abstract class RuntimeTransaction extends BaseTransaction {
         data.to == null
           ? RPCQUANTITY_EMPTY
           : toValidLengthAddress(data.to, "to");
-      this.value = Quantity.from(data.value);
-      this.data = Data.from(data.data == null ? data.input : data.data);
+      this.value = Quantity.from(data.value || 0);
+      const dataVal =
+        data.data == null
+          ? data.input == null
+            ? "0x"
+            : data.input
+          : data.data;
+      this.data = Data.from(dataVal);
     }
   }
 

--- a/src/chains/ethereum/transaction/tests/index.test.ts
+++ b/src/chains/ethereum/transaction/tests/index.test.ts
@@ -327,9 +327,13 @@ describe("@ganache/ethereum-transaction", async () => {
       assert.strictEqual(jsonTx.from, tx.from);
       assert.strictEqual(jsonTx.to, tx.to);
       assert.strictEqual(jsonTx.value, tx.value);
+      // when this value is omitted, we set a default
+      assert.strictEqual(jsonTx.value.toString(), "0x0");
       assert.strictEqual(jsonTx.gas, tx.gas);
       assert.strictEqual(jsonTx.gasPrice, tx.gasPrice);
       assert.strictEqual(jsonTx.input, tx.data);
+      // when this value is omitted, we set a default
+      assert.strictEqual(jsonTx.input.toString(), "0x");
       assert.strictEqual(jsonTx.v, tx.v);
       assert.strictEqual(jsonTx.r, tx.r);
       assert.strictEqual(jsonTx.s, tx.s);
@@ -398,9 +402,13 @@ describe("@ganache/ethereum-transaction", async () => {
       assert.strictEqual(jsonTx.from, tx.from);
       assert.strictEqual(jsonTx.to, tx.to);
       assert.strictEqual(jsonTx.value, tx.value);
+      // when this value is omitted, we set a default
+      assert.strictEqual(jsonTx.value.toString(), "0x0");
       assert.strictEqual(jsonTx.gas, tx.gas);
       assert.strictEqual(jsonTx.gasPrice, tx.gasPrice);
       assert.strictEqual(jsonTx.input, tx.data);
+      // when this value is omitted, we set a default
+      assert.strictEqual(jsonTx.input.toString(), "0x");
       assert.strictEqual(jsonTx.v, tx.v);
       assert.strictEqual(jsonTx.r, tx.r);
       assert.strictEqual(jsonTx.s, tx.s);
@@ -473,11 +481,15 @@ describe("@ganache/ethereum-transaction", async () => {
       assert.strictEqual(jsonTx.from, tx.from);
       assert.strictEqual(jsonTx.to, tx.to);
       assert.strictEqual(jsonTx.value, tx.value);
+      // when this value is omitted, we set a default
+      assert.strictEqual(jsonTx.value.toString(), "0x0");
       assert.strictEqual(jsonTx.gas, tx.gas);
       assert.strictEqual(jsonTx.maxPriorityFeePerGas, tx.maxPriorityFeePerGas);
       assert.strictEqual(jsonTx.maxFeePerGas, tx.maxFeePerGas);
       assert.strictEqual(jsonTx.gasPrice, tx.effectiveGasPrice);
       assert.strictEqual(jsonTx.input, tx.data);
+      // when this value is omitted, we set a default
+      assert.strictEqual(jsonTx.input.toString(), "0x");
       assert.strictEqual(jsonTx.v, tx.v);
       assert.strictEqual(jsonTx.r, tx.r);
       assert.strictEqual(jsonTx.s, tx.s);


### PR DESCRIPTION
Fixes bug in fetching future-nonce transactions.

Before a transaction is mined, its `value` and `data` (aka `input`) fields could possibly be `undefined`. Once the transaction is mined (which, in most cases is immediately), the transaction data is serialized and those `undefined` values are converted to `0x`, which is the desired value for both the `value` and `data` when the fields are omitted by the user.

If a transaction is sent with a future nonce, however, it isn't immediately mined. If that transaction is retrieved via `eth_getTransactionByHash`, it has not yet been serialized. As such those two fields are `undefined` and completely missing from the resulting transaction object. Now, we give default values of `0` for `value` and `0x` for `data` when those fields are missing from a transaction.