### PR TITLE
chore: update licenses for 2022

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/ethereum/address/LICENSE
+++ b/src/chains/ethereum/address/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/ethereum/block/LICENSE
+++ b/src/chains/ethereum/block/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/ethereum/ethereum/LICENSE
+++ b/src/chains/ethereum/ethereum/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/ethereum/options/LICENSE
+++ b/src/chains/ethereum/options/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/ethereum/transaction/LICENSE
+++ b/src/chains/ethereum/transaction/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/ethereum/utils/LICENSE
+++ b/src/chains/ethereum/utils/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/filecoin/options/LICENSE
+++ b/src/chains/filecoin/options/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/tezos/options/LICENSE
+++ b/src/chains/tezos/options/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/chains/tezos/tezos/LICENSE
+++ b/src/chains/tezos/tezos/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/cli/LICENSE
+++ b/src/packages/cli/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/colors/LICENSE
+++ b/src/packages/colors/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 Consensys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/core/LICENSE
+++ b/src/packages/core/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/flavors/LICENSE
+++ b/src/packages/flavors/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/ganache/LICENSE
+++ b/src/packages/ganache/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/options/LICENSE
+++ b/src/packages/options/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/promise-queue/LICENSE
+++ b/src/packages/promise-queue/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/rlp/LICENSE
+++ b/src/packages/rlp/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/secp256k1/LICENSE
+++ b/src/packages/secp256k1/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 

--- a/src/packages/utils/LICENSE
+++ b/src/packages/utils/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Iuri Matias
-Copyright (c) 2019 ConsenSys Software Inc
+Copyright (c) 2022 ConsenSys Software Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
 this software and associated documentation files (the "Software"), to deal in 


### PR DESCRIPTION
This just updates everything to 2022, but maybe we should make it say a year range instead?