### PR TITLE
fix: ensure impersonated "large" accounts use compliant (fake) private keys

### DIFF
--- a/src/chains/ethereum/ethereum/src/wallet.ts
+++ b/src/chains/ethereum/ethereum/src/wallet.ts
@@ -665,7 +665,7 @@ export default class Wallet {
       if (first12.compare(TWELVE_255s) === 0) {
         // keccak returns a 32 byte hash of the input data, which is the exact
         // length we need for a private key.
-        // note: if keccak can return it's own input as it's output, then this
+        // note: if keccak can return its own input as its output, then this
         // loops forever. The chances of this happening are impossibly low, so
         // it's not worth the effort to check, but it would be interesting if
         // someone reported an issue that can cause this for a specific

--- a/src/chains/ethereum/ethereum/src/wallet.ts
+++ b/src/chains/ethereum/ethereum/src/wallet.ts
@@ -663,14 +663,19 @@ export default class Wallet {
       // will. There are obviously many chances for a false positive, but the
       // next condition in the `while` loop will catch those.
       if (first12.compare(TWELVE_255s) === 0) {
-        // keccak returns a 32 byte hash of the input data, which is the exact
-        // length we need for a private key.
-        // note: if keccak can return its own input as its output, then this
-        // loops forever. The chances of this happening are impossibly low, so
-        // it's not worth the effort to check, but it would be interesting if
-        // someone reported an issue that can cause this for a specific
-        // address!
-        fakePrivateKey = keccak(fakePrivateKey);
+        while (
+          BigInt(`0x${fakePrivateKey.toString("hex")}`) >=
+          SECP256K1_MAX_PRIVATE_KEY
+        ) {
+          // keccak returns a 32 byte hash of the input data, which is the exact
+          // length we need for a private key.
+          // note: if keccak can return its own input as its output, then this
+          // loops forever. The chances of this happening are impossibly low, so
+          // it's not worth the effort to check, but it would be interesting if
+          // someone reported an issue that can cause this for a specific
+          // address!
+          fakePrivateKey = keccak(fakePrivateKey);
+        }
       }
     }
     return Data.from(fakePrivateKey);


### PR DESCRIPTION
Transactions from "impersonated" accounts are still "signed" by Ganache, but the private key is faked. It was previously possible for the fake private key we generate for some accounts to cause an error when a transaction is eventually signed.

Fixes https://github.com/trufflesuite/ganache/issues/2586