### PR TITLE
build: drop support for Node.js unsupported odd-numbered node versions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12.0.0, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x]
-        os: [windows-2019, ubuntu-18.04, ubuntu-20.04, macos-11.0]
+        node: [12.0.0, 12.x, 14.x, 16.x, 17.x]
+        os: [windows-2019, ubuntu-18.04, ubuntu-20.04, macos-11]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12.0.0, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x]
+        node: [12.0.0, 12.x, 14.x, 16.x, 17.x]
         os: [ubuntu-20.04]
 
     runs-on: ${{ matrix.os }}
@@ -34,12 +34,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # We start at Node 10.18.0 because it is the first version filecoin's
-        # CBOR package will let us install. Once filecoin is moved out of the
-        # monorepo we want to use 10.7.0 (earliest version the Ethereum side
-        # supports) or 10.13.0 (first node 10 LTS version).
-        node: [10.18.0, 10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x]
-        os: [windows-2019, ubuntu-18.04, ubuntu-20.04]
+        node: [12.0.0, 12.x, 14.x, 16.x, 17.x]
+        os: [windows-2019, ubuntu-18.04, ubuntu-20.04, macos-11]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
I'm starting to think running tests on Node 13 and 15 is annoying since no one should be using them anyway. I think we should support Node's LTS versions + the latest Node.js "supported" odd-numbered releases.

Also, something about the GitHub Actions Windows + Node 15 environment changed recently so tests fail because it can't build some filecoin dependency now. This will do away with that problem :-)