### PR TITLE
chore: remove canary, add rc to release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [beta, alpha, rc]
+    branches: [alpha, beta, rc]
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [beta, alpha, canary]
+    branches: [beta, alpha, rc]
 
 jobs:
   release:


### PR DESCRIPTION
Preparing for a release-candidate (rc) release.