### PR TITLE
fix: prevent DEBUG env var from crashing ganache

### DIFF
--- a/src/packages/ganache/webpack/polyfills/debug.ts
+++ b/src/packages/ganache/webpack/polyfills/debug.ts
@@ -1,0 +1,1 @@
+export const debug = () => () => {};

--- a/src/packages/ganache/webpack/webpack.browser.config.ts
+++ b/src/packages/ganache/webpack/webpack.browser.config.ts
@@ -35,7 +35,10 @@ const config: webpack.Configuration = merge({}, base, {
       // mcl-wasm may be needed when creating a new @ethereumjs/vm and requires a browser version for browsers
       "mcl-wasm": require.resolve("mcl-wasm/browser"),
       // ws doesn't work in the browser, isomorphic-ws does
-      ws: require.resolve("isomorphic-ws/")
+      ws: require.resolve("isomorphic-ws/"),
+      // we don't use the debug module internally, so let's just not include it
+      // in any package.
+      debug: require.resolve("./polyfills/debug")
     }
   },
   output: {

--- a/src/packages/ganache/webpack/webpack.common.config.ts
+++ b/src/packages/ganache/webpack/webpack.common.config.ts
@@ -72,9 +72,12 @@ const base: webpack.Configuration = {
     ]
   },
   plugins: [
-    new webpack.DefinePlugin({
+    new webpack.EnvironmentPlugin({
       // replace process.env.INFURA_KEY in our code
-      "process.env.INFURA_KEY": JSON.stringify(INFURA_KEY)
+      INFURA_KEY,
+      // replace process.env.DEBUG in our code, because we don't use it but
+      // ethereumjs packages do, but we don't implement everything required
+      DEBUG: false
     })
   ]
 };

--- a/src/packages/ganache/webpack/webpack.node.config.ts
+++ b/src/packages/ganache/webpack/webpack.node.config.ts
@@ -14,6 +14,14 @@ const config: webpack.Configuration = merge({}, base, {
     filename: "[name].js",
     path: path.resolve(__dirname, "../", "dist", "node")
   },
+  resolve: {
+    extensions: [".ts", ".js"],
+    alias: {
+      // we don't use the debug module internally, so let's just not include it
+      // in any package.
+      debug: require.resolve("./polyfills/debug")
+    }
+  },
   plugins: [
     // add a shebang at the top of the generated `cli.js`
     new webpack.BannerPlugin({


### PR DESCRIPTION
@ethereumjs/vm uses the `DEBUG` env var and the `debug` npm module to output debug information during runtime. We don't currently use the @ethereum/tx library for our transactions, so our transaction are "missing" some fields that are used only when DEBUG is true. This causes ganache to error when it shouldn't.

Other potential solutions:
 * implement all of the debug-related properties everywhere
 * use @ethereumjs/tx (and probably `/account`, and a `/block, too)
 
A benefit of just removing the `debug` module and replacing `process.env.DEBUG` with `false` is that the resulting build is smaller (and slightly faster due to the minifier removing dead code). Downside: no one can use `debug` for ganache's internals (I doubt anyone was wanting this anyway?) and if we want to use the debug module in the future we can't... because it's removed by the build process.
 