### PR TITLE
fix: make `Tag` type usable

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -67,7 +67,7 @@ async function autofillDefaultTransactionValues(
     const defaultLimit = options.miner.defaultTransactionGasLimit;
     if (defaultLimit === RPCQUANTITY_EMPTY) {
       // if the default limit is `RPCQUANTITY_EMPTY` use a gas estimate
-      tx.gas = await eth_estimateGas(transaction, Tag.LATEST);
+      tx.gas = await eth_estimateGas(transaction, Tag.latest);
     } else {
       tx.gas = defaultLimit;
     }
@@ -147,7 +147,10 @@ function assertExceptionalTransactions(transactions: TypedTransaction[]) {
 export default class EthereumApi implements Api {
   readonly [index: string]: (...args: any) => Promise<any>;
 
-  readonly #getId = (id => () => Quantity.from(++id))(0);
+  readonly #getId = (
+    id => () =>
+      Quantity.from(++id)
+  )(0);
   readonly #filters = new Map<string, Filter>();
   readonly #subscriptions = new Map<string, Emittery.UnsubscribeFn>();
   readonly #options: EthereumInternalOptions;
@@ -784,7 +787,7 @@ export default class EthereumApi implements Api {
   @assertArgLength(1, 2)
   async eth_estimateGas(
     transaction: TypedRpcTransaction,
-    blockNumber: QUANTITY | Tag = Tag.LATEST
+    blockNumber: QUANTITY | Tag = Tag.latest
   ): Promise<Quantity> {
     const blockchain = this.#blockchain;
     const blocks = blockchain.blocks;
@@ -1439,7 +1442,7 @@ export default class EthereumApi implements Api {
   @assertArgLength(1, 2)
   async eth_getBalance(
     address: DATA,
-    blockNumber: QUANTITY | Tag = Tag.LATEST
+    blockNumber: QUANTITY | Tag = Tag.latest
   ) {
     return this.#blockchain.accounts.getBalance(
       Address.from(address),
@@ -1476,7 +1479,7 @@ export default class EthereumApi implements Api {
    * ```
    */
   @assertArgLength(1, 2)
-  async eth_getCode(address: DATA, blockNumber: QUANTITY | Tag = Tag.LATEST) {
+  async eth_getCode(address: DATA, blockNumber: QUANTITY | Tag = Tag.latest) {
     const { accounts } = this.#blockchain;
     return accounts.getCode(Address.from(address), blockNumber);
   }
@@ -1514,7 +1517,7 @@ export default class EthereumApi implements Api {
   async eth_getStorageAt(
     address: DATA,
     position: QUANTITY,
-    blockNumber: QUANTITY | Tag = Tag.LATEST
+    blockNumber: QUANTITY | Tag = Tag.latest
   ) {
     const blockchain = this.#blockchain;
     const blockNum = blockchain.blocks.getEffectiveNumber(blockNumber);
@@ -1622,12 +1625,8 @@ export default class EthereumApi implements Api {
    */
   @assertArgLength(1)
   async eth_getTransactionReceipt(transactionHash: DATA) {
-    const {
-      transactions,
-      transactionReceipts,
-      blocks,
-      common
-    } = this.#blockchain;
+    const { transactions, transactionReceipts, blocks, common } =
+      this.#blockchain;
     const dataHash = Data.from(transactionHash);
     const txHash = dataHash.toBuffer();
 
@@ -2473,7 +2472,7 @@ export default class EthereumApi implements Api {
   @assertArgLength(1, 2)
   async eth_getTransactionCount(
     address: DATA,
-    blockNumber: QUANTITY | Tag = Tag.LATEST
+    blockNumber: QUANTITY | Tag = Tag.latest
   ) {
     return this.#blockchain.accounts.getNonce(
       Address.from(address),
@@ -2517,7 +2516,7 @@ export default class EthereumApi implements Api {
    * ```
    */
   @assertArgLength(1, 2)
-  async eth_call(transaction: any, blockNumber: QUANTITY | Tag = Tag.LATEST) {
+  async eth_call(transaction: any, blockNumber: QUANTITY | Tag = Tag.latest) {
     const blockchain = this.#blockchain;
     const common = this.#blockchain.common;
     const blocks = blockchain.blocks;

--- a/src/chains/ethereum/ethereum/src/data-managers/account-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/account-manager.ts
@@ -18,7 +18,7 @@ export default class AccountManager {
 
   public async get(
     address: Address,
-    blockNumber: Buffer | Tag = Tag.LATEST
+    blockNumber: Buffer | Tag = Tag.latest
   ): Promise<Account | null> {
     const raw = await this.getRaw(address, blockNumber);
     if (raw == null) return null;
@@ -27,7 +27,7 @@ export default class AccountManager {
 
   public async getRaw(
     address: Address,
-    blockNumber: string | Buffer | Tag = Tag.LATEST
+    blockNumber: string | Buffer | Tag = Tag.latest
   ): Promise<Buffer | null> {
     const { trie, blocks } = this.#blockchain;
 
@@ -43,7 +43,7 @@ export default class AccountManager {
   public async getStorageAt(
     address: Address,
     key: Buffer,
-    blockNumber: Buffer | Tag = Tag.LATEST
+    blockNumber: Buffer | Tag = Tag.latest
   ) {
     const { trie, blocks } = this.#blockchain;
 
@@ -58,7 +58,7 @@ export default class AccountManager {
 
   public async getNonce(
     address: Address,
-    blockNumber: QUANTITY | Buffer | Tag = Tag.LATEST
+    blockNumber: QUANTITY | Buffer | Tag = Tag.latest
   ): Promise<Quantity> {
     const data = await this.getRaw(address, blockNumber);
 
@@ -70,7 +70,7 @@ export default class AccountManager {
 
   public async getBalance(
     address: Address,
-    blockNumber: QUANTITY | Buffer | Tag = Tag.LATEST
+    blockNumber: QUANTITY | Buffer | Tag = Tag.latest
   ): Promise<Quantity> {
     const data = await this.getRaw(address, blockNumber);
 
@@ -82,7 +82,7 @@ export default class AccountManager {
 
   public async getNonceAndBalance(
     address: Address,
-    blockNumber: QUANTITY | Buffer | Tag = Tag.LATEST
+    blockNumber: QUANTITY | Buffer | Tag = Tag.latest
   ) {
     const data = await this.getRaw(address, blockNumber);
 
@@ -98,7 +98,7 @@ export default class AccountManager {
 
   public async getCode(
     address: Address,
-    blockNumber: QUANTITY | Buffer | Tag = Tag.LATEST
+    blockNumber: QUANTITY | Buffer | Tag = Tag.latest
   ): Promise<Data> {
     const data = await this.getRaw(address, blockNumber);
 

--- a/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
@@ -145,28 +145,22 @@ export default class BlockManager extends Manager<Block> {
   };
 
   getBlockByTag(tag: Tag) {
-    switch (Tag.normalize(tag as Tag)) {
-      case Tag.LATEST:
+    switch (tag) {
+      case "latest":
         return this.latest;
-      case void 0:
-      case null:
-        // the key is probably a hex string, let nature takes its course.
-        break;
-      case Tag.PENDING:
+      case "pending":
         // TODO: build a real pending block!
         return this.latest; // this.createBlock(this.latest.header);
-      case Tag.EARLIEST:
+      case "earliest":
         return this.earliest;
       default:
-        // this probably can't happen. but if someone passed something like
-        // `toString` in as a block tag and it got this far... maybe we'd
-        // get here...
-        throw new Error(`Invalid block Tag: ${tag}`);
+        // the key is probably a hex string, let nature takes its course.
+        break;
     }
   }
 
   getEffectiveNumber(
-    tagOrBlockNumber: QUANTITY | Buffer | Tag = Tag.LATEST
+    tagOrBlockNumber: QUANTITY | Buffer | Tag = typeof Tag.latest
   ): Quantity {
     if (typeof tagOrBlockNumber === "string") {
       const block = this.getBlockByTag(tagOrBlockNumber as Tag);

--- a/src/chains/ethereum/ethereum/src/forking/fork.ts
+++ b/src/chains/ethereum/ethereum/src/forking/fork.ts
@@ -27,7 +27,7 @@ function fetchBlockNumber(fork: Fork) {
   // shouldn't ever cache a method that can change!
   return fork.request<string>("eth_blockNumber", [], { disableCache: true });
 }
-function fetchBlock(fork: Fork, blockNumber: Quantity | Tag.LATEST) {
+function fetchBlock(fork: Fork, blockNumber: Quantity | typeof Tag.latest) {
   return fork.request<any>("eth_getBlockByNumber", [blockNumber, true]);
 }
 async function fetchNonce(fork: Fork, address: Address, blockNumber: Quantity) {
@@ -138,9 +138,9 @@ export class Fork {
     chainIdPromise: Promise<number>
   ) => {
     const { fork: options } = this.#options;
-    if (options.blockNumber === Tag.LATEST) {
+    if (options.blockNumber === Tag.latest) {
       const [latestBlock, chainId] = await Promise.all([
-        fetchBlock(this, Tag.LATEST),
+        fetchBlock(this, Tag.latest),
         chainIdPromise
       ]);
       let blockNumber = parseInt(latestBlock.number, 16);

--- a/src/chains/ethereum/ethereum/src/forking/persistent-cache/helpers.ts
+++ b/src/chains/ethereum/ethereum/src/forking/persistent-cache/helpers.ts
@@ -124,7 +124,7 @@ export async function resolveTargetAndClosestAncestor(
       closestAncestor = null;
       targetBlock = new Tree(targetHeight, targetHash);
     } else {
-      const earliestBlock = await getBlockByNumber(request, Tag.EARLIEST);
+      const earliestBlock = await getBlockByNumber(request, Tag.earliest);
       if (!earliestBlock) throw new Error('Could not find "earliest" block.');
 
       const { hash: earliestHash, number: earliestNumber } = earliestBlock;
@@ -158,7 +158,7 @@ export async function* findRelated(
   });
 
   for await (const pair of readStream) {
-    const { key, value } = (pair as unknown) as { key: Buffer; value: Buffer };
+    const { key, value } = pair as unknown as { key: Buffer; value: Buffer };
     const node = Tree.deserialize(key, value);
     const { height: candidateHeight } = node.decodeKey();
     const block = await getBlockByNumber(request, candidateHeight);

--- a/src/chains/ethereum/ethereum/src/helpers/filter-parsing.ts
+++ b/src/chains/ethereum/ethereum/src/helpers/filter-parsing.ts
@@ -7,10 +7,9 @@ export function parseFilterDetails(
 ) {
   // `filter.address` may be a single address or an array
   const addresses = filter.address
-    ? (Array.isArray(filter.address)
-        ? filter.address
-        : [filter.address]
-      ).map(a => Address.from(a.toLowerCase()).toBuffer())
+    ? (Array.isArray(filter.address) ? filter.address : [filter.address]).map(
+        a => Address.from(a.toLowerCase()).toBuffer()
+      )
     : [];
   const topics = filter.topics ? filter.topics : [];
   return { addresses, topics };
@@ -22,11 +21,11 @@ export function parseFilterRange(
 ) {
   const latestBlock = blockchain.blocks.latest.header.number;
   const fromBlock = blockchain.blocks.getEffectiveNumber(
-    filter.fromBlock || Tag.LATEST
+    filter.fromBlock || Tag.latest
   );
   const latestBlockNumber = latestBlock.toNumber();
   const toBlock = blockchain.blocks.getEffectiveNumber(
-    filter.toBlock || Tag.LATEST
+    filter.toBlock || Tag.latest
   );
   let toBlockNumber: number;
   // don't search after the "latest" block, unless it's "pending", of course.

--- a/src/chains/ethereum/options/src/fork-options.ts
+++ b/src/chains/ethereum/options/src/fork-options.ts
@@ -9,7 +9,7 @@ const version = process.env.VERSION || "DEV";
 const MAX_BLOCK_NUMBER = Math.floor(Number.MAX_SAFE_INTEGER / 2);
 
 type HeaderRecord = { name: string; value: string };
-type ForkUrl = URL & { _blockNumber?: number | Tag.LATEST };
+type ForkUrl = URL & { _blockNumber?: number | typeof Tag.latest };
 
 type KnownNetworks =
   | "mainnet"
@@ -86,13 +86,13 @@ export type ForkConfig = {
      * Block number the provider should fork from.
      */
     blockNumber: {
-      type: number | Tag.LATEST;
+      type: number | typeof Tag.latest;
       hasDefault: true;
       legacy: {
         /**
          * @deprecated Use fork.blockNumber instead
          */
-        fork_block_number: number | Tag.LATEST;
+        fork_block_number: number | typeof Tag.latest;
       };
     };
 
@@ -266,11 +266,11 @@ export const ForkOptions: Definitions<ForkConfig> = {
         // remove everything after the last @
         url = new URL(path.substr(0, lastIndex), url);
         const blockNumber = path.substr(lastIndex + 1);
-        if (blockNumber && blockNumber !== Tag.LATEST) {
+        if (blockNumber && blockNumber !== Tag.latest) {
           // don't use parseInt because strings like `"123abc"` parse
           // to `123`, and there is probably an error on the user's side we'd
           // want to uncover.
-          const asNum = ((blockNumber as unknown) as number) - 0;
+          const asNum = (blockNumber as unknown as number) - 0;
           // don't allow invalid, negative, or decimals
           if (
             isNaN(asNum) ||
@@ -370,10 +370,10 @@ Use the shorthand command \`ganache --fork\` to automatically fork from Mainnet 
         if (url._blockNumber) {
           return url._blockNumber;
         } else {
-          return Tag.LATEST;
+          return Tag.latest;
         }
       } else if (provider || network) {
-        return Tag.LATEST;
+        return Tag.latest;
       } else {
         return;
       }

--- a/src/chains/ethereum/utils/src/things/tags.ts
+++ b/src/chains/ethereum/utils/src/things/tags.ts
@@ -1,27 +1,13 @@
-export enum Tag {
-  EARLIEST = "earliest",
-  LATEST = "latest",
-  PENDING = "pending"
-}
-enum _Tag {
-  earliest,
-  latest,
-  pending
+export enum InternalTag {
+  earliest = "earliest",
+  latest = "latest",
+  pending = "pending"
 }
 
+export type Tag = keyof typeof InternalTag;
+
 export namespace Tag {
-  export function normalize(tag: keyof typeof _Tag | Tag): Tag {
-    if (typeof tag === "string") {
-      return (<any>Tag)[tag.toUpperCase()];
-    } else {
-      switch (tag) {
-        case _Tag.earliest:
-          return Tag.EARLIEST;
-        case _Tag.latest:
-          return Tag.LATEST;
-        case _Tag.pending:
-          return Tag.PENDING;
-      }
-    }
-  }
+  export const latest = "latest";
+  export const earliest = "earliest";
+  export const pending = "pending";
 }


### PR DESCRIPTION
The `Tag` enum type that we were using meant that the TS compiler didn't think `Tag.LATEST === "latest"` at compile time, even though it does at runtime. This PR updates `Tag` so it isn't an `enum` in order to make our Tag-related types work with the string "latest", "earliest", and "pending".

It also removes a .tgz file that was accidentally included in a previous PR.