### PR TITLE
fix: update @trufflesuite/uws-js-unofficial dependency to silence nodejs 12 warnings

### DIFF
--- a/src/chains/ethereum/ethereum/package-lock.json
+++ b/src/chains/ethereum/ethereum/package-lock.json
@@ -838,9 +838,9 @@
 			"dev": true
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.4.0-unofficial.4",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.4.0-unofficial.4.tgz",
-			"integrity": "sha512-XTfdNdgp2X4ryXOg7Ofva/r0WXrQeiH+kV+v+FmQv4Sauf9g5RVv/7TPEmo7xvc9sz74Jb+C7vcmcxXcS8D5Wg==",
+			"version": "20.4.0-unofficial.5",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.4.0-unofficial.5.tgz",
+			"integrity": "sha512-QR9dSa6TvNFYUWKhvtul1W4CIv8X7QIgF+xwJSqqguBemWsJbVq2INkzvevMUAc2B28k7Orgah1sQ6NhIoJx8A==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",

--- a/src/chains/ethereum/ethereum/package.json
+++ b/src/chains/ethereum/ethereum/package.json
@@ -86,7 +86,7 @@
     "ws": "8.2.3"
   },
   "devDependencies": {
-    "@trufflesuite/uws-js-unofficial": "20.4.0-unofficial.4",
+    "@trufflesuite/uws-js-unofficial": "20.4.0-unofficial.5",
     "@types/encoding-down": "5.0.0",
     "@types/fs-extra": "9.0.2",
     "@types/keccak": "3.0.1",

--- a/src/chains/filecoin/filecoin/package-lock.json
+++ b/src/chains/filecoin/filecoin/package-lock.json
@@ -845,9 +845,9 @@
 			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.4.0-unofficial.4",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.4.0-unofficial.4.tgz",
-			"integrity": "sha512-XTfdNdgp2X4ryXOg7Ofva/r0WXrQeiH+kV+v+FmQv4Sauf9g5RVv/7TPEmo7xvc9sz74Jb+C7vcmcxXcS8D5Wg==",
+			"version": "20.4.0-unofficial.5",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.4.0-unofficial.5.tgz",
+			"integrity": "sha512-QR9dSa6TvNFYUWKhvtul1W4CIv8X7QIgF+xwJSqqguBemWsJbVq2INkzvevMUAc2B28k7Orgah1sQ6NhIoJx8A==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",
@@ -1867,9 +1867,9 @@
 			},
 			"dependencies": {
 				"node-gyp-build": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-					"integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+					"integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
 					"dev": true,
 					"optional": true
 				}
@@ -10350,9 +10350,9 @@
 			},
 			"dependencies": {
 				"node-gyp-build": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-					"integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+					"integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
 					"dev": true,
 					"optional": true
 				}

--- a/src/chains/filecoin/filecoin/package.json
+++ b/src/chains/filecoin/filecoin/package.json
@@ -59,7 +59,7 @@
     "@filecoin-shipyard/lotus-client-schema": "2.0.0",
     "@ganache/filecoin-options": "0.1.4",
     "@ganache/utils": "0.1.4",
-    "@trufflesuite/uws-js-unofficial": "20.4.0-unofficial.4",
+    "@trufflesuite/uws-js-unofficial": "20.4.0-unofficial.5",
     "@types/bn.js": "5.1.0",
     "@types/deep-equal": "1.0.1",
     "@types/levelup": "4.3.0",

--- a/src/chains/tezos/tezos/package-lock.json
+++ b/src/chains/tezos/tezos/package-lock.json
@@ -35,9 +35,9 @@
 			"dev": true
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.4.0-unofficial.4",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.4.0-unofficial.4.tgz",
-			"integrity": "sha512-XTfdNdgp2X4ryXOg7Ofva/r0WXrQeiH+kV+v+FmQv4Sauf9g5RVv/7TPEmo7xvc9sz74Jb+C7vcmcxXcS8D5Wg==",
+			"version": "20.4.0-unofficial.5",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.4.0-unofficial.5.tgz",
+			"integrity": "sha512-QR9dSa6TvNFYUWKhvtul1W4CIv8X7QIgF+xwJSqqguBemWsJbVq2INkzvevMUAc2B28k7Orgah1sQ6NhIoJx8A==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",
@@ -1815,9 +1815,9 @@
 			"dev": true
 		},
 		"node-gyp-build": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-			"integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+			"integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
 			"dev": true,
 			"optional": true
 		},

--- a/src/chains/tezos/tezos/package.json
+++ b/src/chains/tezos/tezos/package.json
@@ -47,7 +47,7 @@
     "emittery": "0.10.0"
   },
   "devDependencies": {
-    "@trufflesuite/uws-js-unofficial": "20.4.0-unofficial.4",
+    "@trufflesuite/uws-js-unofficial": "20.4.0-unofficial.5",
     "@types/mocha": "9.0.0",
     "cheerio": "1.0.0-rc.3",
     "cross-env": "7.0.3",

--- a/src/packages/core/package-lock.json
+++ b/src/packages/core/package-lock.json
@@ -436,9 +436,9 @@
 			"dev": true
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.4.0-unofficial.4",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.4.0-unofficial.4.tgz",
-			"integrity": "sha512-XTfdNdgp2X4ryXOg7Ofva/r0WXrQeiH+kV+v+FmQv4Sauf9g5RVv/7TPEmo7xvc9sz74Jb+C7vcmcxXcS8D5Wg==",
+			"version": "20.4.0-unofficial.5",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.4.0-unofficial.5.tgz",
+			"integrity": "sha512-QR9dSa6TvNFYUWKhvtul1W4CIv8X7QIgF+xwJSqqguBemWsJbVq2INkzvevMUAc2B28k7Orgah1sQ6NhIoJx8A==",
 			"requires": {
 				"bufferutil": "4.0.5",
 				"utf-8-validate": "5.0.7",
@@ -1699,9 +1699,9 @@
 			"dev": true
 		},
 		"node-gyp-build": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-			"integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+			"integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
 			"optional": true
 		},
 		"node-preload": {

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -53,7 +53,7 @@
     "@ganache/options": "0.1.4",
     "@ganache/tezos": "0.1.4",
     "@ganache/utils": "0.1.4",
-    "@trufflesuite/uws-js-unofficial": "20.4.0-unofficial.4",
+    "@trufflesuite/uws-js-unofficial": "20.4.0-unofficial.5",
     "aggregate-error": "3.1.0",
     "emittery": "0.10.0",
     "promise.allsettled": "1.0.4"

--- a/src/packages/ganache/npm-shrinkwrap.json
+++ b/src/packages/ganache/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
 	"name": "ganache",
-	"version": "7.0.2",
+	"version": "7.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/packages/utils/package-lock.json
+++ b/src/packages/utils/package-lock.json
@@ -72,9 +72,9 @@
 			}
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.4.0-unofficial.4",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.4.0-unofficial.4.tgz",
-			"integrity": "sha512-XTfdNdgp2X4ryXOg7Ofva/r0WXrQeiH+kV+v+FmQv4Sauf9g5RVv/7TPEmo7xvc9sz74Jb+C7vcmcxXcS8D5Wg==",
+			"version": "20.4.0-unofficial.5",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.4.0-unofficial.5.tgz",
+			"integrity": "sha512-QR9dSa6TvNFYUWKhvtul1W4CIv8X7QIgF+xwJSqqguBemWsJbVq2INkzvevMUAc2B28k7Orgah1sQ6NhIoJx8A==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",
@@ -227,9 +227,9 @@
 			},
 			"dependencies": {
 				"node-gyp-build": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-					"integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+					"integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
 					"dev": true,
 					"optional": true
 				}
@@ -925,9 +925,9 @@
 			},
 			"dependencies": {
 				"node-gyp-build": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-					"integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+					"integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
 					"dev": true,
 					"optional": true
 				}

--- a/src/packages/utils/package.json
+++ b/src/packages/utils/package.json
@@ -52,7 +52,7 @@
     "seedrandom": "3.0.5"
   },
   "devDependencies": {
-    "@trufflesuite/uws-js-unofficial": "20.4.0-unofficial.4",
+    "@trufflesuite/uws-js-unofficial": "20.4.0-unofficial.5",
     "@types/mocha": "9.0.0",
     "@types/seedrandom": "3.0.1",
     "cross-env": "7.0.3",


### PR DESCRIPTION
Fixes #2095. This introduces a minor version bump in node-gyp-build 4.3.0->4.4.0 (as it's a sub-dependency). This version bump includes a single change to support nodewebkit/nwjs https://github.com/prebuild/node-gyp-build/compare/v4.3.0...v4.4.0

