### PR TITLE
fix: version disparity between startup/`web3_clientVersion`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2150,24 +2150,6 @@
 			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
 			"dev": true
 		},
-		"@zerollup/ts-helpers": {
-			"version": "1.7.18",
-			"resolved": "https://registry.npmjs.org/@zerollup/ts-helpers/-/ts-helpers-1.7.18.tgz",
-			"integrity": "sha512-S9zN+y+i5yN/evfWquzSO3lubqPXIsPQf6p9OiPMpRxDx/0totPLF39XoRw48Dav5dSvbIE8D2eAPpXXJxvKwg==",
-			"dev": true,
-			"requires": {
-				"resolve": "^1.12.0"
-			}
-		},
-		"@zerollup/ts-transform-paths": {
-			"version": "1.7.18",
-			"resolved": "https://registry.npmjs.org/@zerollup/ts-transform-paths/-/ts-transform-paths-1.7.18.tgz",
-			"integrity": "sha512-YPVUxvWQVzRx1OBN0Pmkd58+R9FcfUJuwTaPUSoi5rKxuXMtxevTXdfi0w5mEaIH8b0DfL+wg0wFDHiJE+S2zA==",
-			"dev": true,
-			"requires": {
-				"@zerollup/ts-helpers": "^1.7.18"
-			}
-		},
 		"JSONStream": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -7659,12 +7641,6 @@
 					"dev": true
 				}
 			}
-		},
-		"ts-transformer-inline-file": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ts-transformer-inline-file/-/ts-transformer-inline-file-0.1.1.tgz",
-			"integrity": "sha512-2bPkAFjATsRG4ld8TFTUqn4TvEdXLQf/wwGsepFeRKSXLPqFRhdUHusAGPB1/Zif3CVjppD+bfne58gynd8RfQ==",
-			"dev": true
 		},
 		"tslib": {
 			"version": "1.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7648,15 +7648,6 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
-			}
-		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "semver": "7.3.5",
     "shx": "0.3.3",
     "ts-node": "9.1.1",
-    "ts-transformer-inline-file": "0.1.1",
     "ttypescript": "1.5.12",
     "typescript": "4.1.3",
     "validate-npm-package-name": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "postpublish": "git restore \"$(lerna list --parseable --scope ganache)\"/npm-shrinkwrap.json",
     "start": "lerna exec --loglevel=silent --scope ganache -- npm run start --silent -- ",
     "test": "lerna exec --concurrency 1 -- npm run test",
-    "tsc": "ttsc --build src",
+    "tsc": "tsc --build src",
     "tsc.clean": "npx lerna exec -- npx shx rm -rf lib dist typings"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@types/node": "16.11.6",
     "@types/prettier": "2.4.1",
     "@types/yargs": "16.0.0",
-    "@zerollup/ts-transform-paths": "1.7.18",
     "camelcase": "6.2.0",
     "chalk": "4.1.0",
     "cli-highlight": "2.1.10",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "semver": "7.3.5",
     "shx": "0.3.3",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3",
     "validate-npm-package-name": "3.0.0",
     "yargs": "16.2.0"

--- a/scripts/create.ts
+++ b/scripts/create.ts
@@ -166,7 +166,7 @@ process.stdout.write(`${COLORS.Reset}`);
         directory: `src/${location}/${folderName}`
       },
       scripts: {
-        tsc: "ttsc --build",
+        tsc: "tsc --build",
         test: "nyc npm run mocha",
         mocha:
           "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"

--- a/scripts/create.ts
+++ b/scripts/create.ts
@@ -169,7 +169,7 @@ process.stdout.write(`${COLORS.Reset}`);
         tsc: "ttsc --build",
         test: "nyc npm run mocha",
         mocha:
-          "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+          "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
       },
       bugs: {
         url: "https://github.com/trufflesuite/ganache/issues"

--- a/src/chains/ethereum/address/package-lock.json
+++ b/src/chains/ethereum/address/package-lock.json
@@ -815,12 +815,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -879,15 +873,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -952,15 +937,6 @@
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-extglob": {
@@ -1549,12 +1525,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
 		"picomatch": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -1656,16 +1626,6 @@
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			}
 		},
 		"resolve-from": {
 			"version": "5.0.0",
@@ -1861,15 +1821,6 @@
 					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"type-fest": {

--- a/src/chains/ethereum/address/package.json
+++ b/src/chains/ethereum/address/package.json
@@ -25,7 +25,7 @@
     "directory": "src/chains/ethereum/address"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "nyc npm run mocha",
     "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },

--- a/src/chains/ethereum/address/package.json
+++ b/src/chains/ethereum/address/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "tsc": "ttsc --build",
     "test": "nyc npm run mocha",
-    "mocha": "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -53,7 +53,6 @@
     "mocha": "9.1.3",
     "nyc": "15.1.0",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3"
   },
   "dependencies": {

--- a/src/chains/ethereum/block/package-lock.json
+++ b/src/chains/ethereum/block/package-lock.json
@@ -1043,12 +1043,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1107,15 +1101,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -1208,15 +1193,6 @@
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-extglob": {
@@ -1844,12 +1820,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
 		"pbkdf2": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
@@ -1977,16 +1947,6 @@
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			}
 		},
 		"resolve-from": {
 			"version": "5.0.0",
@@ -2242,15 +2202,6 @@
 					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"type-fest": {

--- a/src/chains/ethereum/block/package.json
+++ b/src/chains/ethereum/block/package.json
@@ -25,7 +25,7 @@
     "directory": "src/chains/ethereum/block"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "nyc npm run mocha",
     "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },

--- a/src/chains/ethereum/block/package.json
+++ b/src/chains/ethereum/block/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "tsc": "ttsc --build",
     "test": "nyc npm run mocha",
-    "mocha": "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -53,7 +53,6 @@
     "mocha": "9.1.3",
     "nyc": "15.1.0",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3"
   },
   "dependencies": {

--- a/src/chains/ethereum/ethereum/package-lock.json
+++ b/src/chains/ethereum/ethereum/package-lock.json
@@ -5040,15 +5040,6 @@
 			"integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
 			"dev": true
 		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
-			}
-		},
 		"tweetnacl": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",

--- a/src/chains/ethereum/ethereum/package-lock.json
+++ b/src/chains/ethereum/ethereum/package-lock.json
@@ -5034,12 +5034,6 @@
 				}
 			}
 		},
-		"ts-transformer-inline-file": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ts-transformer-inline-file/-/ts-transformer-inline-file-0.1.1.tgz",
-			"integrity": "sha512-2bPkAFjATsRG4ld8TFTUqn4TvEdXLQf/wwGsepFeRKSXLPqFRhdUHusAGPB1/Zif3CVjppD+bfne58gynd8RfQ==",
-			"dev": true
-		},
 		"tsscmp": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",

--- a/src/chains/ethereum/ethereum/package.json
+++ b/src/chains/ethereum/ethereum/package.json
@@ -28,7 +28,7 @@
     "docs.build": "rm -rf ./lib/docs ./lib/api.json && npm run docs.typedoc",
     "docs.typedoc": "typedoc --options ./typedoc.json --readme ./README.md --out ../../../../docs/typedoc --json ../../../../docs/typedoc/api.json src/api.ts",
     "docs.preview": "ws --open --port 3010 --directory ../../../../docs",
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "nyc --reporter lcov npm run mocha",
     "mocha": "cross-env TS_NODE_FILES=true mocha -s 0 --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },

--- a/src/chains/ethereum/ethereum/package.json
+++ b/src/chains/ethereum/ethereum/package.json
@@ -110,7 +110,6 @@
     "solc": "0.7.4",
     "superagent": "6.1.0",
     "ts-node": "9.1.1",
-    "ts-transformer-inline-file": "0.1.1",
     "ttypescript": "1.5.12",
     "typedoc": "0.17.8",
     "typescript": "4.1.3"

--- a/src/chains/ethereum/ethereum/package.json
+++ b/src/chains/ethereum/ethereum/package.json
@@ -30,7 +30,7 @@
     "docs.preview": "ws --open --port 3010 --directory ../../../../docs",
     "tsc": "ttsc --build",
     "test": "nyc --reporter lcov npm run mocha",
-    "mocha": "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha -s 0 --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "cross-env TS_NODE_FILES=true mocha -s 0 --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -110,7 +110,6 @@
     "solc": "0.7.4",
     "superagent": "6.1.0",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typedoc": "0.17.8",
     "typescript": "4.1.3"
   },

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -88,7 +88,7 @@ async function autofillDefaultTransactionValues(
   }
 }
 
-const version = process.env.VERSION;
+const version = process.env.VERSION || "DEV";
 //#endregion
 
 //#region Constants

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -42,7 +42,6 @@ import {
 import Blockchain from "./blockchain";
 import { EthereumInternalOptions } from "@ganache/ethereum-options";
 import Wallet from "./wallet";
-import { $INLINE_JSON } from "ts-transformer-inline-file";
 
 import Emittery from "emittery";
 import estimateGas from "./helpers/gas-estimator";
@@ -89,8 +88,7 @@ async function autofillDefaultTransactionValues(
   }
 }
 
-// Read in the current ganache version from core's package.json
-const { version } = $INLINE_JSON("../../../../packages/ganache/package.json");
+const version = process.env.VERSION;
 //#endregion
 
 //#region Constants

--- a/src/chains/ethereum/ethereum/tests/api/web3/web3.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/web3/web3.test.ts
@@ -1,7 +1,6 @@
 import getProvider from "../../helpers/getProvider";
 import assert from "assert";
 import EthereumProvider from "../../../src/provider";
-const { version } = require("../../../../../../packages/ganache/package.json");
 
 describe("api", () => {
   describe("web3", () => {
@@ -14,7 +13,7 @@ describe("api", () => {
       const result = await provider.send("web3_clientVersion");
       assert.deepStrictEqual(
         result,
-        `Ganache/v${version}/EthereumJS TestRPC/v${version}/ethereum-js`
+        `Ganache/vDEV/EthereumJS TestRPC/vDEV/ethereum-js`
       );
     });
 

--- a/src/chains/ethereum/options/package-lock.json
+++ b/src/chains/ethereum/options/package-lock.json
@@ -379,12 +379,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -419,15 +413,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -473,15 +458,6 @@
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-extglob": {
@@ -719,12 +695,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
 		"path-to-regexp": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
@@ -784,16 +754,6 @@
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			}
 		},
 		"ripemd160": {
 			"version": "2.0.2",
@@ -960,15 +920,6 @@
 					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"type-detect": {

--- a/src/chains/ethereum/options/package.json
+++ b/src/chains/ethereum/options/package.json
@@ -25,7 +25,7 @@
     "directory": "src/chains/ethereum/options"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "nyc npm run mocha",
     "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },

--- a/src/chains/ethereum/options/package.json
+++ b/src/chains/ethereum/options/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "tsc": "ttsc --build",
     "test": "nyc npm run mocha",
-    "mocha": "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -62,7 +62,6 @@
     "mocha": "9.1.3",
     "sinon": "12.0.1",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3"
   }
 }

--- a/src/chains/ethereum/options/src/fork-options.ts
+++ b/src/chains/ethereum/options/src/fork-options.ts
@@ -2,7 +2,7 @@ import { normalize } from "./helpers";
 import { Definitions, UnionToTuple } from "@ganache/options";
 import { Tag } from "@ganache/ethereum-utils";
 import { URL } from "url";
-const version = process.env.VERSION;
+const version = process.env.VERSION || "DEV";
 
 // we aren't going to treat block numbers as a bigint, so we don't want to
 // accept block numbers we can't add to

--- a/src/chains/ethereum/options/src/fork-options.ts
+++ b/src/chains/ethereum/options/src/fork-options.ts
@@ -1,9 +1,8 @@
 import { normalize } from "./helpers";
 import { Definitions, UnionToTuple } from "@ganache/options";
-import { $INLINE_JSON } from "ts-transformer-inline-file";
 import { Tag } from "@ganache/ethereum-utils";
 import { URL } from "url";
-const { version } = $INLINE_JSON("../../../../packages/ganache/package.json");
+const version = process.env.VERSION;
 
 // we aren't going to treat block numbers as a bigint, so we don't want to
 // accept block numbers we can't add to

--- a/src/chains/ethereum/transaction/package-lock.json
+++ b/src/chains/ethereum/transaction/package-lock.json
@@ -1341,12 +1341,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -1411,15 +1405,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -1524,15 +1509,6 @@
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-extglob": {
@@ -2379,12 +2355,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
 		"pbkdf2": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
@@ -2518,16 +2488,6 @@
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			}
 		},
 		"resolve-from": {
 			"version": "5.0.0",
@@ -2795,15 +2755,6 @@
 					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"type-fest": {

--- a/src/chains/ethereum/transaction/package.json
+++ b/src/chains/ethereum/transaction/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "tsc": "ttsc --build",
     "test": "nyc npm run mocha",
-    "mocha": "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -64,7 +64,6 @@
     "mocha": "9.1.3",
     "nyc": "15.1.0",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3"
   }
 }

--- a/src/chains/ethereum/transaction/package.json
+++ b/src/chains/ethereum/transaction/package.json
@@ -25,7 +25,7 @@
     "directory": "src/chains/ethereum/transaction"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "nyc npm run mocha",
     "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },

--- a/src/chains/ethereum/utils/package-lock.json
+++ b/src/chains/ethereum/utils/package-lock.json
@@ -807,12 +807,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -852,15 +846,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -935,15 +920,6 @@
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-extglob": {
@@ -1375,12 +1351,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
 		"pbkdf2": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
@@ -1441,16 +1411,6 @@
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			}
 		},
 		"ripemd160": {
 			"version": "2.0.2",
@@ -1640,15 +1600,6 @@
 					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"typescript": {

--- a/src/chains/ethereum/utils/package.json
+++ b/src/chains/ethereum/utils/package.json
@@ -25,7 +25,7 @@
     "directory": "src/chains/ethereum/utils"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "nyc npm run mocha",
     "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },

--- a/src/chains/ethereum/utils/package.json
+++ b/src/chains/ethereum/utils/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "tsc": "ttsc --build",
     "test": "nyc npm run mocha",
-    "mocha": "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -63,7 +63,6 @@
     "cross-env": "7.0.3",
     "mocha": "9.1.3",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3"
   }
 }

--- a/src/chains/filecoin/filecoin/package-lock.json
+++ b/src/chains/filecoin/filecoin/package-lock.json
@@ -10257,12 +10257,6 @@
 				"yn": "3.1.1"
 			}
 		},
-		"ts-transformer-inline-file": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ts-transformer-inline-file/-/ts-transformer-inline-file-0.1.1.tgz",
-			"integrity": "sha512-2bPkAFjATsRG4ld8TFTUqn4TvEdXLQf/wwGsepFeRKSXLPqFRhdUHusAGPB1/Zif3CVjppD+bfne58gynd8RfQ==",
-			"dev": true
-		},
 		"ttypescript": {
 			"version": "1.5.12",
 			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",

--- a/src/chains/filecoin/filecoin/package-lock.json
+++ b/src/chains/filecoin/filecoin/package-lock.json
@@ -10257,15 +10257,6 @@
 				"yn": "3.1.1"
 			}
 		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
-			}
-		},
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",

--- a/src/chains/filecoin/filecoin/package.json
+++ b/src/chains/filecoin/filecoin/package.json
@@ -94,7 +94,6 @@
     "tmp-promise": "3.0.2",
     "ts-loader": "8.0.7",
     "ts-node": "9.1.1",
-    "ts-transformer-inline-file": "0.1.1",
     "ttypescript": "1.5.12",
     "typedoc": "0.17.8",
     "typescript": "4.1.3",

--- a/src/chains/filecoin/filecoin/package.json
+++ b/src/chains/filecoin/filecoin/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "build": "webpack",
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "ts-node ../../../../scripts/require-engines.ts || nyc --reporter lcov npm run mocha",
     "mocha": "ts-node ../../../../scripts/require-engines.ts || cross-env TS_NODE_FILES=true TS_NODE_PROJECT=tsconfig.test.json mocha --timeout 60000 --no-parallel --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },

--- a/src/chains/filecoin/filecoin/package.json
+++ b/src/chains/filecoin/filecoin/package.json
@@ -31,7 +31,7 @@
     "build": "webpack",
     "tsc": "ttsc --build",
     "test": "ts-node ../../../../scripts/require-engines.ts || nyc --reporter lcov npm run mocha",
-    "mocha": "ts-node ../../../../scripts/require-engines.ts || cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true TS_NODE_PROJECT=tsconfig.test.json mocha --timeout 60000 --no-parallel --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "ts-node ../../../../scripts/require-engines.ts || cross-env TS_NODE_FILES=true TS_NODE_PROJECT=tsconfig.test.json mocha --timeout 60000 --no-parallel --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -94,7 +94,6 @@
     "tmp-promise": "3.0.2",
     "ts-loader": "8.0.7",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typedoc": "0.17.8",
     "typescript": "4.1.3",
     "webpack": "5.21.2",

--- a/src/chains/filecoin/filecoin/src/things/version.ts
+++ b/src/chains/filecoin/filecoin/src/things/version.ts
@@ -4,9 +4,8 @@ import {
   SerializedObject,
   Definitions
 } from "./serializable-object";
-import { $INLINE_JSON } from "ts-transformer-inline-file";
 
-const { version: GanacheFilecoinVersion } = $INLINE_JSON("../../package.json");
+const GanacheFilecoinVersion = process.env.GANACHE_FILECOIN_VERSION;
 
 // https://pkg.go.dev/github.com/filecoin-project/lotus@v1.4.0/api#Version
 

--- a/src/chains/filecoin/filecoin/src/things/version.ts
+++ b/src/chains/filecoin/filecoin/src/things/version.ts
@@ -5,7 +5,7 @@ import {
   Definitions
 } from "./serializable-object";
 
-const GanacheFilecoinVersion = process.env.GANACHE_FILECOIN_VERSION;
+const GanacheFilecoinVersion = process.env.GANACHE_FILECOIN_VERSION || "DEV";
 
 // https://pkg.go.dev/github.com/filecoin-project/lotus@v1.4.0/api#Version
 

--- a/src/chains/filecoin/filecoin/webpack/webpack.common.config.ts
+++ b/src/chains/filecoin/filecoin/webpack/webpack.common.config.ts
@@ -11,19 +11,7 @@ const base: webpack.Configuration = {
         test: /\.tsx?$/,
         use: [
           {
-            loader: "ts-loader",
-            options: {
-              // we need to use ttypescript because we use ts transformers
-              compiler: "ttypescript",
-              // Symlinked paths to our packages aren't resolving correctly...
-              // E.g., if PackageA and PackageB both import PackageC, the
-              // compiler assumes PackageA's PackageC is incompatible with
-              // PackageB's PackageC.
-              // Note: if all packages are precompiled before running webpack
-              // this issue doesn't occur, which makes me think this might be a
-              // ts-loader issue.
-              transpileOnly: true
-            }
+            loader: "ts-loader"
           }
         ]
       }

--- a/src/chains/filecoin/options/package-lock.json
+++ b/src/chains/filecoin/options/package-lock.json
@@ -1778,15 +1778,6 @@
 				}
 			}
 		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
-			}
-		},
 		"typescript": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",

--- a/src/chains/filecoin/options/package.json
+++ b/src/chains/filecoin/options/package.json
@@ -29,7 +29,7 @@
     "build": "webpack",
     "tsc": "ttsc --build",
     "test": "nyc npm run mocha",
-    "mocha": "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -61,7 +61,6 @@
     "terser-webpack-plugin": "5.0.3",
     "ts-loader": "8.0.7",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3",
     "webpack": "5.21.2",
     "webpack-cli": "4.5.0"

--- a/src/chains/filecoin/options/package.json
+++ b/src/chains/filecoin/options/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "webpack",
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "nyc npm run mocha",
     "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },

--- a/src/chains/filecoin/options/webpack/webpack.common.config.ts
+++ b/src/chains/filecoin/options/webpack/webpack.common.config.ts
@@ -11,19 +11,7 @@ const base: webpack.Configuration = {
         test: /\.tsx?$/,
         use: [
           {
-            loader: "ts-loader",
-            options: {
-              // we need to use ttypescript because we use ts transformers
-              compiler: "ttypescript",
-              // Symlinked paths to our packages aren't resolving correctly...
-              // E.g., if PackageA and PackageB both import PackageC, the
-              // compiler assumes PackageA's PackageC is incompatible with
-              // PackageB's PackageC.
-              // Note: if all packages are precompiled before running webpack
-              // this issue doesn't occur, which makes me think this might be a
-              // ts-loader issue.
-              transpileOnly: true
-            }
+            loader: "ts-loader"
           }
         ]
       }

--- a/src/chains/tezos/options/package-lock.json
+++ b/src/chains/tezos/options/package-lock.json
@@ -288,12 +288,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -328,15 +322,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -373,15 +358,6 @@
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-extglob": {
@@ -567,12 +543,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
 		"picomatch": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -602,16 +572,6 @@
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			}
 		},
 		"safe-buffer": {
 			"version": "5.2.1",
@@ -723,15 +683,6 @@
 					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"typescript": {

--- a/src/chains/tezos/options/package.json
+++ b/src/chains/tezos/options/package.json
@@ -25,7 +25,7 @@
     "directory": "src/chains/tezos/options"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "nyc npm run mocha",
     "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },

--- a/src/chains/tezos/options/package.json
+++ b/src/chains/tezos/options/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "tsc": "ttsc --build",
     "test": "nyc npm run mocha",
-    "mocha": "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -52,7 +52,6 @@
     "cross-env": "7.0.3",
     "mocha": "9.1.3",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3"
   }
 }

--- a/src/chains/tezos/tezos/package-lock.json
+++ b/src/chains/tezos/tezos/package-lock.json
@@ -2461,15 +2461,6 @@
 			"integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
 			"dev": true
 		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
-			}
-		},
 		"type-is": {
 			"version": "1.6.18",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",

--- a/src/chains/tezos/tezos/package.json
+++ b/src/chains/tezos/tezos/package.json
@@ -25,7 +25,7 @@
     "directory": "src/chains/tezos/tezos"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "echo 'no tests'"
   },
   "bugs": {

--- a/src/chains/tezos/tezos/package.json
+++ b/src/chains/tezos/tezos/package.json
@@ -55,7 +55,6 @@
     "local-web-server": "4.2.1",
     "mocha": "9.1.3",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typedoc": "0.17.8",
     "typescript": "4.1.3"
   }

--- a/src/packages/cli/package-lock.json
+++ b/src/packages/cli/package-lock.json
@@ -499,12 +499,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -539,15 +533,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -611,15 +596,6 @@
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-extglob": {
@@ -882,12 +858,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
 		"pbkdf2": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
@@ -946,16 +916,6 @@
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			}
 		},
 		"ripemd160": {
 			"version": "2.0.2",
@@ -1128,15 +1088,6 @@
 					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"type-fest": {

--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -31,8 +31,8 @@
   "scripts": {
     "tsc": "ttsc --build",
     "test": "nyc npm run mocha",
-    "mocha": "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'",
-    "start": "cross-env TS_NODE_COMPILER=ttypescript node --require ts-node/register --inspect src/cli.ts"
+    "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'",
+    "start": "cross-env node --require ts-node/register --inspect src/cli.ts"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -59,7 +59,6 @@
     "cross-env": "7.0.3",
     "mocha": "9.1.3",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3"
   },
   "dependencies": {

--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -29,7 +29,7 @@
     "directory": "src/packages/cli"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "nyc npm run mocha",
     "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'",
     "start": "cross-env node --require ts-node/register --inspect src/cli.ts"

--- a/src/packages/cli/src/cli.ts
+++ b/src/packages/cli/src/cli.ts
@@ -2,7 +2,6 @@
 
 import type Readline from "readline";
 import Ganache, { ServerStatus } from "@ganache/core";
-import { $INLINE_JSON } from "ts-transformer-inline-file";
 import args from "./args";
 import { EthereumFlavorName, FilecoinFlavorName } from "@ganache/flavors";
 import initializeEthereum from "./initialize/ethereum";
@@ -29,9 +28,10 @@ const logAndForceExit = (messages: any[], exitCode = 0) => {
   process.exit(exitCode);
 };
 
-const { version: coreVersion } = $INLINE_JSON("../../core/package.json");
-const { version: cliVersion } = $INLINE_JSON("../package.json");
-const { version } = $INLINE_JSON("../../ganache/package.json");
+const version = process.env.VERSION;
+const cliVersion = process.env.CLI_VERSION;
+const coreVersion = process.env.CORE_VERSION;
+
 const detailedVersion = `ganache v${version} (@ganache/cli: ${cliVersion}, @ganache/core: ${coreVersion})`;
 
 const isDocker =

--- a/src/packages/cli/src/cli.ts
+++ b/src/packages/cli/src/cli.ts
@@ -28,9 +28,9 @@ const logAndForceExit = (messages: any[], exitCode = 0) => {
   process.exit(exitCode);
 };
 
-const version = process.env.VERSION;
-const cliVersion = process.env.CLI_VERSION;
-const coreVersion = process.env.CORE_VERSION;
+const version = process.env.VERSION || "DEV";
+const cliVersion = process.env.CLI_VERSION || "DEV";
+const coreVersion = process.env.CORE_VERSION || "DEV";
 
 const detailedVersion = `ganache v${version} (@ganache/cli: ${cliVersion}, @ganache/core: ${coreVersion})`;
 

--- a/src/packages/colors/package-lock.json
+++ b/src/packages/colors/package-lock.json
@@ -288,12 +288,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -328,15 +322,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -373,15 +358,6 @@
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-extglob": {
@@ -567,12 +543,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
 		"picomatch": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -602,16 +572,6 @@
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			}
 		},
 		"safe-buffer": {
 			"version": "5.2.1",
@@ -723,15 +683,6 @@
 					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"typescript": {

--- a/src/packages/colors/package.json
+++ b/src/packages/colors/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "tsc": "ttsc --build",
     "test": "nyc npm run mocha",
-    "mocha": "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -44,7 +44,6 @@
     "cross-env": "7.0.3",
     "mocha": "9.1.3",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3"
   }
 }

--- a/src/packages/colors/package.json
+++ b/src/packages/colors/package.json
@@ -25,7 +25,7 @@
     "directory": "src/packages/colors"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "nyc npm run mocha",
     "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },

--- a/src/packages/core/package-lock.json
+++ b/src/packages/core/package-lock.json
@@ -1239,15 +1239,6 @@
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
 			"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
 		},
-		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
-			}
-		},
 		"is-date-object": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
@@ -1964,12 +1955,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
 		"picomatch": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -2095,16 +2080,6 @@
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			}
 		},
 		"resolve-from": {
 			"version": "5.0.0",
@@ -2405,15 +2380,6 @@
 					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"type-fest": {

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -25,7 +25,7 @@
     "directory": "src/packages/core"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "nyc npm run mocha && npm run mocha:fallback",
     "mocha:fallback": "cross-env UWS_USE_FALLBACK=true npm run mocha",
     "mocha": "cross-env TS_NODE_PROJECT=tsconfig.json TS_NODE_FILES=true mocha --exit --colors --throw-deprecation --trace-warnings --check-leaks --require ts-node/register 'tests/**/*.test.ts'"

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -28,7 +28,7 @@
     "tsc": "ttsc --build",
     "test": "nyc npm run mocha && npm run mocha:fallback",
     "mocha:fallback": "cross-env UWS_USE_FALLBACK=true npm run mocha",
-    "mocha": "cross-env TS_NODE_PROJECT=tsconfig.json TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha --exit --colors --throw-deprecation --trace-warnings --check-leaks --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "cross-env TS_NODE_PROJECT=tsconfig.json TS_NODE_FILES=true mocha --exit --colors --throw-deprecation --trace-warnings --check-leaks --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -67,7 +67,6 @@
     "nyc": "15.1.0",
     "superagent": "6.1.0",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3",
     "ws": "8.2.3"
   }

--- a/src/packages/flavors/package-lock.json
+++ b/src/packages/flavors/package-lock.json
@@ -273,12 +273,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -314,15 +308,6 @@
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
 		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
 		"has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -357,15 +342,6 @@
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-extglob": {
@@ -562,12 +538,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
 		"picomatch": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -597,16 +567,6 @@
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			}
 		},
 		"safe-buffer": {
 			"version": "5.2.1",
@@ -717,15 +677,6 @@
 					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"typescript": {

--- a/src/packages/flavors/package.json
+++ b/src/packages/flavors/package.json
@@ -25,7 +25,7 @@
     "directory": "src/packages/flavors"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "echo 'no tests'"
   },
   "bugs": {

--- a/src/packages/flavors/package.json
+++ b/src/packages/flavors/package.json
@@ -61,7 +61,6 @@
     "cross-env": "7.0.3",
     "mocha": "9.1.3",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3"
   }
 }

--- a/src/packages/ganache/npm-shrinkwrap.json
+++ b/src/packages/ganache/npm-shrinkwrap.json
@@ -2623,15 +2623,6 @@
 				}
 			}
 		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
-			}
-		},
 		"typescript": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",

--- a/src/packages/ganache/npm-shrinkwrap.json
+++ b/src/packages/ganache/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
 	"name": "ganache",
-	"version": "7.0.0-alpha.2",
+	"version": "7.0.0-beta.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/packages/ganache/package.json
+++ b/src/packages/ganache/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "npm run tsc && npx shx rm -rf ./dist && webpack",
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "nyc npm run mocha",
     "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'",
     "start": "cross-env node --require ts-node/register --inspect src/cli.ts"

--- a/src/packages/ganache/package.json
+++ b/src/packages/ganache/package.json
@@ -30,8 +30,8 @@
     "build": "npm run tsc && npx shx rm -rf ./dist && webpack",
     "tsc": "ttsc --build",
     "test": "nyc npm run mocha",
-    "mocha": "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'",
-    "start": "cross-env TS_NODE_COMPILER=ttypescript node --require ts-node/register --inspect src/cli.ts"
+    "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'",
+    "start": "cross-env node --require ts-node/register --inspect src/cli.ts"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -77,7 +77,6 @@
     "terser-webpack-plugin": "5.0.3",
     "ts-loader": "8.0.7",
     "ts-node": "9.0.0",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3",
     "util": "0.12.3",
     "webpack": "5.21.2",

--- a/src/packages/ganache/webpack/webpack.common.config.ts
+++ b/src/packages/ganache/webpack/webpack.common.config.ts
@@ -1,5 +1,16 @@
 import webpack from "webpack";
 import TerserPlugin from "terser-webpack-plugin";
+import path from "path";
+
+const VERSION = require(path.join(__dirname, "../package.json")).version;
+const CLI_VERSION = require(path.join(__dirname, "../../cli/package.json"))
+  .version;
+const CORE_VERSION = require(path.join(__dirname, "../../core/package.json"))
+  .version;
+const GANACHE_FILECOIN_VERSION = require(path.join(
+  __dirname,
+  "../../../chains/filecoin/filecoin/package.json"
+)).version;
 
 let INFURA_KEY = process.env.INFURA_KEY;
 // if we don't have an INFURA_KEY at build time we should bail!
@@ -73,11 +84,18 @@ const base: webpack.Configuration = {
   },
   plugins: [
     new webpack.EnvironmentPlugin({
-      // replace process.env.INFURA_KEY in our code
-      INFURA_KEY,
       // replace process.env.DEBUG in our code, because we don't use it but
       // ethereumjs packages do, but we don't implement everything required
-      DEBUG: false
+      DEBUG: false,
+      // set ganache version
+      VERSION,
+      CLI_VERSION,
+      CORE_VERSION,
+      GANACHE_FILECOIN_VERSION
+    }),
+    new webpack.DefinePlugin({
+      // replace process.env.INFURA_KEY in our code
+      "process.env.INFURA_KEY": JSON.stringify(INFURA_KEY)
     })
   ]
 };

--- a/src/packages/ganache/webpack/webpack.common.config.ts
+++ b/src/packages/ganache/webpack/webpack.common.config.ts
@@ -42,11 +42,7 @@ const base: webpack.Configuration = {
         test: /\.tsx?$/,
         use: [
           {
-            loader: "ts-loader",
-            options: {
-              // we need to use ttypescript because we use ts transformers
-              compiler: "ttypescript"
-            }
+            loader: "ts-loader"
           }
         ]
       }

--- a/src/packages/options/package-lock.json
+++ b/src/packages/options/package-lock.json
@@ -338,12 +338,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -378,15 +372,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -432,15 +417,6 @@
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-extglob": {
@@ -636,12 +612,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
 		"pbkdf2": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
@@ -692,16 +662,6 @@
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			}
 		},
 		"ripemd160": {
 			"version": "2.0.2",
@@ -843,15 +803,6 @@
 					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"typescript": {

--- a/src/packages/options/package.json
+++ b/src/packages/options/package.json
@@ -54,7 +54,6 @@
     "cross-env": "7.0.3",
     "mocha": "9.1.3",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3"
   }
 }

--- a/src/packages/options/package.json
+++ b/src/packages/options/package.json
@@ -24,7 +24,7 @@
     "directory": "src/packages/options"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "echo 'no tests'"
   },
   "bugs": {

--- a/src/packages/promise-queue/package-lock.json
+++ b/src/packages/promise-queue/package-lock.json
@@ -293,12 +293,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -333,15 +327,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -378,15 +363,6 @@
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-extglob": {
@@ -572,12 +548,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
 		"picomatch": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -607,16 +577,6 @@
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			}
 		},
 		"safe-buffer": {
 			"version": "5.2.1",
@@ -728,15 +688,6 @@
 					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"typescript": {

--- a/src/packages/promise-queue/package.json
+++ b/src/packages/promise-queue/package.json
@@ -25,7 +25,7 @@
     "directory": "src/packages/promise-queue"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "nyc npm run mocha",
     "mocha": "cross-env TS_NODE_FILES=true mocha --exit --require ts-node/register --recursive --check-leaks 'tests/**.ts'"
   },

--- a/src/packages/promise-queue/package.json
+++ b/src/packages/promise-queue/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "tsc": "ttsc --build",
     "test": "nyc npm run mocha",
-    "mocha": "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha --exit --require ts-node/register --recursive --check-leaks 'tests/**.ts'"
+    "mocha": "cross-env TS_NODE_FILES=true mocha --exit --require ts-node/register --recursive --check-leaks 'tests/**.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -54,7 +54,6 @@
     "cross-env": "7.0.3",
     "mocha": "9.1.3",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3"
   }
 }

--- a/src/packages/rlp/package-lock.json
+++ b/src/packages/rlp/package-lock.json
@@ -820,12 +820,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -884,15 +878,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -957,15 +942,6 @@
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-extglob": {
@@ -1554,12 +1530,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
 		"picomatch": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -1661,16 +1631,6 @@
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			}
 		},
 		"resolve-from": {
 			"version": "5.0.0",
@@ -1874,15 +1834,6 @@
 					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"type-fest": {

--- a/src/packages/rlp/package.json
+++ b/src/packages/rlp/package.json
@@ -25,7 +25,7 @@
     "directory": "src/packages/rlp"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "nyc npm run mocha",
     "mocha": "cross-env DE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },

--- a/src/packages/rlp/package.json
+++ b/src/packages/rlp/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "tsc": "ttsc --build",
     "test": "nyc npm run mocha",
-    "mocha": "cross-env TS_NODE_COMPILER=ttypescript DE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "cross-env DE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -57,7 +57,6 @@
     "mocha": "9.1.3",
     "nyc": "15.1.0",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3"
   }
 }

--- a/src/packages/secp256k1/package-lock.json
+++ b/src/packages/secp256k1/package-lock.json
@@ -839,12 +839,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -903,15 +897,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -994,15 +979,6 @@
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-core-module": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-			"integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-extglob": {
@@ -1611,12 +1587,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
 		"picomatch": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -1718,16 +1688,6 @@
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			}
 		},
 		"resolve-from": {
 			"version": "5.0.0",
@@ -1933,15 +1893,6 @@
 					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"type-fest": {

--- a/src/packages/secp256k1/package.json
+++ b/src/packages/secp256k1/package.json
@@ -25,7 +25,7 @@
     "directory": "src/packages/secp256k1"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "nyc npm run mocha",
     "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },

--- a/src/packages/secp256k1/package.json
+++ b/src/packages/secp256k1/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "tsc": "ttsc --build",
     "test": "nyc npm run mocha",
-    "mocha": "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "cross-env TS_NODE_FILES=true mocha --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -53,7 +53,6 @@
     "mocha": "9.1.3",
     "nyc": "15.1.0",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3"
   },
   "dependencies": {

--- a/src/packages/utils/package-lock.json
+++ b/src/packages/utils/package-lock.json
@@ -381,12 +381,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -421,15 +415,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -466,15 +451,6 @@
 			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-extglob": {
@@ -710,12 +686,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
-		},
 		"path-to-regexp": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
@@ -754,16 +724,6 @@
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			}
 		},
 		"safe-buffer": {
 			"version": "5.2.1",
@@ -905,15 +865,6 @@
 					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
 				}
-			}
-		},
-		"ttypescript": {
-			"version": "1.5.12",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
-			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
-			"dev": true,
-			"requires": {
-				"resolve": ">=1.9.0"
 			}
 		},
 		"type-detect": {

--- a/src/packages/utils/package.json
+++ b/src/packages/utils/package.json
@@ -25,7 +25,7 @@
     "directory": "src/packages/utils"
   },
   "scripts": {
-    "tsc": "ttsc --build",
+    "tsc": "tsc --build",
     "test": "npm run mocha",
     "mocha": "cross-env TS_NODE_FILES=true mocha -s 0 -t 0 --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },

--- a/src/packages/utils/package.json
+++ b/src/packages/utils/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "tsc": "ttsc --build",
     "test": "npm run mocha",
-    "mocha": "cross-env TS_NODE_COMPILER=ttypescript TS_NODE_FILES=true mocha -s 0 -t 0 --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
+    "mocha": "cross-env TS_NODE_FILES=true mocha -s 0 -t 0 --exit --check-leaks --throw-deprecation --trace-warnings --require ts-node/register 'tests/**/*.test.ts'"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/ganache/issues"
@@ -59,7 +59,6 @@
     "mocha": "9.1.3",
     "sinon": "11.1.2",
     "ts-node": "9.1.1",
-    "ttypescript": "1.5.12",
     "typescript": "4.1.3"
   },
   "optionalDependencies": {

--- a/src/tsconfig-base.json
+++ b/src/tsconfig-base.json
@@ -16,12 +16,6 @@
     "noImplicitAny": false,
     "newLine": "lf",
     "lib": ["ES2020"],
-    "experimentalDecorators": true,
-    "plugins": [
-      {
-        "transform": "@zerollup/ts-transform-paths",
-        "exclude": "*"
-      }
-    ]
+    "experimentalDecorators": true
   }
 }

--- a/src/tsconfig-base.json
+++ b/src/tsconfig-base.json
@@ -15,14 +15,9 @@
     "strictNullChecks": false,
     "noImplicitAny": false,
     "newLine": "lf",
-    "lib": [
-      "ES2020"
-    ],
+    "lib": ["ES2020"],
     "experimentalDecorators": true,
     "plugins": [
-      {
-        "transform": "ts-transformer-inline-file/transformer"
-      },
       {
         "transform": "@zerollup/ts-transform-paths",
         "exclude": "*"


### PR DESCRIPTION
Fixes issue with startup version being different from version received when using `web3_clientVersion` by using webpack to set version environment variables on build. Uses "DEV" version as fallback when environment variables aren't availble.

Positive side affect is we were able to remove ts-transformer-inline-file lib. 