### PR TITLE
fix: gethify eth call errors (#2133)

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -114,6 +114,10 @@ type TypedData = Exclude<
 //#endregion
 
 //#region helpers
+/**
+ * Combines RuntimeErrors for a list of rejected or reverted transactions.
+ * @param transactions Array of transactions with errors to assert.
+ */
 function assertExceptionalTransactions(transactions: TypedTransaction[]) {
   let baseError: string = null;
   let errors: string[];

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -9,7 +9,7 @@ import {
   TraceDataFactory,
   TraceStorageMap,
   RuntimeError,
-  RETURN_TYPES,
+  CallError,
   StorageKeys,
   StorageRangeResult,
   StorageRecords,
@@ -1086,9 +1086,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
       context: transactionContext
     });
     if (result.execResult.exceptionError) {
-      // eth_call transactions don't really have a transaction hash
-      const hash = RPCQUANTITY_EMPTY;
-      throw new RuntimeError(hash, result, RETURN_TYPES.RETURN_VALUE);
+      throw new CallError(result);
     } else {
       return Data.from(result.execResult.returnValue || "0x");
     }

--- a/src/chains/ethereum/ethereum/tests/api/eth/contracts/EthCall.sol
+++ b/src/chains/ethereum/ethereum/tests/api/eth/contracts/EthCall.sol
@@ -12,4 +12,7 @@ contract EthCall {
     return block.basefee;
   }
 
+  function doARevert() public pure {
+    revert("you are a failure");
+  }
 }

--- a/src/chains/ethereum/ethereum/tests/api/eth/sendRawTransaction.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/sendRawTransaction.test.ts
@@ -144,17 +144,12 @@ describe("api", () => {
                 "Error code should be -32000"
               );
               assert.strictEqual(
-                result.data.reason,
-                null,
-                "The reason is undecodable, and thus should be null"
-              );
-              assert.strictEqual(
-                result.data.message,
-                "revert",
+                result.message,
+                "VM Exception while processing transaction: revert",
                 "The message should not have a reason string included"
               );
               assert.strictEqual(
-                result.data.result,
+                result.data,
                 revertString,
                 "The revert reason should be encoded as hex"
               );

--- a/src/chains/ethereum/ethereum/tests/api/eth/sendTransaction.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/sendTransaction.test.ts
@@ -200,17 +200,12 @@ describe("api", () => {
                 "Error code should be -32000"
               );
               assert.strictEqual(
-                result.data.reason,
-                null,
-                "The reason is undecodable, and thus should be null"
-              );
-              assert.strictEqual(
-                result.data.message,
-                "revert",
+                result.message,
+                "VM Exception while processing transaction: revert",
                 "The message should not have a reason string included"
               );
               assert.strictEqual(
-                result.data.result,
+                result.data,
                 revertString,
                 "The revert reason should be encoded as hex"
               );

--- a/src/chains/ethereum/utils/src/errors/call-error.ts
+++ b/src/chains/ethereum/utils/src/errors/call-error.ts
@@ -2,6 +2,7 @@ import { EVMResult } from "@ethereumjs/vm/dist/evm/evm";
 import { VM_EXCEPTION } from "./errors";
 import { CodedError } from "./coded-error";
 import { JsonRpcErrorCode } from "@ganache/utils";
+import { Data } from "@ganache/utils";
 
 export class CallError extends CodedError {
   public code: JsonRpcErrorCode;
@@ -16,8 +17,9 @@ export class CallError extends CodedError {
     CodedError.captureStackTraceExtended.bind(this, message);
     this.name = this.constructor.name;
 
-    const reason = CodedError.createRevertReason(execResult);
+    const { returnValue } = execResult;
+    const reason = CodedError.createRevertReason(returnValue);
     this.message = reason ? message + " " + reason : message;
-    this.data = reason;
+    this.data = Data.from(returnValue).toString();
   }
 }

--- a/src/chains/ethereum/utils/src/errors/call-error.ts
+++ b/src/chains/ethereum/utils/src/errors/call-error.ts
@@ -1,0 +1,23 @@
+import { EVMResult } from "@ethereumjs/vm/dist/evm/evm";
+import { VM_EXCEPTION } from "./errors";
+import { CodedError } from "./coded-error";
+import { JsonRpcErrorCode } from "@ganache/utils";
+
+export class CallError extends CodedError {
+  public code: JsonRpcErrorCode;
+  public data: string;
+  constructor(result: EVMResult) {
+    const execResult = result.execResult;
+    const error = execResult.exceptionError.error;
+    let message = VM_EXCEPTION + error;
+
+    super(message, JsonRpcErrorCode.INVALID_INPUT);
+
+    CodedError.captureStackTraceExtended.bind(this, message);
+    this.name = this.constructor.name;
+
+    const reason = CodedError.createRevertReason(execResult);
+    this.message = reason ? message + " " + reason : message;
+    this.data = reason;
+  }
+}

--- a/src/chains/ethereum/utils/src/errors/coded-error.ts
+++ b/src/chains/ethereum/utils/src/errors/coded-error.ts
@@ -45,8 +45,7 @@ export class CodedError extends Error {
       );
     }
   }
-  static createRevertReason(execResult: ExecResult) {
-    const returnValue = execResult.returnValue;
+  static createRevertReason(returnValue: Buffer) {
     let reason: string | null;
     if (
       returnValue.length > 4 &&

--- a/src/chains/ethereum/utils/src/errors/runtime-error.ts
+++ b/src/chains/ethereum/utils/src/errors/runtime-error.ts
@@ -32,11 +32,11 @@ export class RuntimeError extends CodedError {
     CodedError.captureStackTraceExtended.bind(this, message);
     this.name = this.constructor.name;
 
-    const returnValue = execResult.returnValue;
     const hash = transactionHash.toString();
-    const reason = CodedError.createRevertReason(execResult);
+    const { returnValue } = execResult;
+    const reason = CodedError.createRevertReason(returnValue);
+    this.message = reason ? message + " " + reason : message;
 
-    this.message = message;
     this.data = {
       hash: hash,
       programCounter: execResult.runState.programCounter,

--- a/src/chains/ethereum/utils/src/index.ts
+++ b/src/chains/ethereum/utils/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./errors/coded-error";
 export * from "./errors/errors";
 export * from "./errors/runtime-error";
+export * from "./errors/call-error";
 export * from "./errors/abort-error";
 
 export * from "./things/account";


### PR DESCRIPTION
Before this change, errors from `eth_call` were formatted in our "non-standard" `vmErrorsOnRPCResponse` format, which uses the error's `data` property to store some extra helpful information (program counter, hash, etc.):
```
{
   "error": {
     "message": "...",
     "code": ...
     "data": {
          ... bunch of props, like `hash` and `programCounter`...
         "result": "<raw revert hex string>" <---- this moves (See below)
     }
   } 
}
```

 Now, the error's `data` property only contains the raw revert hex string, which should more closely match real node's error handling:
```
{
   "error": {
     "message": "...", // <- we'll change the message
     "code": ...
     "data": "<raw revert hex string>"  <---- new home
   } 
}
```

Our hope is that this will allow users to remove any conditionals handling errors differently between Ganache and real Ethereum nodes.