### PR TITLE
ci: use semantic commits to determine next release version and fix final merge step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # we need all commit history so we can merge master into develop
+          fetch-depth: 0
       - uses: actions/setup-node@v1
         with:
           # use node 14 until we can evaluate using npm 7+ and lock file version 2
@@ -141,5 +143,5 @@ jobs:
         if: ${{ env.TAG == 'latest' }}
         run: |
           git checkout develop
-          git merge master
+          git merge origin/master
           git push origin develop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,24 @@ jobs:
         run: |
           echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
+      - name: Count features
+        if: ${{ env.TAG == 'latest'}}
+        # get all commits in develop that aren't in master, find any that start with feat: or feat(*):, then count them
+        run: echo "FEATURE_COUNT=$(git log ^origin/master origin/develop --pretty=format:%s | grep -o -P '^feat(\(.*?\))?:' | wc -l)" >> $GITHUB_ENV
+
+      - name: Determine Release Kind (minor)
+        # if we are "latest" and we have features, set the release to "minor"
+        if: ${{ env.TAG == 'latest' && env.FEATURE_COUNT != '0' }}
+        run: echo "RELEASE_KIND=minor" >> $GITHUB_ENV
+
+      - name: Determine Release Kind (patch)
+        # if we are "latest" and we do NOT have features, set the release to "patch"
+        if: ${{ env.TAG == 'latest' && env.FEATURE_COUNT == '0' }}
+        run: echo "RELEASE_KIND=patch" >> $GITHUB_ENV
+
       - name: Update package versions for latest release (master)
         if: ${{ env.TAG == 'latest' }}
-        run: $(npm bin)/lerna version patch --no-git-tag-version --no-push --yes --exact
+        run: $(npm bin)/lerna version "$RELEASE_KIND" --no-git-tag-version --no-push --yes --exact
 
       - name: Update package versions for pre-releases
         if: ${{ env.TAG != 'latest' }}


### PR DESCRIPTION
Our previous release mostly worked (it failed to auto-merge back into the develop branch) but had the wrong version number for a neat feature release. This PR should fix both of these issues. :crossed_fingers: 