### PR TITLE
fix: `eth_subscribe` logs

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -2078,8 +2078,6 @@ export default class EthereumApi implements Api {
         const unsubscribe = this.#blockchain.on(
           "blockLogs",
           (blockLogs: BlockLogs) => {
-            // TODO: move the JSON stringification closer to where the message
-            // is actually sent to the listener
             for (const log of blockLogs.filter(addresses, topics)) {
               promiEvent.emit("message", {
                 type: "eth_subscription",

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -2080,16 +2080,15 @@ export default class EthereumApi implements Api {
           (blockLogs: BlockLogs) => {
             // TODO: move the JSON stringification closer to where the message
             // is actually sent to the listener
-            const result = JSON.parse(
-              JSON.stringify([...blockLogs.filter(addresses, topics)])
-            );
-            promiEvent.emit("message", {
-              type: "eth_subscription",
-              data: {
-                result,
-                subscription: subscription.toString()
-              }
-            });
+            for (const log of blockLogs.filter(addresses, topics)) {
+              promiEvent.emit("message", {
+                type: "eth_subscription",
+                data: {
+                  result: log,
+                  subscription: subscription.toString()
+                }
+              });
+            }
           }
         );
         subscriptions.set(subscription.toString(), unsubscribe);

--- a/src/chains/ethereum/ethereum/tests/api/eth/logs.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/logs.test.ts
@@ -13,11 +13,7 @@ describe("api", () => {
       let contractAddress: string;
       let accounts: string[];
 
-      beforeEach(async () => {
-        contract = compile(join(__dirname, "./contracts/Logs.sol"));
-        provider = await getProvider();
-        accounts = await provider.send("eth_accounts");
-
+      const deployContractAndGetAddress = async () => {
         const subscriptionId = await provider.send("eth_subscribe", [
           "newHeads"
         ]);
@@ -33,8 +29,16 @@ describe("api", () => {
           "eth_getTransactionReceipt",
           [transactionHash]
         );
-        contractAddress = transactionReceipt.contractAddress;
         await provider.send("eth_unsubscribe", [subscriptionId]);
+        return transactionReceipt.contractAddress;
+      };
+
+      beforeEach(async () => {
+        contract = compile(join(__dirname, "./contracts/Logs.sol"));
+        provider = await getProvider();
+        accounts = await provider.send("eth_accounts");
+
+        contractAddress = await deployContractAndGetAddress();
       });
 
       describe("eth_subscribe", () => {

--- a/src/chains/ethereum/ethereum/tests/api/eth/logs.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/logs.test.ts
@@ -113,11 +113,11 @@ describe("api", () => {
             ]);
             // the one to return for all messages is the sub2, which we never unsubed
             for (let i = 0; i < numberOfLogs; i++) {
-            assert.strictEqual(
+              assert.strictEqual(
                 messages[i].data.subscription,
-              subscriptionId2,
-              "unsubscribe didn't work"
-            );
+                subscriptionId2,
+                "unsubscribe didn't work"
+              );
             }
           });
 
@@ -298,9 +298,10 @@ describe("api", () => {
             }
           ]); // 0x3
           await provider.once("message");
-          const {
-            blockNumber
-          } = await provider.send("eth_getTransactionReceipt", [txHash]);
+          const { blockNumber } = await provider.send(
+            "eth_getTransactionReceipt",
+            [txHash]
+          );
 
           async function testGetLogs(
             fromBlock: string,
@@ -415,18 +416,21 @@ describe("api", () => {
           }
 
           // tests blockHash
-          let {
-            hash: genesisBlockHash
-          } = await provider.send("eth_getBlockByNumber", [genesisBlockNumber]);
+          let { hash: genesisBlockHash } = await provider.send(
+            "eth_getBlockByNumber",
+            [genesisBlockNumber]
+          );
           await testGetLogs(blockHash, 4);
           await testGetLogs(genesisBlockHash, 0);
-          let {
-            hash: deployBlockHash
-          } = await provider.send("eth_getBlockByNumber", [deployBlockNumber]);
+          let { hash: deployBlockHash } = await provider.send(
+            "eth_getBlockByNumber",
+            [deployBlockNumber]
+          );
           await testGetLogs(deployBlockHash, 1, null);
-          let {
-            hash: emptyBlockHash
-          } = await provider.send("eth_getBlockByNumber", [emptyBlockNumber]);
+          let { hash: emptyBlockHash } = await provider.send(
+            "eth_getBlockByNumber",
+            [emptyBlockNumber]
+          );
           await testGetLogs(emptyBlockHash, 0);
           const invalidBlockHash = "0x123456789";
           await testGetLogs(invalidBlockHash, 0);


### PR DESCRIPTION
Previously, logs returned via `eth_subscribe("logs")` returned all logs in an array. [Geth's logging](https://geth.ethereum.org/docs/rpc/pubsub) and Ganache v6 emit separately for each event. This change makes it so we emit separately for each log once again.

Also, I've added some tests for filtering `eth_subscribe("logs")` events.