### PR TITLE
Fixes #2580 - parse port to number type if provided in a different type

### DIFF
--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -190,7 +190,7 @@ export class Server<
     // inspiration taken from nodejs internal port validator
     // https://github.com/nodejs/node/blob/8c4b8b201ada6b76d5306c9c7f352e45087fb4a9/lib/internal/validators.js#L208-L219
     if ((typeof port !== 'number' && typeof port !== 'string') ||
-      (typeof port === 'string' && String.prototype.trim.apply(port).length === 0) ||
+      (typeof port === 'string' && (<string>port).trim().length === 0) ||
       +port !== (+port >>> 0) ||
       port > 0xFFFF ||
       port === 0) {

--- a/src/packages/core/tests/server.test.ts
+++ b/src/packages/core/tests/server.test.ts
@@ -70,10 +70,10 @@ describe("server", () => {
   (process.env.GITHUB_ACTION ? describe : describe.skip)("listen", function () {
     /**
      * Sends a post request to the server and returns the response.
-     * @param address 
-     * @param port 
-     * @param json 
-     * @returns 
+     * @param address
+     * @param port
+     * @param json
+     * @returns
      */
     function post(host: string, port: number, json: any) {
       const data = JSON.stringify(json);
@@ -297,6 +297,47 @@ describe("server", () => {
         }
         done();
       });
+    });
+
+    it("accepts port as string type (decimal)", async () => {
+      const portString = "5432";
+
+      s = Ganache.server(defaultOptions);
+      await s.listen(<number><unknown>portString);
+
+      try {
+        const req = request.post("http://localhost:5432");
+        await req.send(jsonRpcJson);
+      } finally {
+        await teardown();
+      }
+    });
+
+    it("accepts port as string type (hexidecimal)", async () => {
+      const portString = "0x1538";
+
+      s = Ganache.server(defaultOptions);
+      await s.listen(<number><unknown>portString);
+
+      try {
+        const req = request.post("http://localhost:5432");
+        await req.send(jsonRpcJson);
+      } finally {
+        await teardown();
+      }
+    });
+
+    it("fails with non-numeric port", async () => {
+      const portString = "not a number";
+
+      s = Ganache.server(defaultOptions);
+      try {
+        await assert.rejects(s.listen(<number><unknown>portString), {
+          message: `Provided port is not a valid value: ${portString}.`
+        });
+      } finally {
+        await teardown();
+      }
     });
 
     it("fails to `.listen()` twice, Promise", async () => {


### PR DESCRIPTION
I didn't end up changing the listen() signature, I agree that having a specific signature makes sense.

I did check the http.server.listen() behaviour, AFAIK our implementation now matches it wrt providing port number as string.