### PR TITLE
fix: reject transaction if maxFeePerGas is less than blockBaseFeePerGas of the pending block

### DIFF
--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -476,7 +476,7 @@ export default class TransactionPool extends Emittery<{ drain: undefined }> {
       );
     }
 
-    // transaction maxGasPerFee must be greater or equal to baseFeePerGas _of the pending block_
+    // transaction maxGasPerFee must be greater or equal to baseFeePerGas _of the next block_
     if ("maxFeePerGas" in transaction && !transaction.maxFeePerGas.isNull()) {
       const nextBaseFee = Block.calcNextBaseFee(this.#blockchain.blocks.latest);
       if (transaction.maxFeePerGas.toBigInt() < nextBaseFee) {

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -478,7 +478,6 @@ export default class TransactionPool extends Emittery<{ drain: undefined }> {
 
     // transaction maxGasPerFee must be greater or equal to baseFeePerGas _of the pending block_
     if ("maxFeePerGas" in transaction && !transaction.maxFeePerGas.isNull()) {
-      console.log(this.#blockchain.blocks.latest);
       const nextBaseFee = Block.calcNextBaseFee(this.#blockchain.blocks.latest);
       if (transaction.maxFeePerGas.toBigInt() < nextBaseFee) {
         return new CodedError(

--- a/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
+++ b/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
@@ -63,7 +63,7 @@ describe("transaction pool", async () => {
     futureNonceRpc = {
       from: from,
       type: "0x2",
-      maxFeePerGas: "0xffffff",
+      maxFeePerGas: "0x2da282a8",
       maxPriorityFeePerGas: "0xff",
       gasLimit: "0xffff",
       nonce: "0x2"
@@ -92,7 +92,7 @@ describe("transaction pool", async () => {
       },
       common,
       blocks: {
-        latest: { header: { baseFeePerGas: Quantity.from(875000000) } }
+        latest: { header: { baseFeePerGas: Quantity.from(875000000), gasUsed: Quantity.from(0), gasLimit: Quantity.from(12012000) } }
       }
     };
   });
@@ -148,7 +148,7 @@ describe("transaction pool", async () => {
       },
       common,
       blocks: {
-        latest: { header: { baseFeePerGas: Quantity.from(875000000) } }
+        latest: { header: { baseFeePerGas: Quantity.from(875000000), gasUsed: Quantity.from(0), gasLimit: Quantity.from(12012000) } }
       }
     } as any;
     const txPool = new TransactionPool(options.miner, fakeNonceChain, origins);
@@ -240,6 +240,7 @@ describe("transaction pool", async () => {
       found.serialized.toString(),
       futureNonceTx.serialized.toString()
     );
+
     // now, if we resend the same transaction, since the gas price isn't higher,
     // it should be rejected
     await assert.rejects(
@@ -257,7 +258,7 @@ describe("transaction pool", async () => {
       from,
       type: "0x2",
       value: "0xfffffffffffffffffff",
-      maxFeePerGas: "0xffffff",
+      maxFeePerGas: "0x2da282a8",
       maxPriorityFeePerGas: "0xff",
       gasLimit: "0xffff"
     };

--- a/src/chains/ethereum/utils/src/errors/errors.ts
+++ b/src/chains/ethereum/utils/src/errors/errors.ts
@@ -49,3 +49,8 @@ export const TRANSACTION_LOCKED =
  * Returned if a transaction may require more funds than than account currently has available.
  */
 export const INSUFFICIENT_FUNDS = "insufficient funds for gas * price + value";
+
+/**
+ * Returns in a transaction has maxFeePerGas less than the block base fee of the pending transaction.
+*/
+export const ERROR_FEE_CAP_TOO_LOW = "max fee per gas less than block base fee";


### PR DESCRIPTION
Fixes #2176 