### PR TITLE
Fix not working example of get "eth_accounts"

### DIFF
--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -163,10 +163,11 @@ server.listen(PORT, err => {
 
   console.log(`ganache listening on port ${PORT}...`);
   const provider = server.provider;
-  const accounts = await provider.request({
+  provider.request({
     method: "eth_accounts",
     params: []
-  });
+  }).then(accounts => console.log(accounts));
+
 });
 ```
 


### PR DESCRIPTION
Cannot use `await` inside the server function when using Ganache as a JSON-RPC web server.