### PR TITLE
feat: add __experimental_info export to core

### DIFF
--- a/src/packages/core/index.ts
+++ b/src/packages/core/index.ts
@@ -1,11 +1,23 @@
 import { ConnectorsByName, DefaultFlavor, FlavorName } from "@ganache/flavors";
+import { KNOWN_CHAINIDS } from "@ganache/utils";
 import ConnectorLoader from "./src/connector-loader";
 import { ProviderOptions, ServerOptions } from "./src/options";
 import Server from "./src/server";
 export { Server, ServerStatus, _DefaultServerOptions } from "./src/server";
-
 export type { Provider, EthereumProvider, FilecoinProvider } from "@ganache/flavors";
 export type { ProviderOptions, ServerOptions } from "./src/options";
+export type _ExperimentalInfo = Readonly<{
+  version: string,
+  fork: Readonly<{
+    /**
+     * Chains fully supported by Ganache forking.
+     */
+    supportedChainIds: number[],
+  }>
+}>
+
+
+const version = process.env.VERSION || "DEV";
 
 /**
  * @public
@@ -46,6 +58,18 @@ const Ganache = {
   ): ConnectorsByName[T]["provider"] => {
     const loader = ConnectorLoader.initialize<T>(options);
     return loader.connector.provider;
+  },
+  /**
+   * 
+   * @experimental
+   */
+  __experimental_info(): _ExperimentalInfo {
+    return {
+      version,
+      fork: {
+        supportedChainIds: Array.from(KNOWN_CHAINIDS)
+      }
+    };
   }
 };
 
@@ -57,6 +81,10 @@ export const server = Ganache.server;
  * @public
  */
 export const provider = Ganache.provider;
+/**
+ * @experimental
+ */
+export const __experimental_info = Ganache.__experimental_info;
 /**
  * @public
  */

--- a/src/packages/core/index.ts
+++ b/src/packages/core/index.ts
@@ -10,9 +10,12 @@ export type _ExperimentalInfo = Readonly<{
   version: string,
   fork: Readonly<{
     /**
-     * Chains fully supported by Ganache forking.
+     * Chains Ganache is known to be compatible with. Operations performed
+     * locally at historic block numbers will use the Ethereum Virtual Machine
+     * OPCODEs, gas prices, and EIPs that were active at the time the historic
+     * block originally took place.
      */
-    supportedChainIds: number[],
+    knownChainIds: number[],
   }>
 }>
 
@@ -67,7 +70,7 @@ const Ganache = {
     return {
       version,
       fork: {
-        supportedChainIds: Array.from(KNOWN_CHAINIDS)
+        knownChainIds: Array.from(KNOWN_CHAINIDS)
       }
     };
   }

--- a/src/packages/core/tests/interface.test.ts
+++ b/src/packages/core/tests/interface.test.ts
@@ -3,7 +3,7 @@ import * as assert from "assert";
 import { KNOWN_CHAINIDS } from "@ganache/utils";
 
 describe("interface", () => {
-  it.only("has an interface", () => {
+  it("has an interface", () => {
     assert.ok(Ganache.server);
     assert.ok(Ganache.provider);
     const info = Ganache.__experimental_info();

--- a/src/packages/core/tests/interface.test.ts
+++ b/src/packages/core/tests/interface.test.ts
@@ -5,10 +5,11 @@ describe("interface", () => {
   it("has an interface", () => {
     assert.ok(Ganache.server);
     assert.ok(Ganache.provider);
-    assert.strictEqual(Object.keys(Ganache).length, 2);
+    assert.ok(Ganache.__experimental_info);
+    assert.strictEqual(Object.keys(Ganache).length, 3);
 
     // in v3 these two properties were *removed* because it was confusing.
-    // these tests are kinda unncessary, but I just want to intent to be
+    // these tests are kinda unnecessary, but I just want to intent to be
     // explicit.
     assert.strictEqual("Server" in Ganache, false);
     assert.strictEqual("Provider" in Ganache, false);

--- a/src/packages/core/tests/interface.test.ts
+++ b/src/packages/core/tests/interface.test.ts
@@ -7,7 +7,7 @@ describe("interface", () => {
     assert.ok(Ganache.server);
     assert.ok(Ganache.provider);
     const info = Ganache.__experimental_info();
-    assert.deepStrictEqual(info.fork.supportedChainIds, Array.from(KNOWN_CHAINIDS));
+    assert.deepStrictEqual(info.fork.knownChainIds, Array.from(KNOWN_CHAINIDS));
     assert.deepStrictEqual(info.version, "DEV");
     assert.strictEqual(Object.keys(Ganache).length, 3);
 

--- a/src/packages/core/tests/interface.test.ts
+++ b/src/packages/core/tests/interface.test.ts
@@ -1,11 +1,14 @@
 import Ganache from "..";
 import * as assert from "assert";
+import { KNOWN_CHAINIDS } from "@ganache/utils";
 
 describe("interface", () => {
-  it("has an interface", () => {
+  it.only("has an interface", () => {
     assert.ok(Ganache.server);
     assert.ok(Ganache.provider);
-    assert.ok(Ganache.__experimental_info);
+    const info = Ganache.__experimental_info();
+    assert.deepStrictEqual(info.fork.supportedChainIds, Array.from(KNOWN_CHAINIDS));
+    assert.deepStrictEqual(info.version, "DEV");
     assert.strictEqual(Object.keys(Ganache).length, 3);
 
     // in v3 these two properties were *removed* because it was confusing.

--- a/src/packages/ganache/index.ts
+++ b/src/packages/ganache/index.ts
@@ -12,10 +12,15 @@ export type {
   ProviderOptions,
   EthereumProvider,
   FilecoinProvider,
+  _ExperimentalInfo
 } from "@ganache/core";
 export {
   server,
-  provider
+  provider,
+  /**
+   * @experimental
+   */
+  __experimental_info
 } from "@ganache/core";
 import Ganache from "@ganache/core";
 export default Ganache;


### PR DESCRIPTION
This is an internal and private feature for [Truffle](https://github.com/trufflesuite/truffle). Truffle needed a way to programmatically get the list of chains Ganache fully supports in order to enable the dry-run feature for those chains.

This introduces a new experimental and private (this will likely change in a future release!) `__experimental_info` export:

```typescript
Readonly<{
  version: string,
  fork: Readonly<{
    /**
     * Chains Ganache is known to be compatible with. Operations performed
     * locally at historic block numbers will use the Ethereum Virtual Machine
     * OPCODEs, gas prices, and EIPs that were active at the time the historic
     * block originally took place.
     */
    knownChainIds: number[],
  }>
}>
```