### PR TITLE
perf: improve JSON-RPC data types; better, faster, stronger

### DIFF
--- a/src/chains/ethereum/address/index.ts
+++ b/src/chains/ethereum/address/index.ts
@@ -1,4 +1,4 @@
-import { Data } from "@ganache/utils";
+import { Data, JsonRpcDataInputArg } from "@ganache/utils";
 
 export class Address extends Data {
   static ByteLength = 20;
@@ -12,7 +12,16 @@ export class Address extends Data {
   constructor(value: string | Buffer) {
     super(value, Address.ByteLength);
   }
+
   public static from<T extends string | Buffer = string | Buffer>(value: T) {
     return new Address(value);
+  }
+
+  static toBuffer(value: JsonRpcDataInputArg): Buffer {
+    return Address.from(value).toBuffer();
+  }
+
+  static toString(value: JsonRpcDataInputArg): string {
+    return Address.from(value).toString();
   }
 }

--- a/src/chains/ethereum/address/index.ts
+++ b/src/chains/ethereum/address/index.ts
@@ -3,12 +3,6 @@ import { Data, JsonRpcDataInputArg } from "@ganache/utils";
 export class Address extends Data {
   static ByteLength = 20;
 
-  /**
-   *
-   * @param value -
-   * @param byteLength - the exact length the value represents when encoded as
-   * Ethereum JSON-RPC DATA.
-   */
   constructor(value: string | Buffer) {
     super(value, Address.ByteLength);
   }

--- a/src/chains/ethereum/address/tests/index.test.ts
+++ b/src/chains/ethereum/address/tests/index.test.ts
@@ -23,5 +23,44 @@ describe("@ganache/ethereum-address", () => {
 
       assert.equal(stringifiedAddress, "0x2104859394604359378433865360947116707876");
     });
+
+    it("should pad an address to 20 bytes when called as static function", () => {
+      const stringifiedAddress = Address.toString("0x1");
+
+      assert.equal(stringifiedAddress, "0x0000000000000000000000000000000000000001");
+    });
+  });
+
+  describe("toBuffer()", () => {
+    it("should pad an address to 20 bytes", () => {
+      const address = new Address("0x1");
+      const bufferAddress = address.toBuffer();
+      const expected = Buffer.alloc(20);
+      expected[19] = 1;
+
+      assert.deepEqual(bufferAddress, expected);
+    });
+
+    it("should truncate an address to the specified length", () => {
+      const address = new Address("0x2104859394604359378433865360947116707876");
+      const stringifiedAddress = address.toString(1);
+
+      assert.equal(stringifiedAddress, "0x21");
+    });
+
+    it("should convert a 20 byte address to a buffer", () => {
+      const address = new Address("0x2104859394604359378433865360947116707876");
+      const bufferAddress = address.toBuffer();
+      const expected = Buffer.from([0x21,0x04,0x85,0x93,0x94,0x60,0x43,0x59,0x37,0x84,0x33,0x86,0x53,0x60,0x94,0x71,0x16,0x70,0x78,0x76])
+      assert.deepEqual(bufferAddress, expected);
+    });
+
+    it("should pad an address to 20 bytes when called as static function", () => {
+      const bufferAddress = Address.toBuffer("0x1");
+      const expected = Buffer.alloc(20);
+      expected[19] = 1;
+
+      assert.deepEqual(bufferAddress, expected);
+    });
   });
 });

--- a/src/chains/ethereum/address/tests/index.test.ts
+++ b/src/chains/ethereum/address/tests/index.test.ts
@@ -7,7 +7,10 @@ describe("@ganache/ethereum-address", () => {
       const address = new Address("0x1");
       const stringifiedAddress = address.toString();
 
-      assert.equal(stringifiedAddress, "0x0000000000000000000000000000000000000001");
+      assert.equal(
+        stringifiedAddress,
+        "0x0000000000000000000000000000000000000001"
+      );
     });
 
     it("should truncate an address to the specified length", () => {
@@ -21,13 +24,19 @@ describe("@ganache/ethereum-address", () => {
       const address = new Address("0x2104859394604359378433865360947116707876");
       const stringifiedAddress = address.toString();
 
-      assert.equal(stringifiedAddress, "0x2104859394604359378433865360947116707876");
+      assert.equal(
+        stringifiedAddress,
+        "0x2104859394604359378433865360947116707876"
+      );
     });
 
     it("should pad an address to 20 bytes when called as static function", () => {
       const stringifiedAddress = Address.toString("0x1");
 
-      assert.equal(stringifiedAddress, "0x0000000000000000000000000000000000000001");
+      assert.equal(
+        stringifiedAddress,
+        "0x0000000000000000000000000000000000000001"
+      );
     });
   });
 
@@ -51,7 +60,10 @@ describe("@ganache/ethereum-address", () => {
     it("should convert a 20 byte address to a buffer", () => {
       const address = new Address("0x2104859394604359378433865360947116707876");
       const bufferAddress = address.toBuffer();
-      const expected = Buffer.from([0x21,0x04,0x85,0x93,0x94,0x60,0x43,0x59,0x37,0x84,0x33,0x86,0x53,0x60,0x94,0x71,0x16,0x70,0x78,0x76])
+      const expected = Buffer.from([
+        0x21, 0x04, 0x85, 0x93, 0x94, 0x60, 0x43, 0x59, 0x37, 0x84, 0x33, 0x86,
+        0x53, 0x60, 0x94, 0x71, 0x16, 0x70, 0x78, 0x76
+      ]);
       assert.deepEqual(bufferAddress, expected);
     });
 

--- a/src/chains/ethereum/address/tests/index.test.ts
+++ b/src/chains/ethereum/address/tests/index.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import {Address} from "../";
+import { Address } from "../";
 
 describe("@ganache/ethereum-address", () => {
   describe("toString()", () => {

--- a/src/chains/ethereum/block/src/block.ts
+++ b/src/chains/ethereum/block/src/block.ts
@@ -44,7 +44,7 @@ export class Block {
       const totalDifficulty = deserialized[3];
       this.header = makeHeader(this._raw, totalDifficulty);
       this._rawTransactionMetaData = deserialized[4] || [];
-      this._size = Quantity.from(deserialized[5]).toNumber();
+      this._size = Quantity.toNumber(deserialized[5]);
     }
   }
 
@@ -64,7 +64,7 @@ export class Block {
         hash,
         this.hash().toBuffer(),
         this.header.number.toBuffer(),
-        Quantity.from(index).toBuffer()
+        Quantity.toBuffer(index)
       ];
       return TransactionFactory.fromDatabaseTx(raw, common, extra);
     });
@@ -86,7 +86,7 @@ export class Block {
         hash,
         hashBuffer,
         number,
-        Quantity.from(index).toBuffer()
+        Quantity.toBuffer(index)
       ];
       const tx = TransactionFactory.fromDatabaseTx(raw, common, extra);
       // we could either parse the raw data to check if the tx is type 2,

--- a/src/chains/ethereum/block/src/runtime-block.ts
+++ b/src/chains/ethereum/block/src/runtime-block.ts
@@ -131,7 +131,7 @@ export class RuntimeBlock {
       baseFeePerGas:
         baseFeePerGas === undefined
           ? new BnExtra(BUFFER_ZERO)
-          : new BnExtra(Quantity.from(baseFeePerGas).toBuffer())
+          : new BnExtra(Quantity.toBuffer(baseFeePerGas))
     };
     // When forking we might get a block that doesn't have a baseFeePerGas value,
     // but EIP-1559 might be active on our chain. We need to keep track on if
@@ -166,7 +166,7 @@ export class RuntimeBlock {
       header.difficulty.buf,
       header.number.buf,
       header.gasLimit.buf,
-      gasUsed === 0n ? BUFFER_EMPTY : Quantity.from(gasUsed).toBuffer(),
+      gasUsed === 0n ? BUFFER_EMPTY : Quantity.toBuffer(gasUsed),
       header.timestamp.buf,
       extraData.toBuffer(),
       BUFFER_32_ZERO, // mixHash

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -31,10 +31,7 @@ import {
   PromiEvent,
   Api,
   keccak,
-  RPCQUANTITY_ZERO,
-  RPCQUANTITY_EMPTY,
   JsonRpcErrorCode,
-  RPCQUANTITY_GWEI
 } from "@ganache/utils";
 import Blockchain from "./blockchain";
 import { EthereumInternalOptions } from "@ganache/ethereum-options";
@@ -63,8 +60,8 @@ async function autofillDefaultTransactionValues(
 ) {
   if (tx.gas.isNull()) {
     const defaultLimit = options.miner.defaultTransactionGasLimit;
-    if (defaultLimit === RPCQUANTITY_EMPTY) {
-      // if the default limit is `RPCQUANTITY_EMPTY` use a gas estimate
+    if (defaultLimit === Quantity.Empty) {
+      // if the default limit is `Quantity.Empty` use a gas estimate
       tx.gas = await eth_estimateGas(transaction, Tag.latest);
     } else {
       tx.gas = defaultLimit;
@@ -878,7 +875,7 @@ export default class EthereumApi implements Api {
    */
   @assertArgLength(0)
   async net_peerCount() {
-    return RPCQUANTITY_ZERO;
+    return Quantity.Zero;
   }
   //#endregion
 
@@ -1314,7 +1311,7 @@ export default class EthereumApi implements Api {
    */
   @assertArgLength(1)
   async eth_getUncleCountByBlockHash(hash: DATA) {
-    return RPCQUANTITY_ZERO;
+    return Quantity.Zero;
   }
 
   /**
@@ -1502,7 +1499,7 @@ export default class EthereumApi implements Api {
    */
   @assertArgLength(0)
   async eth_hashrate() {
-    return RPCQUANTITY_ZERO;
+    return Quantity.Zero;
   }
 
   /**
@@ -1530,7 +1527,7 @@ export default class EthereumApi implements Api {
    */
   @assertArgLength(0)
   async eth_maxPriorityFeePerGas() {
-    return RPCQUANTITY_GWEI;
+    return Quantity.Gwei;
   }
 
   /**

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -376,7 +376,7 @@ export default class EthereumApi implements Api {
     const account = await stateManager.getAccount({ buf: buffer } as any);
 
     account.nonce = {
-      toArrayLike: () => Quantity.from(nonce).toBuffer()
+      toArrayLike: () => Quantity.toBuffer(nonce)
     } as any;
 
     await stateManager.putAccount({ buf: buffer } as any, account);
@@ -414,7 +414,7 @@ export default class EthereumApi implements Api {
     const account = await stateManager.getAccount({ buf: buffer } as any);
 
     account.balance = {
-      toArrayLike: () => Quantity.from(balance).toBuffer()
+      toArrayLike: () => Quantity.toBuffer(balance)
     } as any;
 
     await stateManager.putAccount({ buf: buffer } as any, account);
@@ -447,7 +447,7 @@ export default class EthereumApi implements Api {
     // TODO: the effect of this function could happen during a block mine operation, which would cause all sorts of
     // issues. We need to figure out a good way of timing this.
     const addressBuffer = Address.from(address).toBuffer();
-    const codeBuffer = Data.from(code).toBuffer();
+    const codeBuffer = Data.toBuffer(code);
     const blockchain = this.#blockchain;
     const stateManager = blockchain.vm.stateManager;
     // The ethereumjs-vm StateManager does not allow to set empty code,
@@ -495,8 +495,8 @@ export default class EthereumApi implements Api {
     // TODO: the effect of this function could happen during a block mine operation, which would cause all sorts of
     // issues. We need to figure out a good way of timing this.
     const addressBuffer = Address.from(address).toBuffer();
-    const slotBuffer = Data.from(slot).toBuffer();
-    const valueBuffer = Data.from(value).toBuffer();
+    const slotBuffer = Data.toBuffer(slot);
+    const valueBuffer = Data.toBuffer(value);
     const blockchain = this.#blockchain;
     const stateManager = blockchain.vm.stateManager;
     await stateManager.putContractStorage(
@@ -527,7 +527,7 @@ export default class EthereumApi implements Api {
     const milliseconds =
       (typeof seconds === "number"
         ? seconds
-        : Quantity.from(seconds).toNumber()) * 1000;
+        : Quantity.toNumber(seconds)) * 1000;
     return Math.floor(this.#blockchain.increaseTime(milliseconds) / 1000);
   }
 
@@ -560,7 +560,7 @@ export default class EthereumApi implements Api {
         timestamp = time;
         break;
       default:
-        timestamp = Quantity.from(time).toNumber();
+        timestamp = Quantity.toNumber(time);
         break;
     }
     const blockchain = this.#blockchain;
@@ -836,7 +836,7 @@ export default class EthereumApi implements Api {
    */
   @assertArgLength(1)
   async web3_sha3(data: DATA) {
-    return Data.from(keccak(Data.from(data).toBuffer()));
+    return Data.from(keccak(Data.toBuffer(data)));
   }
   //#endregion
 
@@ -1249,7 +1249,7 @@ export default class EthereumApi implements Api {
       .catch<Block>(_ => null);
     if (!block) return null;
     const transactions = block.getTransactions();
-    return transactions[Quantity.from(index).toNumber()].toJSON(
+    return transactions[Quantity.toNumber(index)].toJSON(
       blockchain.common
     );
   }
@@ -1296,7 +1296,7 @@ export default class EthereumApi implements Api {
     const block = await blockchain.blocks.get(number).catch<Block>(_ => null);
     if (!block) return null;
     const transactions = block.getTransactions();
-    return transactions[Quantity.from(index).toNumber()].toJSON(
+    return transactions[Quantity.toNumber(index)].toJSON(
       blockchain.common
     );
   }
@@ -1686,7 +1686,7 @@ export default class EthereumApi implements Api {
     const trie = blockchain.trie.copy(false);
     trie.setContext(blockStateRoot, null, blockNum);
 
-    const posBuff = Quantity.from(position).toBuffer();
+    const posBuff = Quantity.toBuffer(position);
     const length = posBuff.length;
     let paddedPosBuff: Buffer;
     if (length < 32) {
@@ -1752,7 +1752,7 @@ export default class EthereumApi implements Api {
     | null
   > {
     const { transactions } = this.#blockchain;
-    const hashBuffer = Data.from(transactionHash).toBuffer();
+    const hashBuffer = Data.toBuffer(transactionHash);
 
     // we must check the database before checking the pending cache, because the
     // cache is updated _after_ the transaction is already in the database, and
@@ -1989,7 +1989,7 @@ export default class EthereumApi implements Api {
       throw new Error("cannot sign data; no private key");
     }
 
-    const messageHash = hashPersonalMessage(Data.from(message).toBuffer());
+    const messageHash = hashPersonalMessage(Data.toBuffer(message));
     const { v, r, s } = ecsign(messageHash, privateKey.toBuffer());
     return toRpcSig(v, r, s);
   }
@@ -2488,7 +2488,7 @@ export default class EthereumApi implements Api {
    */
   @assertArgLength(1)
   async eth_getFilterChanges(filterId: QUANTITY): Promise<Data[]> {
-    const filter = this.#filters.get(Quantity.from(filterId).toString());
+    const filter = this.#filters.get(Quantity.toString(filterId));
     if (filter) {
       const updates = filter.updates;
       filter.updates = [];
@@ -2514,7 +2514,7 @@ export default class EthereumApi implements Api {
    */
   @assertArgLength(1)
   async eth_uninstallFilter(filterId: QUANTITY): Promise<boolean> {
-    const id = Quantity.from(filterId).toString();
+    const id = Quantity.toString(filterId);
     const filter = this.#filters.get(id);
     if (!filter) return false;
     filter.unsubscribe();
@@ -2558,7 +2558,7 @@ export default class EthereumApi implements Api {
    */
   @assertArgLength(1)
   async eth_getFilterLogs(filterId: QUANTITY): Promise<Ethereum.Logs> {
-    const filter = this.#filters.get(Quantity.from(filterId).toString());
+    const filter = this.#filters.get(Quantity.toString(filterId));
     if (filter && filter.type === FilterTypes.log) {
       return this.eth_getLogs(filter.filter);
     } else {
@@ -2917,10 +2917,10 @@ export default class EthereumApi implements Api {
   ): Promise<Ethereum.StorageRangeAtResult<"private">> {
     return this.#blockchain.storageRangeAt(
       blockHash,
-      Quantity.from(transactionIndex).toNumber(),
+      Quantity.toNumber(transactionIndex),
       contractAddress,
       startKey,
-      Quantity.from(maxResult).toNumber()
+      Quantity.toNumber(maxResult)
     );
   }
 

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -1326,7 +1326,7 @@ export default class EthereumApi implements Api {
    */
   @assertArgLength(1)
   async eth_getUncleCountByBlockNumber(blockNumber: QUANTITY | Ethereum.Tag) {
-    return RPCQUANTITY_ZERO;
+    return Quantity.Zero;
   }
 
   /**

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -31,7 +31,7 @@ import {
   PromiEvent,
   Api,
   keccak,
-  JsonRpcErrorCode,
+  JsonRpcErrorCode
 } from "@ganache/utils";
 import Blockchain from "./blockchain";
 import { EthereumInternalOptions } from "@ganache/ethereum-options";
@@ -522,9 +522,8 @@ export default class EthereumApi implements Api {
   @assertArgLength(1)
   async evm_increaseTime(seconds: number | QUANTITY) {
     const milliseconds =
-      (typeof seconds === "number"
-        ? seconds
-        : Quantity.toNumber(seconds)) * 1000;
+      (typeof seconds === "number" ? seconds : Quantity.toNumber(seconds)) *
+      1000;
     return Math.floor(this.#blockchain.increaseTime(milliseconds) / 1000);
   }
 
@@ -1246,9 +1245,7 @@ export default class EthereumApi implements Api {
       .catch<Block>(_ => null);
     if (!block) return null;
     const transactions = block.getTransactions();
-    return transactions[Quantity.toNumber(index)].toJSON(
-      blockchain.common
-    );
+    return transactions[Quantity.toNumber(index)].toJSON(blockchain.common);
   }
 
   /**
@@ -1293,9 +1290,7 @@ export default class EthereumApi implements Api {
     const block = await blockchain.blocks.get(number).catch<Block>(_ => null);
     if (!block) return null;
     const transactions = block.getTransactions();
-    return transactions[Quantity.toNumber(index)].toJSON(
-      blockchain.common
-    );
+    return transactions[Quantity.toNumber(index)].toJSON(blockchain.common);
   }
 
   /**

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -911,11 +911,6 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
     const rawValue = snapshotId.toBigInt();
     this.#options.logging.logger.log("Reverting to snapshot #" + snapshotId);
 
-    // snapshot ids can't be < 1, so we do a quick sanity check here
-    if (rawValue < 1n) {
-      return false;
-    }
-
     const snapshots = this.#snapshots;
     const snaps = snapshots.snaps;
     const snapshotIndex = Number(rawValue - 1n);

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -524,7 +524,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
       str += `  Contract created: ${Address.from(contractAddress)}${EOL}`;
     }
 
-    str += `  Gas usage: ${Quantity.from(receipt.raw[1]).toNumber()}
+    str += `  Gas usage: ${Quantity.toNumber(receipt.raw[1])}
   Block number: ${blockNumber.toNumber()}
   Block time: ${timestamp}${EOL}`;
 
@@ -1124,7 +1124,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
         } as any,
         data: transaction.data && transaction.data.toBuffer(),
         gasPrice: new BN(transaction.gasPrice.toBuffer()),
-        gasLimit: new BN(Quantity.from(gasLeft).toBuffer()),
+        gasLimit: new BN(Quantity.toBuffer(gasLeft)),
         to,
         value:
           transaction.value == null
@@ -1346,7 +1346,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
                   rawKey
                 );
 
-                storage[Data.from(key, key.length).toString()] = {
+                storage[Data.toString(key, key.length)] = {
                   key: Data.from(rawKey, rawKey.length),
                   value: Data.from(result, 32)
                 };
@@ -1442,7 +1442,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
     transactionHash: string,
     options: TraceTransactionOptions
   ) {
-    const transactionHashBuffer = Data.from(transactionHash).toBuffer();
+    const transactionHashBuffer = Data.toBuffer(transactionHash);
     // #1 - get block via transaction object
     const transaction = await this.transactions.get(transactionHashBuffer);
 
@@ -1555,7 +1555,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
       );
 
       return new Promise<RangedStorageKeys>((resolve, reject) => {
-        const startKeyBuffer = Data.from(startKey).toBuffer();
+        const startKeyBuffer = Data.toBuffer(startKey);
         const compare = (a: Buffer, b: Buffer) => a.compare(b) < 0;
 
         const keys: Buffer[] = [];

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -904,11 +904,11 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
   }
 
   public async revert(snapshotId: Quantity) {
-    const rawValue = snapshotId.valueOf();
-    if (rawValue === null || rawValue === undefined) {
+    if (snapshotId.isNull()) {
       throw new Error("invalid snapshotId");
     }
 
+    const rawValue = snapshotId.toBigInt();
     this.#options.logging.logger.log("Reverting to snapshot #" + snapshotId);
 
     // snapshot ids can't be < 1, so we do a quick sanity check here

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -32,10 +32,8 @@ import {
   Quantity,
   Data,
   BUFFER_EMPTY,
-  RPCQUANTITY_EMPTY,
   BUFFER_32_ZERO,
   BUFFER_256_ZERO,
-  RPCQUANTITY_ZERO,
   findInsertPosition,
   unref,
   KNOWN_CHAINIDS
@@ -740,12 +738,12 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
     await this.#commitAccounts(initialAccounts);
 
     // README: block `0` is weird in that a `0` _should_ be hashed as `[]`,
-    // instead of `[0]`, so we set it to `RPCQUANTITY_EMPTY` instead of
-    // `RPCQUANTITY_ZERO` here. A few lines down in this function we swap
-    // this `RPCQUANTITY_EMPTY` for `RPCQUANTITY_ZERO`. This is all so we don't
+    // instead of `[0]`, so we set it to `Quantity.Empty` instead of
+    // `Quantity.Zero` here. A few lines down in this function we swap
+    // this `Quantity.Empty` for `Quantity.Zero`. This is all so we don't
     // have to have a "treat empty as 0` check in every function that uses the
     // "latest" block (which this genesis block will be for brief moment).
-    const rawBlockNumber = RPCQUANTITY_EMPTY;
+    const rawBlockNumber = Quantity.Empty;
 
     // create the genesis block
     const baseFeePerGas = this.common.isActivatedEIP(1559)
@@ -759,7 +757,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
       BUFFER_ZERO,
       Quantity.from(timestamp),
       this.#options.miner.difficulty,
-      RPCQUANTITY_ZERO, // we start the totalDifficulty at 0
+      Quantity.Zero, // we start the totalDifficulty at 0
       baseFeePerGas
     );
 
@@ -775,7 +773,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
       new Map()
     );
     // README: set the block number to an actual 0 now.
-    block.header.number = RPCQUANTITY_ZERO;
+    block.header.number = Quantity.Zero;
     const hash = block.hash();
     return this.blocks
       .putBlock(block.header.number.toBuffer(), hash, serialized)

--- a/src/chains/ethereum/ethereum/src/data-managers/account-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/account-manager.ts
@@ -5,7 +5,7 @@ import {
   Tag
 } from "@ganache/ethereum-utils";
 import { KECCAK256_NULL } from "ethereumjs-util";
-import { Quantity, Data, RPCQUANTITY_ZERO, DATA_EMPTY } from "@ganache/utils";
+import { Quantity, Data } from "@ganache/utils";
 import { Address } from "@ganache/ethereum-address";
 import { decode } from "@ganache/rlp";
 import Blockchain from "../blockchain";
@@ -62,10 +62,10 @@ export default class AccountManager {
   ): Promise<Quantity> {
     const data = await this.getRaw(address, blockNumber);
 
-    if (data == null) return RPCQUANTITY_ZERO;
+    if (data == null) return Quantity.Zero;
 
     const [nonce] = decode<EthereumRawAccount>(data);
-    return nonce.length === 0 ? RPCQUANTITY_ZERO : Quantity.from(nonce);
+    return nonce.length === 0 ? Quantity.Zero : Quantity.from(nonce);
   }
 
   public async getBalance(
@@ -74,10 +74,10 @@ export default class AccountManager {
   ): Promise<Quantity> {
     const data = await this.getRaw(address, blockNumber);
 
-    if (data == null) return RPCQUANTITY_ZERO;
+    if (data == null) return Quantity.Zero;
 
     const [, balance] = decode<EthereumRawAccount>(data);
-    return balance.length === 0 ? RPCQUANTITY_ZERO : Quantity.from(balance);
+    return balance.length === 0 ? Quantity.Zero : Quantity.from(balance);
   }
 
   public async getNonceAndBalance(
@@ -87,12 +87,12 @@ export default class AccountManager {
     const data = await this.getRaw(address, blockNumber);
 
     if (data == null)
-      return { nonce: RPCQUANTITY_ZERO, balance: RPCQUANTITY_ZERO };
+      return { nonce: Quantity.Zero, balance: Quantity.Zero };
 
     const [nonce, balance] = decode<EthereumRawAccount>(data);
     return {
-      nonce: nonce.length === 0 ? RPCQUANTITY_ZERO : Quantity.from(nonce),
-      balance: balance.length === 0 ? RPCQUANTITY_ZERO : Quantity.from(balance)
+      nonce: nonce.length === 0 ? Quantity.Zero : Quantity.from(nonce),
+      balance: balance.length === 0 ? Quantity.Zero : Quantity.from(balance)
     };
   }
 
@@ -102,10 +102,10 @@ export default class AccountManager {
   ): Promise<Data> {
     const data = await this.getRaw(address, blockNumber);
 
-    if (data == null) return DATA_EMPTY;
+    if (data == null) return Data.Empty;
 
     const [, , , codeHash] = decode<EthereumRawAccount>(data);
-    if (codeHash.equals(KECCAK256_NULL)) return DATA_EMPTY;
+    if (codeHash.equals(KECCAK256_NULL)) return Data.Empty;
     else return this.#blockchain.trie.db.get(codeHash).then(Data.from);
   }
 }

--- a/src/chains/ethereum/ethereum/src/data-managers/account-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/account-manager.ts
@@ -86,8 +86,7 @@ export default class AccountManager {
   ) {
     const data = await this.getRaw(address, blockNumber);
 
-    if (data == null)
-      return { nonce: Quantity.Zero, balance: Quantity.Zero };
+    if (data == null) return { nonce: Quantity.Zero, balance: Quantity.Zero };
 
     const [nonce, balance] = decode<EthereumRawAccount>(data);
     return {

--- a/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
@@ -68,38 +68,38 @@ export default class BlockManager extends Manager<Block> {
 
   static rawFromJSON(json: any, common: Common) {
     const header: EthereumRawBlockHeader = [
-      Data.from(json.parentHash).toBuffer(),
-      Data.from(json.sha3Uncles).toBuffer(),
+      Data.toBuffer(json.parentHash),
+      Data.toBuffer(json.sha3Uncles),
       Address.from(json.miner).toBuffer(),
-      Data.from(json.stateRoot).toBuffer(),
-      Data.from(json.transactionsRoot).toBuffer(),
-      Data.from(json.receiptsRoot).toBuffer(),
-      Data.from(json.logsBloom).toBuffer(),
-      Quantity.from(json.difficulty).toBuffer(),
-      Quantity.from(json.number).toBuffer(),
-      Quantity.from(json.gasLimit).toBuffer(),
-      Quantity.from(json.gasUsed).toBuffer(),
-      Quantity.from(json.timestamp).toBuffer(),
-      Data.from(json.extraData).toBuffer(),
-      Data.from(json.mixHash).toBuffer(),
-      Data.from(json.nonce).toBuffer()
+      Data.toBuffer(json.stateRoot),
+      Data.toBuffer(json.transactionsRoot),
+      Data.toBuffer(json.receiptsRoot),
+      Data.toBuffer(json.logsBloom),
+      Quantity.toBuffer(json.difficulty),
+      Quantity.toBuffer(json.number),
+      Quantity.toBuffer(json.gasLimit),
+      Quantity.toBuffer(json.gasUsed),
+      Quantity.toBuffer(json.timestamp),
+      Data.toBuffer(json.extraData),
+      Data.toBuffer(json.mixHash),
+      Data.toBuffer(json.nonce)
     ];
     // only add baseFeePerGas if the block's JSON already has it
     if (json.baseFeePerGas !== undefined) {
-      header[15] = Data.from(json.baseFeePerGas).toBuffer();
+      header[15] = Data.toBuffer(json.baseFeePerGas);
     }
-    const totalDifficulty = Quantity.from(json.totalDifficulty).toBuffer();
+    const totalDifficulty = Quantity.toBuffer(json.totalDifficulty);
     const txs: TypedDatabaseTransaction[] = [];
     const extraTxs: GanacheRawBlockTransactionMetaData[] = [];
     json.transactions.forEach((tx, index) => {
       const blockExtra = [
-        Quantity.from(tx.from).toBuffer(),
-        Quantity.from(tx.hash).toBuffer()
+        Quantity.toBuffer(tx.from),
+        Quantity.toBuffer(tx.hash)
       ] as any;
       const txExtra = [
         ...blockExtra,
-        Data.from(json.hash).toBuffer(),
-        Quantity.from(json.number).toBuffer(),
+        Data.toBuffer(json.hash),
+        Quantity.toBuffer(json.number),
         index
       ] as any;
       const typedTx = TransactionFactory.fromRpc(tx, common, txExtra);
@@ -174,7 +174,7 @@ export default class BlockManager extends Manager<Block> {
   }
 
   async getNumberFromHash(hash: string | Buffer | Tag) {
-    return this.#blockIndexes.get(Data.from(hash).toBuffer()).catch(e => {
+    return this.#blockIndexes.get(Data.toBuffer(hash)).catch(e => {
       if (e.status === NOTFOUND) return null;
       throw e;
     }) as Promise<Buffer | null>;

--- a/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
@@ -308,12 +308,16 @@ export default class BlockManager extends Manager<Block> {
       const stream = this.base.createValueStream();
       this.latest = await new Promise<Block>((resolve, reject) => {
         let latest: Block;
-        stream.on("data", (data: Buffer) => {
-          const block = new Block(data, this.#common);
-          if (!latest || block.header.number.toBigInt() > latest.header.number.toBigInt()) {
-            latest = block;
-          }
-        })
+        stream
+          .on("data", (data: Buffer) => {
+            const block = new Block(data, this.#common);
+            if (
+              !latest ||
+              block.header.number.toBigInt() > latest.header.number.toBigInt()
+            ) {
+              latest = block;
+            }
+          })
           .on("error", (err: Error) => {
             reject(err);
           })
@@ -323,7 +327,9 @@ export default class BlockManager extends Manager<Block> {
       });
       if (this.latest) {
         // update the LATEST_INDEX_KEY index so we don't have to do this next time
-        await this.#blockIndexes.put(LATEST_INDEX_KEY, this.latest.header.number.toBuffer()).catch(e => null)
+        await this.#blockIndexes
+          .put(LATEST_INDEX_KEY, this.latest.header.number.toBuffer())
+          .catch(e => null);
       }
     }
   }

--- a/src/chains/ethereum/ethereum/src/data-managers/blocklog-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/blocklog-manager.ts
@@ -55,7 +55,7 @@ export default class BlockLogManager extends Manager<BlockLogs> {
         // fetch all the blockLogs in-between `fromBlock` and `toBlock` (excluding
         // from, because we already started fetching that one)
         for (let i = fromBlockNumber + 1, l = toBlockNumber + 1; i < l; i++) {
-          pendingLogsPromises.push(this.get(Quantity.from(i).toBuffer()));
+          pendingLogsPromises.push(this.get(Quantity.toBuffer(i)));
         }
       }
 

--- a/src/chains/ethereum/ethereum/src/data-managers/manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/manager.ts
@@ -19,7 +19,7 @@ export default class Manager<T> {
   }
   getRaw(key: string | Buffer): Promise<Buffer> {
     if (typeof key === "string") {
-      key = Data.from(key).toBuffer();
+      key = Data.toBuffer(key);
     }
 
     if (key.length === 0) {

--- a/src/chains/ethereum/ethereum/src/data-managers/transaction-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/transaction-manager.ts
@@ -6,6 +6,7 @@ import Blockchain from "../blockchain";
 import PromiseQueue from "@ganache/promise-queue";
 import type Common from "@ethereumjs/common";
 import { Data, Quantity } from "@ganache/utils";
+import { Address } from "@ganache/ethereum-address";
 import {
   GanacheRawExtraTx,
   TransactionFactory,
@@ -57,8 +58,8 @@ export default class TransactionManager extends Manager<NoOp> {
     if (!fallback.isValidForkBlockNumber(blockNumber)) return null;
 
     const extra: GanacheRawExtraTx = [
-      Data.toBuffer(tx.from, 20),
-      Data.from((tx as any).hash, 32).toBuffer(),
+      Address.toBuffer(tx.from),
+      Data.toBuffer((tx as any).hash, 32),
       blockHash.toBuffer(),
       blockNumber.toBuffer(),
       index.toBuffer(),

--- a/src/chains/ethereum/ethereum/src/data-managers/transaction-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/transaction-manager.ts
@@ -44,7 +44,7 @@ export default class TransactionManager extends Manager<NoOp> {
   fromFallback = async (transactionHash: Buffer) => {
     const { fallback } = this.#blockchain;
     const tx = await fallback.request<Transaction>("eth_getTransactionByHash", [
-      Data.from(transactionHash).toString()
+      Data.toString(transactionHash)
     ]);
     if (tx == null) return null;
 
@@ -57,12 +57,12 @@ export default class TransactionManager extends Manager<NoOp> {
     if (!fallback.isValidForkBlockNumber(blockNumber)) return null;
 
     const extra: GanacheRawExtraTx = [
-      Data.from(tx.from, 20).toBuffer(),
+      Data.toBuffer(tx.from, 20),
       Data.from((tx as any).hash, 32).toBuffer(),
       blockHash.toBuffer(),
       blockNumber.toBuffer(),
       index.toBuffer(),
-      Quantity.from(tx.gasPrice).toBuffer()
+      Quantity.toBuffer(tx.gasPrice)
     ];
     const common = fallback.getCommonForBlockNumber(
       fallback.common,

--- a/src/chains/ethereum/ethereum/src/data-managers/transaction-receipt-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/transaction-receipt-manager.ts
@@ -31,16 +31,16 @@ export default class TransactionReceiptManager extends Manager<InternalTransacti
 
       const status =
         res.status === "0x1" ? RPCQUANTITY_ONE.toBuffer() : BUFFER_ZERO;
-      const cumulativeGasUsed = Quantity.from(res.cumulativeGasUsed).toBuffer();
-      const logsBloom = Data.from(res.logsBloom, 256).toBuffer();
+      const cumulativeGasUsed = Quantity.toBuffer(res.cumulativeGasUsed);
+      const logsBloom = Data.toBuffer(res.logsBloom, 256);
       const logs = res.logs.map(log => [
         Address.from(log.address).toBuffer(),
-        log.topics.map(topic => Data.from(topic).toBuffer()),
+        log.topics.map(topic => Data.toBuffer(topic)),
         Array.isArray(log.data)
-          ? log.data.map(data => Data.from(data).toBuffer())
-          : Data.from(log.data).toBuffer()
+          ? log.data.map(data => Data.toBuffer(data))
+          : Data.toBuffer(log.data)
       ]);
-      const gasUsed = Quantity.from(res.gasUsed).toBuffer();
+      const gasUsed = Quantity.toBuffer(res.gasUsed);
       const contractAddress =
         res.contractAddress == null
           ? BUFFER_EMPTY

--- a/src/chains/ethereum/ethereum/src/data-managers/transaction-receipt-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/transaction-receipt-manager.ts
@@ -4,7 +4,6 @@ import {
   Data,
   Quantity,
   BUFFER_EMPTY,
-  RPCQUANTITY_ONE,
   BUFFER_ZERO
 } from "@ganache/utils";
 import Blockchain from "../blockchain";
@@ -30,7 +29,7 @@ export default class TransactionReceiptManager extends Manager<InternalTransacti
       if (!res) return null;
 
       const status =
-        res.status === "0x1" ? RPCQUANTITY_ONE.toBuffer() : BUFFER_ZERO;
+        res.status === "0x1" ? Quantity.One.toBuffer() : BUFFER_ZERO;
       const cumulativeGasUsed = Quantity.toBuffer(res.cumulativeGasUsed);
       const logsBloom = Data.toBuffer(res.logsBloom, 256);
       const logs = res.logs.map(log => [

--- a/src/chains/ethereum/ethereum/src/data-managers/transaction-receipt-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/transaction-receipt-manager.ts
@@ -1,11 +1,6 @@
 import { LevelUp } from "levelup";
 import Manager from "./manager";
-import {
-  Data,
-  Quantity,
-  BUFFER_EMPTY,
-  BUFFER_ZERO
-} from "@ganache/utils";
+import { Data, Quantity, BUFFER_EMPTY, BUFFER_ZERO } from "@ganache/utils";
 import Blockchain from "../blockchain";
 import { InternalTransactionReceipt } from "@ganache/ethereum-transaction";
 import { Address } from "@ganache/ethereum-address";

--- a/src/chains/ethereum/ethereum/src/forking/lexicographic-key-codec.ts
+++ b/src/chains/ethereum/ethereum/src/forking/lexicographic-key-codec.ts
@@ -13,7 +13,7 @@ export function encode(parts: Buffer[]) {
       pieces.push([BUFFER_ZERO, BUFFER_EMPTY]);
     } else {
       const length = part.length;
-      const lengthBuffer = Quantity.from(length).toBuffer();
+      const lengthBuffer = Quantity.toBuffer(length);
       const lengthLength = lengthBuffer.length;
 
       totalLength += 1 + lengthLength + length;

--- a/src/chains/ethereum/ethereum/src/forking/persistent-cache/helpers.ts
+++ b/src/chains/ethereum/ethereum/src/forking/persistent-cache/helpers.ts
@@ -165,7 +165,7 @@ export async function* findRelated(
     // if the chain has a block at this height, and the hash of the
     // block is the same as the one in the db we've found our closest
     // ancestor!
-    if (block != null && block.hash === Data.from(node.hash).toString()) {
+    if (block != null && block.hash === Data.toString(node.hash)) {
       yield node;
     }
   }

--- a/src/chains/ethereum/ethereum/src/forking/persistent-cache/helpers.ts
+++ b/src/chains/ethereum/ethereum/src/forking/persistent-cache/helpers.ts
@@ -1,5 +1,5 @@
 import { Tag } from "@ganache/ethereum-utils";
-import { BUFFER_EMPTY, Data, DATA_EMPTY, Quantity } from "@ganache/utils";
+import { BUFFER_EMPTY, Data, Quantity } from "@ganache/utils";
 import { LevelUp } from "levelup";
 import { Tree } from "./tree";
 
@@ -185,7 +185,7 @@ export async function findClosestAncestor(
 ) {
   const generator = findRelated(db, request, {
     gte: upTo,
-    lt: Tree.encodeKey(height, DATA_EMPTY),
+    lt: Tree.encodeKey(height, Data.Empty),
     reverse: true
   });
   const first = await generator.next();
@@ -204,7 +204,7 @@ export async function* findClosestDescendants(
   height: Quantity
 ) {
   const generator = findRelated(db, request, {
-    gte: Tree.encodeKey(Quantity.from(height.toBigInt() + 1n), DATA_EMPTY),
+    gte: Tree.encodeKey(Quantity.from(height.toBigInt() + 1n), Data.Empty),
     reverse: false
   });
   for await (const node of generator) {

--- a/src/chains/ethereum/ethereum/src/forking/persistent-cache/persistent-cache.ts
+++ b/src/chains/ethereum/ethereum/src/forking/persistent-cache/persistent-cache.ts
@@ -87,10 +87,10 @@ export class PersistentCache {
           descendants[keyHex] = node;
           collection[parentKeyHex].descendants = descendants;
         }
-        (node as any).hash = Data.from(node.hash).toString();
+        (node as any).hash = Data.toString(node.hash);
         (node as any).parent =
           node.closestKnownAncestor.length > 0
-            ? Data.from(collection[parentKeyHex].hash).toString()
+            ? Data.toString(collection[parentKeyHex].hash)
             : null;
         delete node.key;
         // delete node.hash;
@@ -201,7 +201,7 @@ export class PersistentCache {
           if (
             descendantRawBlock == null ||
             descendantRawBlock.hash !==
-            Data.from(descendantNode.hash, 32).toString()
+            Data.toString(descendantNode.hash, 32)
           ) {
             ancestorsDescendants.push(descendantKey);
           } else {

--- a/src/chains/ethereum/ethereum/src/forking/persistent-cache/persistent-cache.ts
+++ b/src/chains/ethereum/ethereum/src/forking/persistent-cache/persistent-cache.ts
@@ -47,7 +47,7 @@ export class PersistentCache {
   protected ancestry: Ancestry;
   protected hashBuffer: Buffer;
   protected request: Request;
-  constructor() { }
+  constructor() {}
 
   static async deleteDb(dbSuffix?: string) {
     return new Promise((resolve, reject) => {
@@ -73,7 +73,7 @@ export class PersistentCache {
       const tree: Tree = {};
       const collection = {};
       for await (const data of rs) {
-        const { key, value } = (data as any) as { key: Buffer; value: Buffer };
+        const { key, value } = data as any as { key: Buffer; value: Buffer };
 
         const node = Tree.deserialize(key, value);
         (node as any).height = node.decodeKey().height.toNumber();
@@ -115,7 +115,10 @@ export class PersistentCache {
     const directory = PersistentCache.getDbDirectory(dbSuffix);
     await promises.mkdir(directory, { recursive: true });
 
-    const store: AbstractLevelDOWN = encode(leveldown(directory, leveldownOpts), levelupOptions);
+    const store: AbstractLevelDOWN = encode(
+      leveldown(directory, leveldownOpts),
+      levelupOptions
+    );
     const db = await new Promise<LevelUp>((resolve, reject) => {
       const db = levelup(store, (err: Error) => {
         if (err) return void reject(err);
@@ -136,16 +139,13 @@ export class PersistentCache {
     this.hashBuffer = hash.toBuffer();
     this.request = request;
 
-    const {
-      targetBlock,
-      closestAncestor,
-      previousClosestAncestor
-    } = await resolveTargetAndClosestAncestor(
-      this.ancestorDb,
-      this.request,
-      height,
-      hash
-    );
+    const { targetBlock, closestAncestor, previousClosestAncestor } =
+      await resolveTargetAndClosestAncestor(
+        this.ancestorDb,
+        this.request,
+        height,
+        hash
+      );
 
     this.ancestry = new Ancestry(this.ancestorDb, closestAncestor);
 
@@ -200,8 +200,7 @@ export class PersistentCache {
           // keep it in the parent
           if (
             descendantRawBlock == null ||
-            descendantRawBlock.hash !==
-            Data.toString(descendantNode.hash, 32)
+            descendantRawBlock.hash !== Data.toString(descendantNode.hash, 32)
           ) {
             ancestorsDescendants.push(descendantKey);
           } else {
@@ -239,7 +238,7 @@ export class PersistentCache {
       // we don't care if it fails because this is an optimization that only
       // matters for _future_ runs of ganache for blocks beyond our current fork
       // block
-      .catch(_ => { })
+      .catch(_ => {})
       .finally(() => {
         this._reBalancePromise = null;
       });
@@ -337,11 +336,14 @@ export class PersistentCache {
     });
 
     for await (const data of readStream) {
-      const { key: k, value } = (data as any) as { key: Buffer; value: Buffer };
+      const { key: k, value } = data as any as { key: Buffer; value: Buffer };
       const [_height, _key, blockHash] = lexico.decode(k);
       // if our key no longer matches make sure we don't keep searching
       if (!_key.equals(bufKey)) return;
-      if (this.hashBuffer.equals(blockHash) || (await this.ancestry.has(blockHash))) {
+      if (
+        this.hashBuffer.equals(blockHash) ||
+        (await this.ancestry.has(blockHash))
+      ) {
         return value;
       }
     }

--- a/src/chains/ethereum/ethereum/src/forking/trie.ts
+++ b/src/chains/ethereum/ethereum/src/forking/trie.ts
@@ -215,7 +215,7 @@ export class ForkTrie extends GanacheTrie {
     try {
       const codeHex = await codeProm;
       if (codeHex !== "0x") {
-        const code = Data.from(codeHex).toBuffer();
+        const code = Data.toBuffer(codeHex);
         // the codeHash is just the keccak hash of the code itself
         account.codeHash = keccak(code);
         if (!account.codeHash.equals(KECCAK256_NULL)) {

--- a/src/chains/ethereum/ethereum/src/forking/trie.ts
+++ b/src/chains/ethereum/ethereum/src/forking/trie.ts
@@ -2,7 +2,6 @@ import { Address } from "@ganache/ethereum-address";
 import {
   keccak,
   BUFFER_EMPTY,
-  RPCQUANTITY_EMPTY,
   Quantity,
   Data
 } from "@ganache/utils";
@@ -234,9 +233,9 @@ export class ForkTrie extends GanacheTrie {
     // the serialized data
     const [nonce, balance] = await Promise.all(promises);
     account.nonce =
-      nonce === "0x0" ? RPCQUANTITY_EMPTY : Quantity.from(nonce, true);
+      nonce === "0x0" ? Quantity.Empty : Quantity.from(nonce, true);
     account.balance =
-      balance === "0x0" ? RPCQUANTITY_EMPTY : Quantity.from(balance);
+      balance === "0x0" ? Quantity.Empty : Quantity.from(balance);
 
     return account.serialize();
   };

--- a/src/chains/ethereum/ethereum/src/forking/trie.ts
+++ b/src/chains/ethereum/ethereum/src/forking/trie.ts
@@ -1,10 +1,5 @@
 import { Address } from "@ganache/ethereum-address";
-import {
-  keccak,
-  BUFFER_EMPTY,
-  Quantity,
-  Data
-} from "@ganache/utils";
+import { keccak, BUFFER_EMPTY, Quantity, Data } from "@ganache/utils";
 import type { LevelUp } from "levelup";
 import Blockchain from "../blockchain";
 import AccountManager from "../data-managers/account-manager";
@@ -147,7 +142,7 @@ export class ForkTrie extends GanacheTrie {
       reverse: true
     });
     for await (const data of stream) {
-      const { key: encodedKey, value } = (data as unknown) as KVP;
+      const { key: encodedKey, value } = data as unknown as KVP;
       if (!value || !value.equals(DELETED_VALUE)) continue;
       if (isEqualKey(encodedKey, selfAddress, key)) return true;
     }
@@ -194,9 +189,8 @@ export class ForkTrie extends GanacheTrie {
   ) => {
     const { fallback } = this.blockchain;
 
-    const number = this.blockchain.fallback.selectValidForkBlockNumber(
-      blockNumber
-    );
+    const number =
+      this.blockchain.fallback.selectValidForkBlockNumber(blockNumber);
 
     // get nonce, balance, and code from the fork/fallback
     const codeProm = fallback.request<string>(GET_CODE, [address, number]);
@@ -290,7 +284,11 @@ export class ForkTrie extends GanacheTrie {
    */
   copy(includeCheckpoints: boolean = true) {
     const db = this.db.copy() as CheckpointDB;
-    const secureTrie = new ForkTrie(db._leveldb as LevelUp, this.root, this.blockchain);
+    const secureTrie = new ForkTrie(
+      db._leveldb as LevelUp,
+      this.root,
+      this.blockchain
+    );
     secureTrie.accounts = this.accounts;
     secureTrie.address = this.address;
     secureTrie.blockNumber = this.blockNumber;

--- a/src/chains/ethereum/ethereum/src/helpers/gas-estimator.ts
+++ b/src/chains/ethereum/ethereum/src/helpers/gas-estimator.ts
@@ -1,6 +1,6 @@
 import { BN } from "ethereumjs-util";
 import { RuntimeError, RETURN_TYPES } from "@ganache/ethereum-utils";
-import { RPCQUANTITY_EMPTY } from "@ganache/utils";
+import { Quantity } from "@ganache/utils";
 
 const bn = (val = 0) => new (BN as any)(val);
 const STIPEND = bn(2300);
@@ -256,7 +256,7 @@ const exactimate = async (vm, runArgs, callback) => {
   } else if (result.execResult.exceptionError) {
     const error = new RuntimeError(
       // erroneous gas estimations don't have meaningful hashes
-      RPCQUANTITY_EMPTY,
+      Quantity.Empty,
       result,
       RETURN_TYPES.RETURN_VALUE
     );

--- a/src/chains/ethereum/ethereum/src/helpers/run-call.ts
+++ b/src/chains/ethereum/ethereum/src/helpers/run-call.ts
@@ -185,8 +185,9 @@ export async function applySimulationOverrides(
             await stateManager.clearContractStorage(vmAddr);
             clearedState = true;
           }
-          const slotBuf = Quantity.from(slot).toBuffer();
-          const valueBuf = Quantity.from(value).toBuffer();
+          const slotBuf = Data.from(slot, 32).toBuffer();
+          const valueBuf = Data.from(value).toBuffer();
+
           await stateManager.putContractStorage(vmAddr, slotBuf, valueBuf);
         }
       } else {
@@ -196,8 +197,9 @@ export async function applySimulationOverrides(
           const value = stateDiff[slot];
           validateStorageOverride(slot, value, "StateDiff");
 
-          const slotBuf = Quantity.from(slot).toBuffer();
-          const valueBuf = Quantity.from(value).toBuffer();
+          const slotBuf = Data.from(slot, 32).toBuffer();
+          const valueBuf = Data.from(value).toBuffer();
+
           await stateManager.putContractStorage(vmAddr, slotBuf, valueBuf);
         }
       }

--- a/src/chains/ethereum/ethereum/src/helpers/run-call.ts
+++ b/src/chains/ethereum/ethereum/src/helpers/run-call.ts
@@ -82,7 +82,7 @@ export function runCall(
 
   const message = new Message({
     caller,
-    gasLimit: new BN(Quantity.from(gasLeft).toBuffer()),
+    gasLimit: new BN(Quantity.toBuffer(gasLeft)),
     to,
     value,
     data: transaction.data && transaction.data.toBuffer()
@@ -142,19 +142,19 @@ export async function applySimulationOverrides(
         account.nonce = {
           toArrayLike: () =>
             // geth treats empty strings as "0x0" nonce for overrides
-            nonce === "" ? BUFFER_EMPTY : Quantity.from(nonce).toBuffer()
+            nonce === "" ? BUFFER_EMPTY : Quantity.toBuffer(nonce)
         } as any;
       }
       if (balance != null) {
         account.balance = {
           toArrayLike: () =>
             // geth treats empty strings as "0x0" balance for overrides
-            balance === "" ? BUFFER_EMPTY : Quantity.from(balance).toBuffer()
+            balance === "" ? BUFFER_EMPTY : Quantity.toBuffer(balance)
         } as any;
       }
       if (code != null) {
         // geth treats empty strings as "0x" code for overrides
-        const codeBuffer = Data.from(code === "" ? "0x" : code).toBuffer();
+        const codeBuffer = Data.toBuffer(code === "" ? "0x" : code);
         // The ethereumjs-vm StateManager does not allow to set empty code,
         // therefore we will manually set the code hash when "clearing" the contract code
         const codeHash =
@@ -185,8 +185,8 @@ export async function applySimulationOverrides(
             await stateManager.clearContractStorage(vmAddr);
             clearedState = true;
           }
-          const slotBuf = Data.from(slot, 32).toBuffer();
-          const valueBuf = Data.from(value).toBuffer();
+          const slotBuf = Data.toBuffer(slot, 32);
+          const valueBuf = Data.toBuffer(value);
 
           await stateManager.putContractStorage(vmAddr, slotBuf, valueBuf);
         }
@@ -197,8 +197,8 @@ export async function applySimulationOverrides(
           const value = stateDiff[slot];
           validateStorageOverride(slot, value, "StateDiff");
 
-          const slotBuf = Data.from(slot, 32).toBuffer();
-          const valueBuf = Data.from(value).toBuffer();
+          const slotBuf = Data.toBuffer(slot, 32);
+          const valueBuf = Data.toBuffer(value);
 
           await stateManager.putContractStorage(vmAddr, slotBuf, valueBuf);
         }

--- a/src/chains/ethereum/ethereum/src/wallet.ts
+++ b/src/chains/ethereum/ethereum/src/wallet.ts
@@ -9,7 +9,6 @@ import {
   Data,
   keccak,
   Quantity,
-  RPCQUANTITY_ZERO,
   unref,
   WEI
 } from "@ganache/utils";
@@ -557,7 +556,7 @@ export default class Wallet {
     const acct = createAccountFromSeed(seed);
     const address = uncompressedPublicKeyToAddress(acct.publicKey);
     const privateKey = Data.from(acct.privateKey);
-    return Wallet.createAccount(RPCQUANTITY_ZERO, privateKey, address);
+    return Wallet.createAccount(Quantity.Zero, privateKey, address);
   }
 
   public async unlockAccount(

--- a/src/chains/ethereum/ethereum/tests/api/debug/debug.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/debug/debug.test.ts
@@ -185,7 +185,7 @@ describe("api", () => {
 
       // The next line is gross, but it makes testing new values easy.
       const timesToRunLoopArgument = Data.from(
-        Quantity.from(timesToRunLoop).toBuffer(),
+        Quantity.toBuffer(timesToRunLoop),
         32
       )
         .toString()
@@ -211,8 +211,8 @@ describe("api", () => {
         {
           data: contract.code,
           from: from.toString(),
-          gasLimit: Quantity.from(6721975).toString(),
-          nonce: Quantity.from(0).toString()
+          gasLimit: Quantity.toString(6721975),
+          nonce: Quantity.toString(0)
         },
         common
       );
@@ -239,9 +239,9 @@ describe("api", () => {
           ).toString(),
           to: Address.from(contractAddress).toString(),
           from,
-          gasLimit: Quantity.from(6721975).toString(),
+          gasLimit: Quantity.toString(6721975),
           nonce: "0x1",
-          gasPrice: Quantity.from(0).toString()
+          gasPrice: Quantity.toString(0)
         },
         common
       );

--- a/src/chains/ethereum/ethereum/tests/api/debug/debug_storageRangeAt.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/debug/debug_storageRangeAt.test.ts
@@ -432,7 +432,7 @@ describe("api", () => {
             from: accounts[0],
             to: contractAddress,
             gas: "0x2fefd8",
-            data: `0x${methods["setValue(uint)"]}${initialValue}`
+            data: `0x${methods["setValue(uint256)"]}${initialValue}`
           }
         ]);
         await provider.once("message");

--- a/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
@@ -524,7 +524,7 @@ describe("api", () => {
                 },
                 {
                   junk: "0x",
-                  error: `Cannot wrap "0x" as a json-rpc Quantity type; Quantity must contain at least one digit`
+                  error: `Cannot wrap "0x" as a json-rpc Quantity type; strings must contain at least one hexadecimal symbol.`
                 },
               ],
               contractMethod: `0x${methods["getBalance(address)"]}${encodedAddr}`

--- a/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
@@ -508,7 +508,7 @@ describe("api", () => {
                 },
                 {
                   junk: "123",
-                  error: `cannot convert string value "123" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
                 },
                 {
                   junk: {},
@@ -545,7 +545,7 @@ describe("api", () => {
                 },
                 {
                   junk: "123",
-                  error: `cannot convert string value "123" into type \`Data\`; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
                 },
                 {
                   junk: {},
@@ -571,7 +571,7 @@ describe("api", () => {
                 },
                 {
                   junk: "",
-                  error: `cannot convert string value "" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
                 },
                 {
                   junk: "0x",
@@ -583,7 +583,7 @@ describe("api", () => {
                 },
                 {
                   junk: "123",
-                  error: `cannot convert string value "123" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
                 },
                 {
                   junk: {},
@@ -611,7 +611,7 @@ describe("api", () => {
                 },
                 {
                   junk: "",
-                  error: `cannot convert string value "" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
                 },
                 {
                   junk: "0x",
@@ -623,7 +623,7 @@ describe("api", () => {
                 },
                 {
                   junk: "123",
-                  error: `cannot convert string value "123" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
                 },
                 {
                   junk: {},
@@ -642,16 +642,16 @@ describe("api", () => {
               junks: [
                 {
                   junk: null,
-                  error: `cannot convert string value "null" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`,
+                  error: `Cannot wrap string value "null" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`,
                   expectedValue: null
                 },
                 {
                   junk: undefined,
-                  error: `cannot convert string value "undefined" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "undefined" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
                 },
                 {
                   junk: "",
-                  error: `cannot convert string value "" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
                 },
                 {
                   junk: "0x",
@@ -663,11 +663,11 @@ describe("api", () => {
                 },
                 {
                   junk: "123",
-                  error: `cannot convert string value "123" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
                 },
                 {
                   junk: {},
-                  error: `cannot convert string value "[object Object]" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "[object Object]" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
                 }
                 // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2725 is closed
                 // { junk: "0xa string", error: `` }
@@ -682,16 +682,16 @@ describe("api", () => {
               junks: [
                 {
                   junk: null,
-                  error: `cannot convert string value "null" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`,
+                  error: `Cannot wrap string value "null" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`,
                   expectedValue: null
                 },
                 {
                   junk: undefined,
-                  error: `cannot convert string value "undefined" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "undefined" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
                 },
                 {
                   junk: "",
-                  error: `cannot convert string value "" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
                 },
                 {
                   junk: "0x",
@@ -703,11 +703,11 @@ describe("api", () => {
                 },
                 {
                   junk: "123",
-                  error: `cannot convert string value "123" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
                 },
                 {
                   junk: {},
-                  error: `cannot convert string value "[object Object]" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "[object Object]" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
                 }
                 // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2725 is closed
                 // { junk: "0xa string", error: `` }
@@ -734,7 +734,7 @@ describe("api", () => {
                 },
                 {
                   junk: "123",
-                  error: `cannot convert string value "123" into type \`Quantity\`; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
                 },
                 {
                   junk: {},
@@ -787,7 +787,7 @@ describe("api", () => {
                 await assert.rejects(
                   prom,
                   new Error(error),
-                  `Failed junk data validation for "${type}" override type with value "${junk}".`
+                  `Failed junk data validation for "${type}" override type with value "${junk}". Expected error: ${error}`
                 );
               } else {
                 assert.strictEqual(

--- a/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
@@ -524,7 +524,7 @@ describe("api", () => {
                 },
                 {
                   junk: "0x",
-                  error: `Cannot wrap "0x" as a json-rpc Quantity type; strings must contain at least one hexadecimal symbol.`
+                  error: `Cannot wrap "0x" as a json-rpc Quantity type; strings must contain at least one hexadecimal character.`
                 },
               ],
               contractMethod: `0x${methods["getBalance(address)"]}${encodedAddr}`

--- a/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
@@ -513,13 +513,19 @@ describe("api", () => {
                 {
                   junk: {},
                   error: `Cannot wrap a "object" as a json-rpc type`
-                }
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2725 is closed
-                // { junk: "0xa string", error: `` }
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2728 is closed
-                // { junk: -9, error: `` },
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2857 is closed
-                //{ junk: "0x", error: `` },
+                },
+                {
+                  junk: "0xa string",
+                  error: `Cannot wrap string value "0xa string" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                },
+                {
+                  junk: -9,
+                  error: "Cannot wrap a negative value as a json-rpc type"
+                },
+                {
+                  junk: "0x",
+                  error: `Cannot wrap "0x" as a json-rpc Quantity type; Quantity must contain at least one digit`
+                },
               ],
               contractMethod: `0x${methods["getBalance(address)"]}${encodedAddr}`
             },

--- a/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
@@ -20,7 +20,7 @@ import { GanacheTrie } from "../../../src/helpers/trie";
 import { Transaction } from "@ganache/ethereum-transaction";
 
 const encodeValue = (val: number | string) => {
-  return Quantity.from(val).toBuffer().toString("hex").padStart(64, "0");
+  return Quantity.toBuffer(val).toString("hex").padStart(64, "0");
 };
 
 async function deployContract(provider, from, code) {
@@ -77,7 +77,7 @@ describe("api", () => {
         it("executes a message call", async () => {
           const result = await provider.send("eth_call", [tx, "latest"]);
           // gets the contract's "value", which should be 5
-          assert.strictEqual(Quantity.from(result).toNumber(), 5);
+          assert.strictEqual(Quantity.toNumber(result), 5);
         });
 
         it("does not create a transaction on the chain", async () => {
@@ -100,7 +100,7 @@ describe("api", () => {
           };
           const result = await provider.send("eth_call", [tx, "latest"]);
           // we can still get the result when the gasPrice is set
-          assert.strictEqual(Quantity.from(result).toNumber(), 5);
+          assert.strictEqual(Quantity.toNumber(result), 5);
         });
 
         it("allows eip-1559 fee market transactions", async () => {
@@ -114,13 +114,13 @@ describe("api", () => {
 
           const result = await provider.send("eth_call", [tx, "latest"]);
           // we can still get the result when the maxFeePerGas/maxPriorityFeePerGas are set
-          assert.strictEqual(Quantity.from(result).toNumber(), 5);
+          assert.strictEqual(Quantity.toNumber(result), 5);
         });
 
         it("allows gas price to be omitted", async () => {
           const result = await provider.send("eth_call", [tx, "latest"]);
           // we can get the value if no gas info is given at all
-          assert.strictEqual(Quantity.from(result).toNumber(), 5);
+          assert.strictEqual(Quantity.toNumber(result), 5);
         });
 
         it("rejects transactions that specify both legacy and eip-1559 transaction fields", async () => {
@@ -850,10 +850,10 @@ describe("api", () => {
             block: block
           };
           ethereumJsFromAddress = new EthereumJsAddress(
-            Quantity.from(from).toBuffer()
+            Quantity.toBuffer(from)
           );
           ethereumJsToAddress = new EthereumJsAddress(
-            Quantity.from(to).toBuffer()
+            Quantity.toBuffer(to)
           );
           // set up a real transaction
           transaction = {

--- a/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
@@ -3,7 +3,7 @@ import { EthereumProvider } from "../../../src/provider";
 import getProvider from "../../helpers/getProvider";
 import compile, { CompileOutput } from "../../helpers/compile";
 import { join } from "path";
-import { BUFFER_EMPTY, Data, Quantity, RPCQUANTITY_ONE } from "@ganache/utils";
+import { BUFFER_EMPTY, Data, Quantity } from "@ganache/utils";
 import { CallError } from "@ganache/ethereum-utils";
 import Blockchain from "../../../src/blockchain";
 import Wallet from "../../../src/wallet";
@@ -836,7 +836,7 @@ describe("api", () => {
             gas.toBuffer(),
             parentHeader.gasUsed.toBuffer(),
             parentHeader.timestamp,
-            RPCQUANTITY_ONE, // difficulty
+            Quantity.One, // difficulty
             parentHeader.totalDifficulty,
             parentHeader.baseFeePerGas.toBigInt()
           );

--- a/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
@@ -525,7 +525,7 @@ describe("api", () => {
                 {
                   junk: "0x",
                   error: `Cannot wrap "0x" as a json-rpc Quantity type; strings must contain at least one hexadecimal character.`
-                },
+                }
               ],
               contractMethod: `0x${methods["getBalance(address)"]}${encodedAddr}`
             },
@@ -556,11 +556,15 @@ describe("api", () => {
                 {
                   junk: {},
                   error: `Cannot wrap a "object" as a json-rpc type`
+                },
+                {
+                  junk: "0xa string",
+                  error: `Cannot wrap string value "0xa string" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                },
+                {
+                  junk: -9,
+                  error: "Cannot wrap a negative value as a json-rpc type"
                 }
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2725 is closed
-                // { junk: "0xa string", error: `` }
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2728 is closed
-                // { junk: -9, error: `` },
               ],
               contractMethod: `0x${methods["getCode(address)"]}${encodedContractAddress}`
             },
@@ -594,13 +598,19 @@ describe("api", () => {
                 {
                   junk: {},
                   error: `Cannot wrap a "object" as a json-rpc type`
+                },
+                {
+                  junk: "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth",
+                  error: `Cannot wrap string value "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                },
+                {
+                  junk: -9,
+                  error: "Cannot wrap a negative value as a json-rpc type"
+                },
+                {
+                  junk: "0x",
+                  error: "StateDiff override data must be a 64 character hex string. Received 0 character string."
                 }
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2725 is closed
-                // { junk: "0xa string", error: `` }
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2728 is closed
-                // { junk: -9, error: `` },
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2857 is closed
-                //{ junk: "0x", error: `` },
               ],
               contractMethod: `0x${methods["getStorageAt(uint256)"]}${slot}`
             },
@@ -634,13 +644,19 @@ describe("api", () => {
                 {
                   junk: {},
                   error: `Cannot wrap a "object" as a json-rpc type`
+                },
+                { // State override data must be 64 characters long in order to hit this validation
+                  junk: "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth",
+                  error: `Cannot wrap string value "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                },
+                {
+                  junk: -9,
+                  error: "Cannot wrap a negative value as a json-rpc type"
+                },
+                {
+                  junk: "0x",
+                  error: "State override data must be a 64 character hex string. Received 0 character string."
                 }
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2725 is closed
-                // { junk: "0xa string", error: `` }
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2728 is closed
-                // { junk: -9, error: `` },
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2857 is closed
-                //{ junk: "0x", error: `` },
               ],
               contractMethod: `0x${methods["getStorageAt(uint256)"]}${slot}`
             },
@@ -674,13 +690,19 @@ describe("api", () => {
                 {
                   junk: {},
                   error: `Cannot wrap string value "[object Object]" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                },
+                {
+                  junk: "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth",
+                  error: `Cannot wrap string value "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                },
+                {
+                  junk: -9,
+                  error: `Cannot wrap string value "-9" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                },
+                {
+                  junk: "0x",
+                  error: "StateDiff override slot must be a 64 character hex string. Received 0 character string."
                 }
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2725 is closed
-                // { junk: "0xa string", error: `` }
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2728 is closed
-                // { junk: -9, error: `` },
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2857 is closed
-                //{ junk: "0x", error: `` },
               ],
               contractMethod: `0x${methods["getStorageAt(uint256)"]}${slot}`
             },
@@ -714,13 +736,19 @@ describe("api", () => {
                 {
                   junk: {},
                   error: `Cannot wrap string value "[object Object]" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                },
+                { // State override must be 64 characters long in order to hit this validation
+                  junk: "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth",
+                  error: `Cannot wrap string value "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                },
+                {
+                  junk: -9,
+                  error: `Cannot wrap string value "-9" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                },
+                {
+                  junk: "0x",
+                  error: `State override slot must be a 64 character hex string. Received 0 character string.`
                 }
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2725 is closed
-                // { junk: "0xa string", error: `` }
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2728 is closed
-                // { junk: -9, error: `` },
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2857 is closed
-                //{ junk: "0x", error: `` },
               ],
               contractMethod: `0x${methods["getStorageAt(uint256)"]}${slot}`
             },
@@ -745,13 +773,19 @@ describe("api", () => {
                 {
                   junk: {},
                   error: `Cannot wrap a "object" as a json-rpc type`
+                },
+                {
+                  junk: "0xa string",
+                  error: `Cannot wrap string value "0xa string" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                },
+                {
+                  junk: -9,
+                  error: "Cannot wrap a negative value as a json-rpc type"
+                },
+                {
+                  junk: "0x",
+                  error: `Cannot wrap "0x" as a json-rpc Quantity type; strings must contain at least one hexadecimal character.`
                 }
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2725 is closed
-                // { junk: "0xa string", error: `` }
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2728 is closed
-                // { junk: -9, error: `` },
-                // TODO: add this back once https://github.com/trufflesuite/ganache/issues/2857 is closed
-                //{ junk: "0x", error: `` },
               ],
               contractMethod: `0x${methods["createContract(bytes)"]}${simpleSol}`
             }

--- a/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
@@ -609,7 +609,8 @@ describe("api", () => {
                 },
                 {
                   junk: "0x",
-                  error: "StateDiff override data must be a 64 character hex string. Received 0 character string."
+                  error:
+                    "StateDiff override data must be a 64 character hex string. Received 0 character string."
                 }
               ],
               contractMethod: `0x${methods["getStorageAt(uint256)"]}${slot}`
@@ -645,7 +646,8 @@ describe("api", () => {
                   junk: {},
                   error: `Cannot wrap a "object" as a json-rpc type`
                 },
-                { // State override data must be 64 characters long in order to hit this validation
+                {
+                  // State override data must be 64 characters long in order to hit this validation
                   junk: "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth",
                   error: `Cannot wrap string value "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth" as a json-rpc type; the input value contains an invalid hex character.`
                 },
@@ -655,7 +657,8 @@ describe("api", () => {
                 },
                 {
                   junk: "0x",
-                  error: "State override data must be a 64 character hex string. Received 0 character string."
+                  error:
+                    "State override data must be a 64 character hex string. Received 0 character string."
                 }
               ],
               contractMethod: `0x${methods["getStorageAt(uint256)"]}${slot}`
@@ -701,7 +704,8 @@ describe("api", () => {
                 },
                 {
                   junk: "0x",
-                  error: "StateDiff override slot must be a 64 character hex string. Received 0 character string."
+                  error:
+                    "StateDiff override slot must be a 64 character hex string. Received 0 character string."
                 }
               ],
               contractMethod: `0x${methods["getStorageAt(uint256)"]}${slot}`
@@ -737,7 +741,8 @@ describe("api", () => {
                   junk: {},
                   error: `Cannot wrap string value "[object Object]" as a json-rpc type; strings must be prefixed with "0x".`
                 },
-                { // State override must be 64 characters long in order to hit this validation
+                {
+                  // State override must be 64 characters long in order to hit this validation
                   junk: "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth",
                   error: `Cannot wrap string value "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth" as a json-rpc type; the input value contains an invalid hex character.`
                 },
@@ -892,9 +897,7 @@ describe("api", () => {
           ethereumJsFromAddress = new EthereumJsAddress(
             Quantity.toBuffer(from)
           );
-          ethereumJsToAddress = new EthereumJsAddress(
-            Quantity.toBuffer(to)
-          );
+          ethereumJsToAddress = new EthereumJsAddress(Quantity.toBuffer(to));
           // set up a real transaction
           transaction = {
             from,

--- a/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
@@ -508,7 +508,7 @@ describe("api", () => {
                 },
                 {
                   junk: "123",
-                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: {},
@@ -516,7 +516,7 @@ describe("api", () => {
                 },
                 {
                   junk: "0xa string",
-                  error: `Cannot wrap string value "0xa string" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "0xa string" as a json-rpc type; the input value contains an invalid hex character.`
                 },
                 {
                   junk: -9,
@@ -551,7 +551,7 @@ describe("api", () => {
                 },
                 {
                   junk: "123",
-                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: {},
@@ -559,7 +559,7 @@ describe("api", () => {
                 },
                 {
                   junk: "0xa string",
-                  error: `Cannot wrap string value "0xa string" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "0xa string" as a json-rpc type; the input value contains an invalid hex character.`
                 },
                 {
                   junk: -9,
@@ -581,7 +581,7 @@ describe("api", () => {
                 },
                 {
                   junk: "",
-                  error: `Cannot wrap string value "" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: "0x",
@@ -593,7 +593,7 @@ describe("api", () => {
                 },
                 {
                   junk: "123",
-                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: {},
@@ -601,7 +601,7 @@ describe("api", () => {
                 },
                 {
                   junk: "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth",
-                  error: `Cannot wrap string value "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth" as a json-rpc type; the input value contains an invalid hex character.`
                 },
                 {
                   junk: -9,
@@ -627,7 +627,7 @@ describe("api", () => {
                 },
                 {
                   junk: "",
-                  error: `Cannot wrap string value "" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: "0x",
@@ -639,7 +639,7 @@ describe("api", () => {
                 },
                 {
                   junk: "123",
-                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: {},
@@ -647,7 +647,7 @@ describe("api", () => {
                 },
                 { // State override data must be 64 characters long in order to hit this validation
                   junk: "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth",
-                  error: `Cannot wrap string value "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth" as a json-rpc type; the input value contains an invalid hex character.`
                 },
                 {
                   junk: -9,
@@ -664,16 +664,16 @@ describe("api", () => {
               junks: [
                 {
                   junk: null,
-                  error: `Cannot wrap string value "null" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`,
+                  error: `Cannot wrap string value "null" as a json-rpc type; strings must be prefixed with "0x".`,
                   expectedValue: null
                 },
                 {
                   junk: undefined,
-                  error: `Cannot wrap string value "undefined" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "undefined" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: "",
-                  error: `Cannot wrap string value "" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: "0x",
@@ -685,19 +685,19 @@ describe("api", () => {
                 },
                 {
                   junk: "123",
-                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: {},
-                  error: `Cannot wrap string value "[object Object]" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "[object Object]" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth",
-                  error: `Cannot wrap string value "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth" as a json-rpc type; the input value contains an invalid hex character.`
                 },
                 {
                   junk: -9,
-                  error: `Cannot wrap string value "-9" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "-9" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: "0x",
@@ -710,16 +710,16 @@ describe("api", () => {
               junks: [
                 {
                   junk: null,
-                  error: `Cannot wrap string value "null" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`,
+                  error: `Cannot wrap string value "null" as a json-rpc type; strings must be prefixed with "0x".`,
                   expectedValue: null
                 },
                 {
                   junk: undefined,
-                  error: `Cannot wrap string value "undefined" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "undefined" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: "",
-                  error: `Cannot wrap string value "" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: "0x",
@@ -731,19 +731,19 @@ describe("api", () => {
                 },
                 {
                   junk: "123",
-                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: {},
-                  error: `Cannot wrap string value "[object Object]" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "[object Object]" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 { // State override must be 64 characters long in order to hit this validation
                   junk: "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth",
-                  error: `Cannot wrap string value "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "0xnothexnothexnothexnothexnothexnothexnothexnothexnothexnothexnoth" as a json-rpc type; the input value contains an invalid hex character.`
                 },
                 {
                   junk: -9,
-                  error: `Cannot wrap string value "-9" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "-9" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: "0x",
@@ -768,7 +768,7 @@ describe("api", () => {
                 },
                 {
                   junk: "123",
-                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "123" as a json-rpc type; strings must be prefixed with "0x".`
                 },
                 {
                   junk: {},
@@ -776,7 +776,7 @@ describe("api", () => {
                 },
                 {
                   junk: "0xa string",
-                  error: `Cannot wrap string value "0xa string" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`
+                  error: `Cannot wrap string value "0xa string" as a json-rpc type; the input value contains an invalid hex character.`
                 },
                 {
                   junk: -9,

--- a/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
@@ -1,4 +1,4 @@
-import { RPCQUANTITY_GWEI } from "@ganache/utils";
+import { Quantity } from "@ganache/utils";
 import assert from "assert";
 import { EthereumProvider } from "../../../src/provider";
 import getProvider, { mnemonic } from "../../helpers/getProvider";
@@ -52,7 +52,7 @@ describe("api", () => {
     describe("eth_maxPriorityFeePerGas", () => {
       it("should return 1 GWEI", async () => {
         const tip = await provider.send("eth_maxPriorityFeePerGas");
-        assert.strictEqual(tip, RPCQUANTITY_GWEI.toString());
+        assert.strictEqual(tip, Quantity.Gwei.toString());
       });
     });
 

--- a/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
@@ -492,8 +492,10 @@ describe("api", () => {
       await provider.send("miner_start");
 
       await provider.once("message");
-      
-      const {hash: blockHash} = await provider.send("eth_getBlockByNumber", ["0x1"]);
+
+      const { hash: blockHash } = await provider.send("eth_getBlockByNumber", [
+        "0x1"
+      ]);
       const retrievedTx1 = await provider.send(
         "eth_getTransactionByBlockHashAndIndex",
         [blockHash, "0x0"]

--- a/src/chains/ethereum/ethereum/tests/api/eth/getCode.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getCode.test.ts
@@ -28,7 +28,7 @@ describe("api", () => {
 
         it("should return 0x for un-initialized address", async () => {
           const code = await provider.send("eth_getCode", [
-            "0xabcdefg012345678abcdefg012345678abcdefg0"
+            "0xabcdef012345678abcdef012345678abcdef0123"
           ]);
           assert.strictEqual(code, "0x");
         });

--- a/src/chains/ethereum/ethereum/tests/api/eth/getCode.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getCode.test.ts
@@ -176,7 +176,7 @@ describe("api", () => {
             await assert.rejects(
               provider.send("eth_getCode", [
                 contractAddress,
-                Quantity.from(nextBlockNumber).toString()
+                Quantity.toString(nextBlockNumber)
               ]),
               {
                 message: "header not found"

--- a/src/chains/ethereum/ethereum/tests/api/eth/sendTransaction.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/sendTransaction.test.ts
@@ -332,7 +332,7 @@ describe("api", () => {
           const wallet = new Wallet(options.wallet);
 
           function makeKeys(address: string) {
-            const addressBuf = Data.from(address).toBuffer();
+            const addressBuf = Data.toBuffer(address);
             const pk = BigInt(wallet.createFakePrivateKey(address).toString());
             const naivePk = Quantity.from(
               Buffer.concat([addressBuf, addressBuf.slice(0, 12)])

--- a/src/chains/ethereum/ethereum/tests/api/eth/sign.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/sign.test.ts
@@ -38,7 +38,7 @@ describe("api", () => {
         const address = accounts[0];
         let sgn = await provider.send("eth_sign", [
           address,
-          Data.from(msg).toString()
+          Data.toString(msg)
         ]);
         sgn = sgn.slice(2);
 
@@ -56,7 +56,7 @@ describe("api", () => {
         // ecsign w/ the account set in this test's 'before' block.
         const msgHex =
           "0x07091653daf94aafce9acf09e22dbde1ddf77f740f9844ac1f0ab790334f0627";
-        const edgeCaseMsg = Data.from(msgHex).toBuffer();
+        const edgeCaseMsg = Data.toBuffer(msgHex);
         const msgHash = hashPersonalMessage(edgeCaseMsg);
 
         let sgn = await provider.send("eth_sign", [accounts[0], msgHex]);

--- a/src/chains/ethereum/ethereum/tests/api/eth/subscribe.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/subscribe.test.ts
@@ -80,7 +80,7 @@ describe("api", () => {
                 miner: `0x${"0".repeat(40)}`,
                 mixHash: `0x${"0".repeat(64)}`,
                 nonce: "0x0000000000000000",
-                number: Quantity.from(startingBlockNumber + 1).toString(),
+                number: Quantity.toString(startingBlockNumber + 1),
                 parentHash:
                   "0x599bbde60ad155e0c9dbfa8575e325235c2c48f8b6c4100c175dc9b68c5c2dba",
                 receiptsRoot:
@@ -89,7 +89,7 @@ describe("api", () => {
                   "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
                 stateRoot:
                   "0x4971da3022e43da306da38e8ed8a7990b8f0d842164e1662ee28a84921d59ad4",
-                timestamp: Quantity.from(timestamp).toString(),
+                timestamp: Quantity.toString(timestamp),
                 transactionsRoot:
                   "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
               },

--- a/src/chains/ethereum/ethereum/tests/api/evm/snapshot.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/evm/snapshot.test.ts
@@ -230,16 +230,10 @@ describe("api", () => {
         );
       });
 
-      it("evm_revert returns false for out-of-range subscriptionId values", async () => {
+      it("evm_revert returns false for out-of-range subscriptionId", async () => {
         const { send } = context;
-        const ids = [-1, Buffer.from([0])];
-        const promises = ids.map(id =>
-          send("evm_revert", [id]).then(result =>
-            assert.strictEqual(result, false)
-          ).catch(() => {})
-          // either result is false, or it throws
-        );
-        await Promise.all(promises);
+        const result = await send("evm_revert", [0]);
+        assert.strictEqual(result, false);
       });
 
       it("removes transactions that are already in processing at the start of evm_revert", async () => {

--- a/src/chains/ethereum/ethereum/tests/api/evm/snapshot.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/evm/snapshot.test.ts
@@ -236,7 +236,8 @@ describe("api", () => {
         const promises = ids.map(id =>
           send("evm_revert", [id]).then(result =>
             assert.strictEqual(result, false)
-          )
+          ).catch(() => {})
+          // either result is false, or it throws
         );
         await Promise.all(promises);
       });

--- a/src/chains/ethereum/ethereum/tests/api/personal/personal.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/personal/personal.test.ts
@@ -192,7 +192,7 @@ describe("api", () => {
       const transaction = {
         from: newAccount,
         to: newAccount,
-        gasLimit: Quantity.from(21000).toString(),
+        gasLimit: Quantity.toString(21000),
         gasPrice: "0x0",
         value: "0x0",
         nonce: "0x0"

--- a/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
@@ -817,7 +817,7 @@ describe("forking", function () {
           const blockNumber = parseInt((message.data.result as any).number, 16);
           const checkValue = await get(localProvider, "value1", blockNumber);
           assert.strictEqual(
-            Quantity.from(checkValue).toNumber(),
+            Quantity.toNumber(checkValue),
             snapshotValue,
             `Value after snapshot not as expected. Conditions: ${initialValue}, ${JSON.stringify(
               snapshotValues
@@ -1076,7 +1076,7 @@ describe("forking", () => {
 
         const originalChainIdCall = await remoteProvider.send("eth_call", [
           tx,
-          Quantity.from(contractBlockNum).toString()
+          Quantity.toString(contractBlockNum)
         ]);
         assert.strictEqual(parseInt(originalChainIdCall), originalChainId);
 
@@ -1084,7 +1084,7 @@ describe("forking", () => {
         // at or before our fork block number
         const forkChainIdAtForkBlockCall = await provider.send("eth_call", [
           tx,
-          Quantity.from(contractBlockNum + 2).toString()
+          Quantity.toString(contractBlockNum + 2)
         ]);
         assert.strictEqual(
           parseInt(forkChainIdAtForkBlockCall),
@@ -1097,7 +1097,7 @@ describe("forking", () => {
         assert.strictEqual(forkChainId, 1337); // sanity check
         const forkChainIdAfterForkBlockCall = await provider.send("eth_call", [
           tx,
-          Quantity.from(contractBlockNum + 3).toString()
+          Quantity.toString(contractBlockNum + 3)
         ]);
         assert.strictEqual(
           parseInt(forkChainIdAfterForkBlockCall),

--- a/src/chains/ethereum/ethereum/tests/forking/helpers.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/helpers.ts
@@ -10,7 +10,7 @@ export const logging = {
 };
 
 export const encodeValue = (val: number) => {
-  return Quantity.from(val).toBuffer().toString("hex").padStart(64, "0");
+  return Quantity.toBuffer(val).toString("hex").padStart(64, "0");
 };
 
 export const updateRemotesAccountsBalances = async (

--- a/src/chains/ethereum/ethereum/tests/provider.test.ts
+++ b/src/chains/ethereum/ethereum/tests/provider.test.ts
@@ -314,7 +314,7 @@ describe("provider", () => {
       it("emits vm:tx:* events for eth_sendRawTransaction", async () => {
         const accounts = provider.getInitialAccounts();
         const gasPrice = await provider.send("eth_gasPrice", []);
-        const secretKey = Data.from(accounts[from].secretKey).toBuffer();
+        const secretKey = Data.toBuffer(accounts[from].secretKey);
         const tx = Transaction.fromTxData(
           // specify gasPrice so we don't have to deal with a type 2 transaction
           { ...transaction, nonce: "0x1", gasPrice },
@@ -337,7 +337,7 @@ describe("provider", () => {
         await testEvents(async () => {
           const subId = await provider.send("eth_subscribe", ["newHeads"]);
           const accounts = provider.getInitialAccounts();
-          const secretKey = Data.from(accounts[from].secretKey).toString();
+          const secretKey = Data.toString(accounts[from].secretKey);
           const password = "password";
           await provider.send("personal_importRawKey", [secretKey, password]);
           await provider.send("personal_sendTransaction", [

--- a/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
+++ b/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
@@ -323,7 +323,7 @@ describe("transaction pool", async () => {
     );
 
     // raise our replacement transaction's prices by exactly the price bump amount
-    const originalMaxFee = Quantity.from(executableRpc.maxFeePerGas).toBigInt();
+    const originalMaxFee = Quantity.toBigInt(executableRpc.maxFeePerGas);
     const originalTip = Quantity.from(
       executableRpc.maxPriorityFeePerGas
     ).toBigInt();
@@ -333,8 +333,8 @@ describe("transaction pool", async () => {
     const replacementRpc: Transaction = {
       from: from,
       type: "0x2",
-      maxFeePerGas: Quantity.from(maxFeePremium).toString(),
-      maxPriorityFeePerGas: Quantity.from(tipPremium).toString(),
+      maxFeePerGas: Quantity.toString(maxFeePremium),
+      maxPriorityFeePerGas: Quantity.toString(tipPremium),
       gasLimit: "0xffff",
       nonce: "0x0"
     };

--- a/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
+++ b/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
@@ -457,7 +457,7 @@ describe("transaction pool", async () => {
     const transaction = TransactionFactory.fromRpc(rpcTx, common);
 
     // our transaction doesn't have a nonce up front.
-    assert.strictEqual(transaction.nonce.valueOf(), undefined);
+    assert(transaction.nonce.isNull());
     await txPool.prepareTransaction(transaction, secretKey);
     // after it's prepared by the txPool, an appropriate nonce for the account is set
     assert.strictEqual(transaction.nonce.valueOf(), Quantity.from(0).valueOf());

--- a/src/chains/ethereum/options/src/miner-options.ts
+++ b/src/chains/ethereum/options/src/miner-options.ts
@@ -2,10 +2,7 @@ import { normalize } from "./helpers";
 import {
   Data,
   Quantity,
-  ACCOUNT_ZERO,
-  DATA_EMPTY,
-  RPCQUANTITY_EMPTY,
-  RPCQUANTITY_ONE
+  ACCOUNT_ZERO
 } from "@ganache/utils";
 import { Address } from "@ganache/ethereum-address";
 import { Definitions } from "@ganache/options";
@@ -261,7 +258,7 @@ export const MinerOptions: Definitions<MinerConfig> = {
   },
   defaultTransactionGasLimit: {
     normalize: rawType =>
-      rawType === "estimate" ? RPCQUANTITY_EMPTY : Quantity.from(rawType),
+      rawType === "estimate" ? Quantity.Empty : Quantity.from(rawType),
     cliDescription:
       'Sets the default transaction gas limit in WEI. Set to "estimate" to use an estimate (slows down transaction execution by 40%+).',
     default: () => Quantity.from(90_000),
@@ -271,7 +268,7 @@ export const MinerOptions: Definitions<MinerConfig> = {
   difficulty: {
     normalize: Quantity.from,
     cliDescription: "Sets the block difficulty.",
-    default: () => RPCQUANTITY_ONE,
+    default: () => Quantity.One,
     cliType: "string",
     cliCoerce: toBigIntOrString
   },
@@ -316,7 +313,7 @@ export const MinerOptions: Definitions<MinerConfig> = {
       return bytes;
     },
     cliDescription: "Set the extraData block header field a miner can include.",
-    default: () => DATA_EMPTY,
+    default: () => Data.Empty,
     cliType: "string"
   },
   priceBump: {

--- a/src/chains/ethereum/options/src/miner-options.ts
+++ b/src/chains/ethereum/options/src/miner-options.ts
@@ -1,9 +1,5 @@
 import { normalize } from "./helpers";
-import {
-  Data,
-  Quantity,
-  ACCOUNT_ZERO
-} from "@ganache/utils";
+import { Data, Quantity, ACCOUNT_ZERO } from "@ganache/utils";
 import { Address } from "@ganache/ethereum-address";
 import { Definitions } from "@ganache/options";
 

--- a/src/chains/ethereum/transaction/src/access-lists.ts
+++ b/src/chains/ethereum/transaction/src/access-lists.ts
@@ -27,12 +27,12 @@ export class AccessLists {
 
       for (let i = 0; i < accessList.length; i++) {
         const item: AccessListItem = accessList[i];
-        const addressBuffer = Data.from(item.address, 32).toBuffer();
+        const addressBuffer = Data.toBuffer(item.address, 32);
         const storageItems: Buffer[] = [];
         const storageKeysLength = item.storageKeys.length;
         slots += storageKeysLength;
         for (let index = 0; index < storageKeysLength; index++) {
-          storageItems.push(Data.from(item.storageKeys[index]).toBuffer());
+          storageItems.push(Data.toBuffer(item.storageKeys[index]));
         }
         newAccessList.push([addressBuffer, storageItems]);
       }
@@ -43,12 +43,12 @@ export class AccessLists {
       const json: AccessList = [];
       for (let i = 0; i < bufferAccessList.length; i++) {
         const data = bufferAccessList[i];
-        const address = Data.from(data[0], 32).toString();
+        const address = Data.toString(data[0], 32);
         const storageKeys: string[] = [];
         const storageKeysLength = data[1].length;
         slots += storageKeysLength;
         for (let item = 0; item < storageKeysLength; item++) {
-          storageKeys.push(Data.from(data[1][item], 32).toString());
+          storageKeys.push(Data.toString(data[1][item], 32));
         }
         const jsonItem: AccessListItem = {
           address,

--- a/src/chains/ethereum/transaction/src/access-lists.ts
+++ b/src/chains/ethereum/transaction/src/access-lists.ts
@@ -11,8 +11,18 @@ export {
   isAccessList
 } from "@ethereumjs/tx";
 import { Data } from "@ganache/utils";
+import { Address } from "@ganache/ethereum-address";
 import { Params } from "./params";
 
+const STORAGE_KEY_LENGTH = 32;
+
+/*
+  As per https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2930.md
+
+  AccessLists must be in the form of:
+  [[{20 bytes}, [{32 bytes}...]]...]
+  where ... implies "zero or more of the thing to the left"
+*/
 export class AccessLists {
   public static getAccessListData(accessList: AccessListBuffer | AccessList) {
     let AccessListJSON: AccessList;
@@ -27,12 +37,12 @@ export class AccessLists {
 
       for (let i = 0; i < accessList.length; i++) {
         const item: AccessListItem = accessList[i];
-        const addressBuffer = Data.toBuffer(item.address, 32);
+        const addressBuffer = Address.toBuffer(item.address);
         const storageItems: Buffer[] = [];
         const storageKeysLength = item.storageKeys.length;
         slots += storageKeysLength;
         for (let index = 0; index < storageKeysLength; index++) {
-          storageItems.push(Data.toBuffer(item.storageKeys[index]));
+          storageItems.push(Data.toBuffer(item.storageKeys[index], STORAGE_KEY_LENGTH));
         }
         newAccessList.push([addressBuffer, storageItems]);
       }
@@ -43,12 +53,12 @@ export class AccessLists {
       const json: AccessList = [];
       for (let i = 0; i < bufferAccessList.length; i++) {
         const data = bufferAccessList[i];
-        const address = Data.toString(data[0], 32);
+        const address = Address.toString(data[0]);
         const storageKeys: string[] = [];
         const storageKeysLength = data[1].length;
         slots += storageKeysLength;
         for (let item = 0; item < storageKeysLength; item++) {
-          storageKeys.push(Data.toString(data[1][item], 32));
+          storageKeys.push(Data.toString(data[1][item], STORAGE_KEY_LENGTH));
         }
         const jsonItem: AccessListItem = {
           address,

--- a/src/chains/ethereum/transaction/src/access-lists.ts
+++ b/src/chains/ethereum/transaction/src/access-lists.ts
@@ -42,7 +42,9 @@ export class AccessLists {
         const storageKeysLength = item.storageKeys.length;
         slots += storageKeysLength;
         for (let index = 0; index < storageKeysLength; index++) {
-          storageItems.push(Data.toBuffer(item.storageKeys[index], STORAGE_KEY_LENGTH));
+          storageItems.push(
+            Data.toBuffer(item.storageKeys[index], STORAGE_KEY_LENGTH)
+          );
         }
         newAccessList.push([addressBuffer, storageItems]);
       }

--- a/src/chains/ethereum/transaction/src/base-transaction.ts
+++ b/src/chains/ethereum/transaction/src/base-transaction.ts
@@ -79,7 +79,7 @@ export class BaseTransaction {
   public type: Quantity;
   public nonce: Quantity;
   public gas: Quantity;
-  public to: Address | null;
+  public to: Address;
   public value: Quantity;
   public data: Data;
   public v: Quantity | null;

--- a/src/chains/ethereum/transaction/src/base-transaction.ts
+++ b/src/chains/ethereum/transaction/src/base-transaction.ts
@@ -32,9 +32,8 @@ export const calculateIntrinsicGas = (
     // Bump the required gas by the amount of transactional data
     const dataLength = input.byteLength;
     if (dataLength > 0) {
-      const TRANSACTION_DATA_NON_ZERO_GAS = Params.TRANSACTION_DATA_NON_ZERO_GAS.get(
-        hardfork
-      );
+      const TRANSACTION_DATA_NON_ZERO_GAS =
+        Params.TRANSACTION_DATA_NON_ZERO_GAS.get(hardfork);
       const TRANSACTION_DATA_ZERO_GAS = Params.TRANSACTION_DATA_ZERO_GAS;
 
       // Zero and non-zero bytes are priced differently

--- a/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
@@ -3,7 +3,6 @@ import {
   Quantity,
   keccak,
   BUFFER_32_ZERO,
-  RPCQUANTITY_EMPTY,
   BUFFER_ZERO,
   JsonRpcErrorCode
 } from "@ganache/utils";
@@ -65,7 +64,7 @@ export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
       this.maxPriorityFeePerGas = Quantity.from(data[2]);
       this.maxFeePerGas = Quantity.from(data[3]);
       this.gas = Quantity.from(data[4]);
-      this.to = data[5].length == 0 ? RPCQUANTITY_EMPTY : Address.from(data[5]);
+      this.to = data[5].length == 0 ? Quantity.Empty : Address.from(data[5]);
       this.value = Quantity.from(data[6]);
       this.data = Data.from(data[7]);
       const accessListData = AccessLists.getAccessListData(data[8]);

--- a/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
@@ -178,7 +178,7 @@ export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
        */
       getBaseFee: () => {
         const fee = this.calculateIntrinsicGas();
-        return new BN(Quantity.from(fee).toBuffer());
+        return new BN(Quantity.toBuffer(fee));
       },
       getUpfrontCost: (baseFee: BN = new BN(0)) => {
         const { gas, maxPriorityFeePerGas, maxFeePerGas, value } = this;

--- a/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
@@ -179,12 +179,12 @@ export class EIP2930AccessListTransaction extends RuntimeTransaction {
        */
       getBaseFee: () => {
         const fee = this.calculateIntrinsicGas();
-        return new BN(Quantity.from(fee + this.accessListDataFee).toBuffer());
+        return new BN(Quantity.toBuffer(fee + this.accessListDataFee));
       },
       getUpfrontCost: () => {
         const { gas, gasPrice, value } = this;
         const c = gas.toBigInt() * gasPrice.toBigInt() + value.toBigInt();
-        return new BN(Quantity.from(c).toBuffer());
+        return new BN(Quantity.toBuffer(c));
       },
       supports: (capability: Capability) => {
         return CAPABILITIES.includes(capability);

--- a/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
@@ -4,7 +4,6 @@ import {
   keccak,
   BUFFER_ZERO,
   BUFFER_32_ZERO,
-  RPCQUANTITY_EMPTY,
   JsonRpcErrorCode
 } from "@ganache/utils";
 import { Address } from "@ganache/ethereum-address";
@@ -64,7 +63,7 @@ export class EIP2930AccessListTransaction extends RuntimeTransaction {
       this.nonce = Quantity.from(data[1]);
       this.gasPrice = this.effectiveGasPrice = Quantity.from(data[2]);
       this.gas = Quantity.from(data[3]);
-      this.to = data[4].length == 0 ? RPCQUANTITY_EMPTY : Address.from(data[4]);
+      this.to = data[4].length == 0 ? Quantity.Empty : Address.from(data[4]);
       this.value = Quantity.from(data[5]);
       this.data = Data.from(data[6]);
       const accessListData = AccessLists.getAccessListData(data[7]);

--- a/src/chains/ethereum/transaction/src/legacy-transaction.ts
+++ b/src/chains/ethereum/transaction/src/legacy-transaction.ts
@@ -141,12 +141,12 @@ export class LegacyTransaction extends RuntimeTransaction {
        */
       getBaseFee: () => {
         const fee = this.calculateIntrinsicGas();
-        return new BN(Quantity.from(fee).toBuffer());
+        return new BN(Quantity.toBuffer(fee));
       },
       getUpfrontCost: () => {
         const { gas, gasPrice, value } = this;
         const c = gas.toBigInt() * gasPrice.toBigInt() + value.toBigInt();
-        return new BN(Quantity.from(c).toBuffer());
+        return new BN(Quantity.toBuffer(c));
       },
       supports: (capability: Capability) => {
         return false;

--- a/src/chains/ethereum/transaction/src/legacy-transaction.ts
+++ b/src/chains/ethereum/transaction/src/legacy-transaction.ts
@@ -4,7 +4,6 @@ import {
   keccak,
   BUFFER_EMPTY,
   BUFFER_32_ZERO,
-  RPCQUANTITY_EMPTY
 } from "@ganache/utils";
 import { Address } from "@ganache/ethereum-address";
 import type Common from "@ethereumjs/common";
@@ -36,7 +35,7 @@ export class LegacyTransaction extends RuntimeTransaction {
       this.nonce = Quantity.from(data[0]);
       this.gasPrice = this.effectiveGasPrice = Quantity.from(data[1]);
       this.gas = Quantity.from(data[2]);
-      this.to = data[3].length == 0 ? RPCQUANTITY_EMPTY : Address.from(data[3]);
+      this.to = data[3].length == 0 ? Quantity.Empty : Address.from(data[3]);
       this.value = Quantity.from(data[4]);
       this.data = Data.from(data[5]);
       this.v = Quantity.from(data[6]);

--- a/src/chains/ethereum/transaction/src/legacy-transaction.ts
+++ b/src/chains/ethereum/transaction/src/legacy-transaction.ts
@@ -3,7 +3,7 @@ import {
   Quantity,
   keccak,
   BUFFER_EMPTY,
-  BUFFER_32_ZERO,
+  BUFFER_32_ZERO
 } from "@ganache/utils";
 import { Address } from "@ganache/ethereum-address";
 import type Common from "@ethereumjs/common";

--- a/src/chains/ethereum/transaction/src/runtime-transaction.ts
+++ b/src/chains/ethereum/transaction/src/runtime-transaction.ts
@@ -24,7 +24,7 @@ import { InternalTransactionReceipt } from "./transaction-receipt";
 import { Address } from "@ganache/ethereum-address";
 
 export const toValidLengthAddress = (address: string, fieldName: string) => {
-  const buffer = Data.toBuffer(address);
+  const buffer = Address.toBuffer(address);
   if (buffer.byteLength !== Address.ByteLength) {
     throw new Error(
       `The field ${fieldName} must have byte length of ${Address.ByteLength}`

--- a/src/chains/ethereum/transaction/src/runtime-transaction.ts
+++ b/src/chains/ethereum/transaction/src/runtime-transaction.ts
@@ -24,7 +24,7 @@ import { InternalTransactionReceipt } from "./transaction-receipt";
 import { Address } from "@ganache/ethereum-address";
 
 export const toValidLengthAddress = (address: string, fieldName: string) => {
-  const buffer = Data.from(address).toBuffer();
+  const buffer = Data.toBuffer(address);
   if (buffer.byteLength !== Address.ByteLength) {
     throw new Error(
       `The field ${fieldName} must have byte length of ${Address.ByteLength}`
@@ -156,7 +156,7 @@ export abstract class RuntimeTransaction extends BaseTransaction {
 
     const receipt = (this.receipt = InternalTransactionReceipt.fromValues(
       status,
-      Quantity.from(cumulativeGasUsed).toBuffer(),
+      Quantity.toBuffer(cumulativeGasUsed),
       result.bloom.bitvector,
       (this.logs = vmResult.logs || ([] as TransactionLog[])),
       result.gasUsed.toArrayLike(Buffer),

--- a/src/chains/ethereum/transaction/src/runtime-transaction.ts
+++ b/src/chains/ethereum/transaction/src/runtime-transaction.ts
@@ -6,9 +6,7 @@ import {
 import {
   Data,
   Quantity,
-  RPCQUANTITY_ONE,
   BUFFER_ZERO,
-  RPCQUANTITY_EMPTY
 } from "@ganache/utils";
 import { Transaction } from "./rpc-transaction";
 import type Common from "@ethereumjs/common";
@@ -48,7 +46,7 @@ type TransactionFinalization =
   | { status: "confirmed"; error?: Error }
   | { status: "rejected"; error: Error };
 
-const ONE_BUFFER = RPCQUANTITY_ONE.toBuffer();
+const ONE_BUFFER = Quantity.One.toBuffer();
 
 /**
  * A RuntimeTransaction can be changed; its hash is not finalized and it is not
@@ -92,7 +90,7 @@ export abstract class RuntimeTransaction extends BaseTransaction {
       this.gas = Quantity.from(data.gas == null ? data.gasLimit : data.gas);
       this.to =
         data.to == null
-          ? RPCQUANTITY_EMPTY
+          ? Quantity.Empty
           : toValidLengthAddress(data.to, "to");
       this.value = Quantity.from(data.value || 0);
       const dataVal =

--- a/src/chains/ethereum/transaction/src/runtime-transaction.ts
+++ b/src/chains/ethereum/transaction/src/runtime-transaction.ts
@@ -22,7 +22,7 @@ import { InternalTransactionReceipt } from "./transaction-receipt";
 import { Address } from "@ganache/ethereum-address";
 
 export const toValidLengthAddress = (address: string, fieldName: string) => {
-  const buffer = Address.toBuffer(address);
+  const buffer = Data.toBuffer(address);
   if (buffer.byteLength !== Address.ByteLength) {
     throw new Error(
       `The field ${fieldName} must have byte length of ${Address.ByteLength}`

--- a/src/chains/ethereum/transaction/src/runtime-transaction.ts
+++ b/src/chains/ethereum/transaction/src/runtime-transaction.ts
@@ -3,11 +3,7 @@ import {
   RETURN_TYPES,
   TransactionLog
 } from "@ganache/ethereum-utils";
-import {
-  Data,
-  Quantity,
-  BUFFER_ZERO,
-} from "@ganache/utils";
+import { Data, Quantity, BUFFER_ZERO } from "@ganache/utils";
 import { Transaction } from "./rpc-transaction";
 import type Common from "@ethereumjs/common";
 import {
@@ -89,9 +85,7 @@ export abstract class RuntimeTransaction extends BaseTransaction {
       this.nonce = Quantity.from(data.nonce, true);
       this.gas = Quantity.from(data.gas == null ? data.gasLimit : data.gas);
       this.to =
-        data.to == null
-          ? Quantity.Empty
-          : toValidLengthAddress(data.to, "to");
+        data.to == null ? Quantity.Empty : toValidLengthAddress(data.to, "to");
       this.value = Quantity.from(data.value || 0);
       const dataVal =
         data.data == null

--- a/src/chains/ethereum/transaction/src/transaction-factory.ts
+++ b/src/chains/ethereum/transaction/src/transaction-factory.ts
@@ -235,7 +235,7 @@ export class TransactionFactory {
    * @param common - Options to pass on to the constructor of the transaction
    */
   public static fromString(txData: string, common: Common) {
-    let data = Data.from(txData).toBuffer();
+    let data = Data.toBuffer(txData);
     const type = data[0];
     const txType = this.typeOf(type);
     let tx: TypedTransaction;

--- a/src/chains/ethereum/transaction/src/transaction-factory.ts
+++ b/src/chains/ethereum/transaction/src/transaction-factory.ts
@@ -2,7 +2,6 @@ import {
   Data,
   JsonRpcErrorCode,
   Quantity,
-  RPCQUANTITY_GWEI
 } from "@ganache/utils";
 import type Common from "@ethereumjs/common";
 import { LegacyTransaction } from "./legacy-transaction";
@@ -142,7 +141,7 @@ export class TransactionFactory {
               tx.maxFeePerGas = Quantity.from(null);
             }
             if (!txData.maxPriorityFeePerGas) {
-              tx.maxPriorityFeePerGas = RPCQUANTITY_GWEI;
+              tx.maxPriorityFeePerGas = Quantity.Gwei;
             }
           }
           return tx;

--- a/src/chains/ethereum/transaction/src/transaction-factory.ts
+++ b/src/chains/ethereum/transaction/src/transaction-factory.ts
@@ -1,8 +1,4 @@
-import {
-  Data,
-  JsonRpcErrorCode,
-  Quantity,
-} from "@ganache/utils";
+import { Data, JsonRpcErrorCode, Quantity } from "@ganache/utils";
 import type Common from "@ethereumjs/common";
 import { LegacyTransaction } from "./legacy-transaction";
 import { EIP2930AccessListTransaction } from "./eip2930-access-list-transaction";

--- a/src/chains/ethereum/transaction/src/transaction-receipt.ts
+++ b/src/chains/ethereum/transaction/src/transaction-receipt.ts
@@ -2,12 +2,11 @@ import { Address } from "@ganache/ethereum-address";
 import { BlockLogs, TransactionLog } from "@ganache/ethereum-utils";
 import { decode, digest, encodeRange } from "@ganache/rlp";
 import { Data, Quantity } from "@ganache/utils";
-import { RPCQUANTITY_ZERO, RPCQUANTITY_ONE } from "@ganache/utils";
 import { AccessList } from "./access-lists";
 import Common from "@ethereumjs/common";
 import { TypedTransaction } from "./transaction-types";
 
-const STATUSES = [RPCQUANTITY_ZERO, RPCQUANTITY_ONE];
+const STATUSES = [Quantity.Zero, Quantity.One];
 
 type EthereumRawReceipt = [
   status: Buffer,

--- a/src/chains/ethereum/transaction/tests/index.test.ts
+++ b/src/chains/ethereum/transaction/tests/index.test.ts
@@ -33,7 +33,7 @@ describe("@ganache/ethereum-transaction", async () => {
   );
   // #region configure accounts and private keys in wallet
   const privKey = `0x${"46".repeat(32)}`;
-  const privKeyBuf = Quantity.from(privKey).toBuffer();
+  const privKeyBuf = Quantity.toBuffer(privKey);
   const options = EthereumOptionsConfig.normalize({
     wallet: {
       accounts: [

--- a/src/chains/ethereum/transaction/tests/index.test.ts
+++ b/src/chains/ethereum/transaction/tests/index.test.ts
@@ -408,7 +408,7 @@ describe("@ganache/ethereum-transaction", async () => {
       tx.signAndHash(privKeyBuf);
       assert.strictEqual(
         tx.hash.toString(),
-        "0x078395f79508111c9061f9983d387c8b7bfed990dfa098497aa4d34b0e47b265"
+        "0x1d37ff36e8af71fca608ad0f92b52e741b381663ebfe02d0dd1117a4462c206f"
       );
     });
     describe("toVmTransaction", () => {
@@ -484,7 +484,7 @@ describe("@ganache/ethereum-transaction", async () => {
       tx.signAndHash(privKeyBuf);
       assert.strictEqual(
         tx.hash.toString(),
-        "0xabe11ba446440bd0ea9b9e9de9eb479ae4555455ec2244a80ef7a72eddf6fe17"
+        "0xd6bf3834e7515e9806407646b1a55541c1de4abc4763f5d905f23eda856a56d8"
       );
     });
     describe("toVmTransaction", () => {

--- a/src/chains/ethereum/transaction/tests/index.test.ts
+++ b/src/chains/ethereum/transaction/tests/index.test.ts
@@ -408,7 +408,7 @@ describe("@ganache/ethereum-transaction", async () => {
       tx.signAndHash(privKeyBuf);
       assert.strictEqual(
         tx.hash.toString(),
-        "0x1d37ff36e8af71fca608ad0f92b52e741b381663ebfe02d0dd1117a4462c206f"
+        "0x078395f79508111c9061f9983d387c8b7bfed990dfa098497aa4d34b0e47b265"
       );
     });
     describe("toVmTransaction", () => {
@@ -484,7 +484,7 @@ describe("@ganache/ethereum-transaction", async () => {
       tx.signAndHash(privKeyBuf);
       assert.strictEqual(
         tx.hash.toString(),
-        "0xd6bf3834e7515e9806407646b1a55541c1de4abc4763f5d905f23eda856a56d8"
+        "0xabe11ba446440bd0ea9b9e9de9eb479ae4555455ec2244a80ef7a72eddf6fe17"
       );
     });
     describe("toVmTransaction", () => {

--- a/src/chains/ethereum/utils/src/errors/call-error.ts
+++ b/src/chains/ethereum/utils/src/errors/call-error.ts
@@ -20,6 +20,6 @@ export class CallError extends CodedError {
     const { returnValue } = execResult;
     const reason = CodedError.createRevertReason(returnValue);
     this.message = reason ? message + " " + reason : message;
-    this.data = Data.from(returnValue).toString();
+    this.data = Data.toString(returnValue);
   }
 }

--- a/src/chains/ethereum/utils/src/errors/runtime-error.ts
+++ b/src/chains/ethereum/utils/src/errors/runtime-error.ts
@@ -43,7 +43,7 @@ export class RuntimeError extends CodedError {
       result:
         returnType === RETURN_TYPES.TRANSACTION_HASH
           ? hash
-          : Data.from(returnValue || "0x").toString(),
+          : Data.toString(returnValue || "0x"),
       reason: reason,
       message: error
     };

--- a/src/chains/ethereum/utils/src/things/account.ts
+++ b/src/chains/ethereum/utils/src/things/account.ts
@@ -2,7 +2,6 @@ import { Address } from "@ganache/ethereum-address";
 import { Data, Quantity } from "@ganache/utils";
 import { KECCAK256_RLP, KECCAK256_NULL } from "ethereumjs-util";
 import { encode, decode } from "@ganache/rlp";
-import { RPCQUANTITY_EMPTY } from "@ganache/utils";
 
 export type EthereumRawAccount = [
   nonce: Buffer,
@@ -21,8 +20,8 @@ export class Account {
 
   constructor(address: Address) {
     this.address = address;
-    this.balance = RPCQUANTITY_EMPTY;
-    this.nonce = RPCQUANTITY_EMPTY;
+    this.balance = Quantity.Empty;
+    this.nonce = Quantity.Empty;
   }
 
   public static fromBuffer(buffer: Buffer) {

--- a/src/chains/ethereum/utils/src/things/blocklogs.ts
+++ b/src/chains/ethereum/utils/src/things/blocklogs.ts
@@ -47,7 +47,7 @@ const filterByTopic = (
 
     let expectedTopicSet: string[];
     if (!Array.isArray(expectedTopic)) {
-      return logTopics[logPosition].equals(Data.from(expectedTopic).toBuffer());
+      return logTopics[logPosition].equals(Data.toBuffer(expectedTopic));
     }
     // an empty rule set means "anything"
     if (expectedTopic.length === 0) return true;
@@ -56,7 +56,7 @@ const filterByTopic = (
     const logTopic = logTopics[logPosition];
     // "OR" logic, e.g., [[A, B]] means log topic in the first position matching either "A" OR "B":
     return expectedTopicSet.some(expectedTopic =>
-      logTopic.equals(Data.from(expectedTopic).toBuffer())
+      logTopic.equals(Data.toBuffer(expectedTopic))
     );
   });
 };
@@ -132,14 +132,14 @@ export class BlockLogs {
       const address = Address.from(log.address);
       const blockNumber = log.blockNumber;
       const data = Array.isArray(log.data)
-        ? log.data.map(d => Data.from(d).toBuffer())
-        : Data.from(log.data).toBuffer();
+        ? log.data.map(d => Data.toBuffer(d))
+        : Data.toBuffer(log.data);
       const logIndex = log.logIndex;
       const removed =
         log.removed === false ? BUFFER_ZERO : RPCQUANTITY_ONE.toBuffer();
       const topics = Array.isArray(log.topics)
-        ? log.topics.map(t => Data.from(t, 32).toBuffer())
-        : Data.from(log.topics, 32).toBuffer();
+        ? log.topics.map(t => Data.toBuffer(t, 32))
+        : Data.toBuffer(log.topics, 32);
       const transactionHash = Data.from(log.transactionHash, 32);
       const transactionIndex = Quantity.from(log.transactionIndex);
       blockLogs.append(transactionIndex, transactionHash, [

--- a/src/chains/ethereum/utils/src/things/blocklogs.ts
+++ b/src/chains/ethereum/utils/src/things/blocklogs.ts
@@ -1,5 +1,5 @@
 import { Data, Quantity } from "@ganache/utils";
-import { BUFFER_ZERO, RPCQUANTITY_ONE } from "@ganache/utils";
+import { BUFFER_ZERO } from "@ganache/utils";
 import { decode, encode } from "@ganache/rlp";
 import { Address } from "@ganache/ethereum-address";
 
@@ -136,7 +136,7 @@ export class BlockLogs {
         : Data.toBuffer(log.data);
       const logIndex = log.logIndex;
       const removed =
-        log.removed === false ? BUFFER_ZERO : RPCQUANTITY_ONE.toBuffer();
+        log.removed === false ? BUFFER_ZERO : Quantity.One.toBuffer();
       const topics = Array.isArray(log.topics)
         ? log.topics.map(t => Data.toBuffer(t, 32))
         : Data.toBuffer(log.topics, 32);

--- a/src/chains/filecoin/filecoin/src/blockchain.ts
+++ b/src/chains/filecoin/filecoin/src/blockchain.ts
@@ -201,7 +201,7 @@ export default class Blockchain extends Emittery<BlockchainEvents> {
     } else {
       this.tipsetManager.earliest = recordedGenesisTipset; // initialize earliest
       const data: Buffer = await this.#database.db!.get("latest-tipset");
-      const height = Quantity.from(data).toNumber();
+      const height = Quantity.toNumber(data);
       const latestTipset = await this.tipsetManager.getTipsetWithBlocks(height);
       this.tipsetManager.latest = latestTipset!; // initialize latest
     }

--- a/src/packages/utils/src/things/json-rpc/index.ts
+++ b/src/packages/utils/src/things/json-rpc/index.ts
@@ -1,1 +1,1 @@
-export { JsonRpcType } from "./json-rpc-base-types";
+export { BaseJsonRpcType as JsonRpcType } from "./json-rpc-base-types";

--- a/src/packages/utils/src/things/json-rpc/input-parsers.ts
+++ b/src/packages/utils/src/things/json-rpc/input-parsers.ts
@@ -1,0 +1,73 @@
+import {bigIntToBuffer} from "../../utils/bigint-to-buffer";
+import {uintToBuffer} from "../../utils/uint-to-buffer";
+const BUFFER_EMPTY = Buffer.allocUnsafe(0);
+
+export function parseAndValidateBufferInput(input: Buffer): Buffer {
+  return input;
+}
+
+export function parseAndValidateNumberInput(input: number): Buffer {
+  if (input < 0) {
+    throw new Error("Cannot wrap a negative value as a json-rpc type");
+  }
+  if (<number>input % 1) {
+    throw new Error("Cannot wrap a decimal as a json-rpc type");
+  }
+  if (!isFinite(<number>input)) {
+    throw new Error(`Cannot wrap a ${input} as a json-rpc type`);
+  }
+  if (input === 0) {
+    return BUFFER_EMPTY;
+  } else {
+    return uintToBuffer(input as number);
+  }
+}
+
+export function parseAndValidateBigIntInput(input: bigint): Buffer {
+  if (input < 0n) {
+    throw new Error("Cannot wrap a negative value as a json-rpc type");
+  }
+  return input === 0n ? BUFFER_EMPTY : bigIntToBuffer(input as bigint);
+}
+
+const VALIDATE_REGEX = /^0x[0-9a-f]*$/i;
+export function parseAndValidateStringInput(input: string): Buffer {
+  if (!VALIDATE_REGEX.test(input)) {
+    throw new Error(`Cannot wrap string value "${input}" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`);
+  }
+  //preserve length
+  let hexValue = (<string>input).slice(2);
+
+  if (hexValue.length & 1) {
+    hexValue = `0${hexValue}`;
+  }
+  return Buffer.from(hexValue, "hex");
+}
+
+export function parseAndValidateNullInput(input: null | undefined): Buffer {
+  return input;
+}
+
+const TYPE_TO_PARSER_MAP = {
+  number: parseAndValidateNumberInput,
+  bigint: parseAndValidateBigIntInput,
+  string: parseAndValidateStringInput
+};
+
+export function getParseAndValidateFor(input: number | bigint | string | Buffer): any {
+  if (input == null) {
+    return parseAndValidateNullInput
+  }
+
+  if (Buffer.isBuffer(input)) {
+    return parseAndValidateBufferInput;
+  }
+
+  const type = typeof input;
+  const parser = TYPE_TO_PARSER_MAP[type];
+  if (parser === undefined) {
+    throw new Error(`Cannot wrap a "${type}" as a json-rpc type`);
+  }
+
+  return parser;
+}

--- a/src/packages/utils/src/things/json-rpc/input-parsers.ts
+++ b/src/packages/utils/src/things/json-rpc/input-parsers.ts
@@ -5,10 +5,46 @@ const BUFFER_EMPTY = Buffer.allocUnsafe(0);
 
 export type JsonRpcInputArg = number | bigint | string | Buffer;
 
-export function parseAndValidateBufferInput(input: Buffer): Buffer {
+const TYPE_TO_PARSER_MAP = {
+  number: parseAndValidateNumberInput,
+  bigint: parseAndValidateBigIntInput,
+  string: parseAndValidateStringInput
+};
+
+/**
+ * JSON-RPC data types store their value internally as a {@link Buffer}. This function returns another
+ * function which will perform the parsing and validation of the given input to a {@link Buffer} for this purpose.
+ * @param {T} input - the value for which a ParseAndValidate function will be returned.
+ * @returns {(T) => Buffer} a ParseAndValidate function for the given input.
+ */
+export function getParseAndValidateFor<T extends JsonRpcInputArg>(input: T): ((T) => Buffer) {
+  if (input == null || Buffer.isBuffer(input)) {
+    return noopParseAndValidate;
+  }
+
+  const type = typeof input;
+  const parser = TYPE_TO_PARSER_MAP[type];
+  if (parser === undefined) {
+    throw new Error(`Cannot wrap a "${type}" as a json-rpc type`);
+  }
+
+  return parser;
+}
+
+/**
+ * ParseAndValidate function that performs no operation, and returns the input parameter.
+ * @param {T} input
+ * @returns {T} input parameter without performing and operations.
+ */
+export function noopParseAndValidate<T>(input: T): T {
   return input;
 }
 
+/**
+ * Parse and validate a {@link number} to {@link Buffer} as internal representation for a JSON-RPC data type.
+ * @param {number} input - must be a positive, finite integer, or null.
+ * @returns {Buffer}
+ */
 export function parseAndValidateNumberInput(input: number): Buffer {
   if (input < 0) {
     throw new Error("Cannot wrap a negative value as a json-rpc type");
@@ -26,6 +62,11 @@ export function parseAndValidateNumberInput(input: number): Buffer {
   }
 }
 
+/**
+ * Parse and validate a {@link bigint} to {@link Buffer} as internal representation for a JSON-RPC data type.
+ * @param  {bigint} input - must be a positive integer, or null.
+ * @returns {Buffer}
+ */
 export function parseAndValidateBigIntInput(input: bigint): Buffer {
   if (input < 0n) {
     throw new Error("Cannot wrap a negative value as a json-rpc type");
@@ -34,6 +75,11 @@ export function parseAndValidateBigIntInput(input: bigint): Buffer {
 }
 
 const VALIDATE_REGEX = /^0x[0-9a-f]*$/i;
+/**
+ * Parse and validate a {@link string} to {@link Buffer} as internal representation for a JSON-RPC data type.
+ * @param  {string} input - must be a hex encoded integer prefixed with "0x".
+ * @returns Buffer
+ */
 export function parseAndValidateStringInput(input: string): Buffer {
   if (!VALIDATE_REGEX.test(input)) {
     throw new Error(`Cannot wrap string value "${input}" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`);
@@ -41,39 +87,11 @@ export function parseAndValidateStringInput(input: string): Buffer {
 
   let hexValue = (<string>input).slice(2);
 
-  // hexValue must be an even number of hexidecimal characters for decoding in Buffer.from
+  // hexValue must be an even number of hexidecimal characters in order to correctly decode in Buffer.from
   // see: https://nodejs.org/api/buffer.html#buffers-and-character-encodings
   if (hexValue.length & 1) {
     hexValue = `0${hexValue}`;
   }
 
   return Buffer.from(hexValue, "hex");
-}
-
-export function parseAndValidateNullInput(input: null | undefined): Buffer {
-  return input;
-}
-
-const TYPE_TO_PARSER_MAP = {
-  number: parseAndValidateNumberInput,
-  bigint: parseAndValidateBigIntInput,
-  string: parseAndValidateStringInput
-};
-
-export function getParseAndValidateFor(input: JsonRpcInputArg): any {
-  if (input == null) {
-    return parseAndValidateNullInput
-  }
-
-  if (Buffer.isBuffer(input)) {
-    return parseAndValidateBufferInput;
-  }
-
-  const type = typeof input;
-  const parser = TYPE_TO_PARSER_MAP[type];
-  if (parser === undefined) {
-    throw new Error(`Cannot wrap a "${type}" as a json-rpc type`);
-  }
-
-  return parser;
 }

--- a/src/packages/utils/src/things/json-rpc/input-parsers.ts
+++ b/src/packages/utils/src/things/json-rpc/input-parsers.ts
@@ -87,7 +87,7 @@ export function parseAndValidateBigIntInput(input: bigint): Buffer {
 export function parseAndValidateStringInput(input: string): Buffer {
   let hexValue = input.slice(2);
 
-  // hexValue must be an even number of hexidecimal characters in order to correctly decode in Buffer.from
+  // hexValue must be an even number of hexadecimal characters in order to correctly decode in Buffer.from
   // see: https://nodejs.org/api/buffer.html#buffers-and-character-encodings
   if (hexValue.length & 1) {
     hexValue = `0${hexValue}`;
@@ -96,7 +96,8 @@ export function parseAndValidateStringInput(input: string): Buffer {
 
   const _buffer = Buffer.from(hexValue, "hex");
   if (input.slice(0, 2).toLowerCase() !== "0x" || _buffer.length !== byteLength) {
-    // Buffer.from will return an empty buffer if the input does not conform to hexidecimal encoding
+    // Buffer.from will return the result after encountering an input that does not conform to hexadecimal encoding.
+    // this means that an invalid input can never return a value with the expected bytelength.
     throw new Error(`Cannot wrap string value "${input}" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`);
   }
 

--- a/src/packages/utils/src/things/json-rpc/input-parsers.ts
+++ b/src/packages/utils/src/things/json-rpc/input-parsers.ts
@@ -5,41 +5,6 @@ const BUFFER_EMPTY = Buffer.allocUnsafe(0);
 
 export type JsonRpcInputArg = number | bigint | string | Buffer;
 
-const TYPE_TO_PARSER_MAP = {
-  number: parseAndValidateNumberInput,
-  bigint: parseAndValidateBigIntInput,
-  string: parseAndValidateStringInput
-};
-
-/**
- * JSON-RPC data types store their value internally as a {@link Buffer}. This function returns another
- * function which will perform the parsing and validation of the given input to a {@link Buffer} for this purpose.
- * @param {T} input - the value for which a ParseAndValidate function will be returned.
- * @returns {(T) => Buffer} a ParseAndValidate function for the given input.
- */
-export function getParseAndValidateFor<T extends JsonRpcInputArg>(input: T): ((T) => Buffer) {
-  if (input == null || Buffer.isBuffer(input)) {
-    return noopParseAndValidate;
-  }
-
-  const type = typeof input;
-  const parser = TYPE_TO_PARSER_MAP[type];
-  if (parser === undefined) {
-    throw new Error(`Cannot wrap a "${type}" as a json-rpc type`);
-  }
-
-  return parser;
-}
-
-/**
- * ParseAndValidate function that performs no operation, and returns the input parameter.
- * @param {T} input
- * @returns {T} input parameter without performing and operations.
- */
-export function noopParseAndValidate<T>(input: T): T {
-  return input;
-}
-
 /**
  * Parse and validate a {@link number} to {@link Buffer} as internal representation for a JSON-RPC data type.
  * @param {number} input - must be a positive, finite integer, or null.

--- a/src/packages/utils/src/things/json-rpc/input-parsers.ts
+++ b/src/packages/utils/src/things/json-rpc/input-parsers.ts
@@ -1,5 +1,5 @@
-import {bigIntToBuffer} from "../../utils/bigint-to-buffer";
-import {uintToBuffer} from "../../utils/uint-to-buffer";
+import { bigIntToBuffer } from "../../utils/bigint-to-buffer";
+import { uintToBuffer } from "../../utils/uint-to-buffer";
 
 const BUFFER_EMPTY = Buffer.allocUnsafe(0);
 
@@ -51,7 +51,9 @@ export function parseAndValidateBigIntInput(input: bigint): Buffer {
  */
 export function parseAndValidateStringInput(input: string): Buffer {
   if (input.slice(0, 2).toLowerCase() !== "0x") {
-    throw new Error(`Cannot wrap string value "${input}" as a json-rpc type; strings must be prefixed with "0x".`);
+    throw new Error(
+      `Cannot wrap string value "${input}" as a json-rpc type; strings must be prefixed with "0x".`
+    );
   }
 
   let hexValue = input.slice(2);
@@ -67,7 +69,9 @@ export function parseAndValidateStringInput(input: string): Buffer {
   if (_buffer.length !== byteLength) {
     // Buffer.from will return the result after encountering an input that does not conform to hexadecimal encoding.
     // this means that an invalid input can never return a value with the expected bytelength.
-    throw new Error(`Cannot wrap string value "${input}" as a json-rpc type; the input value contains an invalid hex character.`);
+    throw new Error(
+      `Cannot wrap string value "${input}" as a json-rpc type; the input value contains an invalid hex character.`
+    );
   }
 
   return _buffer;

--- a/src/packages/utils/src/things/json-rpc/input-parsers.ts
+++ b/src/packages/utils/src/things/json-rpc/input-parsers.ts
@@ -50,6 +50,10 @@ export function parseAndValidateBigIntInput(input: bigint): Buffer {
  * @returns Buffer
  */
 export function parseAndValidateStringInput(input: string): Buffer {
+  if (input.slice(0, 2).toLowerCase() !== "0x") {
+    throw new Error(`Cannot wrap string value "${input}" as a json-rpc type; strings must be prefixed with "0x".`);
+  }
+
   let hexValue = input.slice(2);
 
   // hexValue must be an even number of hexadecimal characters in order to correctly decode in Buffer.from
@@ -60,10 +64,10 @@ export function parseAndValidateStringInput(input: string): Buffer {
   const byteLength = Math.ceil(input.length / 2 - 1);
 
   const _buffer = Buffer.from(hexValue, "hex");
-  if (input.slice(0, 2).toLowerCase() !== "0x" || _buffer.length !== byteLength) {
+  if (_buffer.length !== byteLength) {
     // Buffer.from will return the result after encountering an input that does not conform to hexadecimal encoding.
     // this means that an invalid input can never return a value with the expected bytelength.
-    throw new Error(`Cannot wrap string value "${input}" as a json-rpc type; strings must be hex-encoded and prefixed with "0x".`);
+    throw new Error(`Cannot wrap string value "${input}" as a json-rpc type; the input value contains an invalid hex character.`);
   }
 
   return _buffer;

--- a/src/packages/utils/src/things/json-rpc/json-rpc-base-types.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-base-types.ts
@@ -1,6 +1,5 @@
-import { getParseAndValidateFor } from "./input-parsers";
+import { JsonRpcInputArg, getParseAndValidateFor } from "./input-parsers";
 
-export type JsonRpcInputArg = number | bigint | string | Buffer;
 const inspect = Symbol.for("nodejs.util.inspect.custom");
 export class BaseJsonRpcType {
   public [Symbol.toStringTag]: string;
@@ -12,7 +11,7 @@ export class BaseJsonRpcType {
     return `[${this.constructor.name}] ${this.toString()}`;
   }
 
-  constructor(value: number | bigint | string | Buffer) {
+  constructor(value: JsonRpcInputArg) {
     this[Symbol.toStringTag] = typeof(value);
 
     const parseAndValidate = getParseAndValidateFor(value);

--- a/src/packages/utils/src/things/json-rpc/json-rpc-base-types.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-base-types.ts
@@ -16,7 +16,7 @@ export class BaseJsonRpcType {
 
   constructor(value: JsonRpcInputArg) {
     if (value == null) {
-      this.bufferValue = <null>value;
+      this.bufferValue = null;
     } else if (Buffer.isBuffer(value)) {
       // empty buffer should be treated as null
       this.bufferValue = value.length === 0 ? null: value;
@@ -39,7 +39,7 @@ export class BaseJsonRpcType {
 
   toString(): string | null {
     if (this.bufferValue == null) {
-      return <null>this.bufferValue;
+      return null;
     }
     return `0x${this.bufferValue.toString("hex")}`;
   }

--- a/src/packages/utils/src/things/json-rpc/json-rpc-base-types.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-base-types.ts
@@ -2,9 +2,7 @@ import { JsonRpcInputArg, getParseAndValidateFor } from "./input-parsers";
 
 const inspect = Symbol.for("nodejs.util.inspect.custom");
 export class BaseJsonRpcType {
-  public [Symbol.toStringTag]: string;
-
-  protected bufferValue: any | null;
+  protected bufferValue: Buffer | null;
 
   // used to make console.log debugging a little easier
   private [inspect](_depth: number, _options: any): string {
@@ -12,8 +10,6 @@ export class BaseJsonRpcType {
   }
 
   constructor(value: JsonRpcInputArg) {
-    this[Symbol.toStringTag] = typeof(value);
-
     const parseAndValidate = getParseAndValidateFor(value);
     this.bufferValue = parseAndValidate(value);
   }

--- a/src/packages/utils/src/things/json-rpc/json-rpc-base-types.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-base-types.ts
@@ -19,18 +19,18 @@ export class BaseJsonRpcType {
       this.bufferValue = null;
     } else if (Buffer.isBuffer(value)) {
       // empty buffer should be treated as null
-      this.bufferValue = value.length === 0 ? null: value;
+      this.bufferValue = value.length === 0 ? null : value;
     } else {
       switch (typeof value) {
         case "string":
           this.bufferValue = parseAndValidateStringInput(value);
-        break;
+          break;
         case "number":
           this.bufferValue = parseAndValidateNumberInput(value);
-        break;
+          break;
         case "bigint":
           this.bufferValue = parseAndValidateBigIntInput(value);
-        break;
+          break;
         default:
           throw new Error(`Cannot wrap a "${typeof value}" as a json-rpc type`);
       }

--- a/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
@@ -1,4 +1,5 @@
 import { BaseJsonRpcType } from "./json-rpc-base-types";
+
 const BUFFER_EMPTY = Buffer.allocUnsafe(0);
 
 type JsonRpcDataInputArg = string | Buffer;
@@ -10,9 +11,7 @@ export class Data extends BaseJsonRpcType {
     if (typeof value === "bigint") {
       throw new Error(`Cannot create a ${typeof value} as a Data`);
     }
-    if (_byteLength !== undefined) {
-      Data.validateByteLength(_byteLength);
-    }
+    Data.validateByteLength(_byteLength);
   }
 
   public toString(byteLength?: number): string | null {
@@ -27,7 +26,7 @@ export class Data extends BaseJsonRpcType {
       return super.toString();
     }
 
-    return `0x${Data.padString(this.bufferValue.toString("hex"), length)}`;
+    return `0x${Data.toFixedLengthString(this.bufferValue.toString("hex"), length)}`;
   }
 
   public toBuffer(byteLength?: number): Buffer {
@@ -43,7 +42,7 @@ export class Data extends BaseJsonRpcType {
       return this.bufferValue;
     }
 
-    return Data.padBuffer(this.bufferValue, length);
+    return Data.toFixedLengthBuffer(this.bufferValue, length);
   }
 
   public static from(value: JsonRpcDataInputArg, byteLength?: number) {
@@ -59,7 +58,7 @@ export class Data extends BaseJsonRpcType {
     }
   }
   
-  private static padString(value: string, byteLength: number | undefined) {
+  private static toFixedLengthString(value: string, byteLength: number | undefined) {
     let paddedString;
     const charLength = byteLength * 2
   
@@ -68,7 +67,7 @@ export class Data extends BaseJsonRpcType {
     }
   
     // (desired byte count - actual byte count) * 2 characters per byte
-    const padCharCount = (byteLength - value.length / 2) * 2;
+    const padCharCount = charLength - value.length;
     if (padCharCount === 0) {
       paddedString = value;
     } else if (padCharCount > 0) {
@@ -79,7 +78,7 @@ export class Data extends BaseJsonRpcType {
     return paddedString;
   }
   
-  private static padBuffer(value: Buffer, byteLength: number | undefined) {
+  private static toFixedLengthBuffer(value: Buffer, byteLength: number | undefined) {
     if (byteLength === undefined || byteLength === value.length) {
       return value;
     }

--- a/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
@@ -2,7 +2,7 @@ import { BaseJsonRpcType } from "./json-rpc-base-types";
 
 const BUFFER_EMPTY = Buffer.allocUnsafe(0);
 
-type JsonRpcDataInputArg = string | Buffer;
+export type JsonRpcDataInputArg = string | Buffer;
 
 export class Data extends BaseJsonRpcType {
   constructor(value: JsonRpcDataInputArg, private _byteLength?: number) {
@@ -26,7 +26,7 @@ export class Data extends BaseJsonRpcType {
       return super.toString();
     }
 
-    return `0x${Data.stringToFixedLength(this.bufferValue.toString("hex"), length)}`;
+    return `0x${Data.stringToFixedByteLength(this.bufferValue.toString("hex"), length)}`;
   }
 
   public toBuffer(byteLength?: number): Buffer {
@@ -38,11 +38,11 @@ export class Data extends BaseJsonRpcType {
       return BUFFER_EMPTY;
     }
 
-    if (length === undefined || length === this.bufferValue.length) {
+    if (length == undefined || length === this.bufferValue.length) {
       return this.bufferValue;
     }
 
-    return Data.bufferToFixedLength(this.bufferValue, length);
+    return Data.bufferToFixedByteLength(this.bufferValue, length);
   }
 
   public static from(value: JsonRpcDataInputArg, byteLength?: number) {
@@ -58,7 +58,7 @@ export class Data extends BaseJsonRpcType {
     }
   }
 
-  private static stringToFixedLength(value: string, byteLength: number | undefined) {
+  private static stringToFixedByteLength(value: string, byteLength: number | undefined) {
     const desiredCharLength = byteLength * 2
 
     if (byteLength === undefined || desiredCharLength === value.length) {
@@ -75,7 +75,7 @@ export class Data extends BaseJsonRpcType {
     return fixedLengthValue;
   }
 
-  private static bufferToFixedLength(value: Buffer, byteLength: number | undefined) {
+  private static bufferToFixedByteLength(value: Buffer, byteLength: number | undefined) {
     if (byteLength === undefined || byteLength === value.length) {
       return value;
     }

--- a/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
@@ -1,57 +1,107 @@
 import { BaseJsonRpcType } from "./json-rpc-base-types";
-import { strCache, toStrings } from "./json-rpc-base-types";
+const BUFFER_EMPTY = Buffer.allocUnsafe(0);
 
-function validateByteLength(byteLength?: number) {
-  if (typeof byteLength !== "number" || !(byteLength >= 0)) {
-    throw new Error(`byteLength must be a number greater than or equal to 0, provided: ${byteLength}`);
-  }
-}
+type JsonRpcDataInputArg = string | Buffer;
 
 export class Data extends BaseJsonRpcType {
-
-  constructor(value: string | Buffer, private _byteLength?: number) {
+  constructor(value: JsonRpcDataInputArg, private _byteLength?: number) {
     super(value);
+
     if (typeof value === "bigint") {
       throw new Error(`Cannot create a ${typeof value} as a Data`);
     }
     if (_byteLength !== undefined) {
-      validateByteLength(_byteLength);
+      Data.validateByteLength(_byteLength);
     }
   }
-  public toString(byteLength?: number): string {
-    if (byteLength === undefined) {
-      byteLength = this._byteLength;
-    }
-    if (byteLength === undefined && strCache.has(this)) {
-      return strCache.get(this) as string;
-    } else {
-      let str = toStrings.get(this)() as string;
-      let length = str.length;
 
-      if (length % 2 === 1) {
-        length++;
-        str = `0${str}`;
-      }
+  public toString(byteLength?: number): string | null {
+    Data.validateByteLength(byteLength);
+    const length = byteLength || this._byteLength;
 
-      if (byteLength !== undefined) {
-        validateByteLength(byteLength);
-        const strLength = byteLength * 2;
-        const padBy = strLength - length;
-        if (padBy < 0) {
-          // if our hex-encoded data is longer than it should be, truncate it:
-          str = str.slice(0, strLength);
-        } else if (padBy > 0) {
-          // if our hex-encoded data is shorter than it should be, pad it:
-          str = "0".repeat(padBy) + str;
-        }
-      }
-      return `0x${str}`;
+    if (this.bufferValue == null) {
+      return <null>this.bufferValue;
     }
+
+    if (length === undefined) {
+      return super.toString();
+    }
+
+    return `0x${Data.padString(this.bufferValue.toString("hex"), length)}`;
   }
-  public static from<T extends string | Buffer = string | Buffer>(
-    value: T,
-    byteLength?: number
-  ) {
+
+  public toBuffer(byteLength?: number): Buffer {
+    Data.validateByteLength(byteLength);
+
+    const length = byteLength || this._byteLength;
+
+    if (this.bufferValue == null) {
+      return BUFFER_EMPTY;
+    }
+
+    if (length === undefined || length === this.bufferValue.length) {
+      return this.bufferValue;
+    }
+
+    return Data.padBuffer(this.bufferValue, length);
+  }
+
+  public static from(value: JsonRpcDataInputArg, byteLength?: number) {
+    if (value instanceof Data) {
+      return value;
+    }
     return new Data(value, byteLength);
+  }
+
+  private static validateByteLength(byteLength?: number) {
+    if (byteLength !== undefined && (typeof byteLength !== "number" || byteLength < 0 || !isFinite(byteLength))) {
+      throw new Error(`byteLength must be a number greater than or equal to 0, provided: ${byteLength}`);
+    }
+  }
+  
+  private static padString(value: string, byteLength: number | undefined) {
+    let paddedString;
+    const charLength = byteLength * 2
+  
+    if (byteLength === undefined || charLength === value.length) {
+      return value;
+    }
+  
+    // (desired byte count - actual byte count) * 2 characters per byte
+    const padCharCount = (byteLength - value.length / 2) * 2;
+    if (padCharCount === 0) {
+      paddedString = value;
+    } else if (padCharCount > 0) {
+      paddedString = "0".repeat(padCharCount) + value;
+    } else {
+      paddedString = value.slice(0, charLength);
+    }
+    return paddedString;
+  }
+  
+  private static padBuffer(value: Buffer, byteLength: number | undefined) {
+    if (byteLength === undefined || byteLength === value.length) {
+      return value;
+    }
+  
+    const returnValue = Buffer.allocUnsafe(byteLength);
+  
+    const sourceStart = 0;
+    const targetStart = value.length > byteLength ? 0 : byteLength - value.length;
+    if (targetStart > 0) {
+      returnValue.fill(0, 0, targetStart);
+    }
+  
+    value.copy(returnValue, targetStart, sourceStart, byteLength);
+  
+    return returnValue;
+  }
+
+  static toBuffer(value: JsonRpcDataInputArg, byteLength?: number): Buffer {
+    return Data.from(value, byteLength).toBuffer();
+  }
+
+  static toString(value: JsonRpcDataInputArg, byteLength?: number): string {
+    return Data.from(value, byteLength).toString();
   }
 }

--- a/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
@@ -26,7 +26,7 @@ export class Data extends BaseJsonRpcType {
       return super.toString();
     }
 
-    return `0x${Data.toFixedLengthString(this.bufferValue.toString("hex"), length)}`;
+    return `0x${Data.stringToFixedLength(this.bufferValue.toString("hex"), length)}`;
   }
 
   public toBuffer(byteLength?: number): Buffer {
@@ -42,7 +42,7 @@ export class Data extends BaseJsonRpcType {
       return this.bufferValue;
     }
 
-    return Data.toFixedLengthBuffer(this.bufferValue, length);
+    return Data.bufferToFixedLength(this.bufferValue, length);
   }
 
   public static from(value: JsonRpcDataInputArg, byteLength?: number) {
@@ -57,43 +57,40 @@ export class Data extends BaseJsonRpcType {
       throw new Error(`byteLength must be a number greater than or equal to 0, provided: ${byteLength}`);
     }
   }
-  
-  private static toFixedLengthString(value: string, byteLength: number | undefined) {
-    let paddedString;
-    const charLength = byteLength * 2
-  
-    if (byteLength === undefined || charLength === value.length) {
+
+  private static stringToFixedLength(value: string, byteLength: number | undefined) {
+    const desiredCharLength = byteLength * 2
+
+    if (byteLength === undefined || desiredCharLength === value.length) {
       return value;
     }
-  
-    // (desired byte count - actual byte count) * 2 characters per byte
-    const padCharCount = charLength - value.length;
-    if (padCharCount === 0) {
-      paddedString = value;
-    } else if (padCharCount > 0) {
-      paddedString = "0".repeat(padCharCount) + value;
+
+    const padCharCount = desiredCharLength - value.length;
+    let fixedLengthValue;
+    if (padCharCount > 0) {
+      fixedLengthValue = "0".repeat(padCharCount) + value;
     } else {
-      paddedString = value.slice(0, charLength);
+      fixedLengthValue = value.slice(0, desiredCharLength);
     }
-    return paddedString;
+    return fixedLengthValue;
   }
-  
-  private static toFixedLengthBuffer(value: Buffer, byteLength: number | undefined) {
+
+  private static bufferToFixedLength(value: Buffer, byteLength: number | undefined) {
     if (byteLength === undefined || byteLength === value.length) {
       return value;
     }
-  
-    const returnValue = Buffer.allocUnsafe(byteLength);
-  
+
+    const fixedLengthValue = Buffer.allocUnsafe(byteLength);
+
     const sourceStart = 0;
     const targetStart = value.length > byteLength ? 0 : byteLength - value.length;
     if (targetStart > 0) {
-      returnValue.fill(0, 0, targetStart);
+      fixedLengthValue.fill(0, 0, targetStart);
     }
-  
-    value.copy(returnValue, targetStart, sourceStart, byteLength);
-  
-    return returnValue;
+
+    value.copy(fixedLengthValue, targetStart, sourceStart, byteLength);
+
+    return fixedLengthValue;
   }
 
   static toBuffer(value: JsonRpcDataInputArg, byteLength?: number): Buffer {

--- a/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
@@ -18,7 +18,7 @@ export class Data extends BaseJsonRpcType {
     const length = byteLength || this._byteLength;
 
     if (this.bufferValue == null) {
-      return <null>this.bufferValue;
+      return "0x";
     }
 
     if (length === undefined) {
@@ -58,7 +58,7 @@ export class Data extends BaseJsonRpcType {
     }
 
     const padCharCount = desiredCharLength - value.length;
-    let fixedLengthValue;
+    let fixedLengthValue: string;
     if (padCharCount > 0) {
       fixedLengthValue = "0".repeat(padCharCount) + value;
     } else {

--- a/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
@@ -1,10 +1,11 @@
 import { BaseJsonRpcType } from "./json-rpc-base-types";
-
-const BUFFER_EMPTY = Buffer.allocUnsafe(0);
+import { BUFFER_EMPTY } from "../../utils/constants";
 
 export type JsonRpcDataInputArg = string | Buffer;
 
 export class Data extends BaseJsonRpcType {
+  public static Empty = Data.from(BUFFER_EMPTY);
+
   constructor(value: JsonRpcDataInputArg, private _byteLength?: number) {
     super(value);
 

--- a/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
@@ -51,7 +51,7 @@ export class Data extends BaseJsonRpcType {
   }
 
   private static stringToFixedByteLength(value: string, byteLength: number) {
-    const desiredCharLength = byteLength * 2
+    const desiredCharLength = byteLength * 2;
 
     if (desiredCharLength === value.length) {
       return value;

--- a/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
@@ -11,11 +11,9 @@ export class Data extends BaseJsonRpcType {
     if (typeof value === "bigint") {
       throw new Error(`Cannot create a ${typeof value} as a Data`);
     }
-    Data.validateByteLength(_byteLength);
   }
 
   public toString(byteLength?: number): string | null {
-    Data.validateByteLength(byteLength);
     const length = byteLength || this._byteLength;
 
     if (this.bufferValue == null) {
@@ -26,12 +24,11 @@ export class Data extends BaseJsonRpcType {
       return super.toString();
     }
 
-    return `0x${Data.stringToFixedByteLength(this.bufferValue.toString("hex"), length)}`;
+    const strValue = this.bufferValue.toString("hex");
+    return length === undefined? `0x${strValue}` : `0x${Data.stringToFixedByteLength(strValue, length)}`;
   }
 
   public toBuffer(byteLength?: number): Buffer {
-    Data.validateByteLength(byteLength);
-
     const length = byteLength || this._byteLength;
 
     if (this.bufferValue == null) {
@@ -42,7 +39,7 @@ export class Data extends BaseJsonRpcType {
       return this.bufferValue;
     }
 
-    return Data.bufferToFixedByteLength(this.bufferValue, length);
+    return length === undefined? this.bufferValue: Data.bufferToFixedByteLength(this.bufferValue, length);
   }
 
   public static from(value: JsonRpcDataInputArg, byteLength?: number) {
@@ -52,16 +49,10 @@ export class Data extends BaseJsonRpcType {
     return new Data(value, byteLength);
   }
 
-  private static validateByteLength(byteLength?: number) {
-    if (byteLength !== undefined && (typeof byteLength !== "number" || byteLength < 0 || !isFinite(byteLength))) {
-      throw new Error(`byteLength must be a number greater than or equal to 0, provided: ${byteLength}`);
-    }
-  }
-
-  private static stringToFixedByteLength(value: string, byteLength: number | undefined) {
+  private static stringToFixedByteLength(value: string, byteLength: number) {
     const desiredCharLength = byteLength * 2
 
-    if (byteLength === undefined || desiredCharLength === value.length) {
+    if (desiredCharLength === value.length) {
       return value;
     }
 
@@ -75,8 +66,8 @@ export class Data extends BaseJsonRpcType {
     return fixedLengthValue;
   }
 
-  private static bufferToFixedByteLength(value: Buffer, byteLength: number | undefined) {
-    if (byteLength === undefined || byteLength === value.length) {
+  private static bufferToFixedByteLength(value: Buffer, byteLength: number) {
+    if (byteLength === value.length) {
       return value;
     }
 

--- a/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
@@ -26,16 +26,15 @@ export class Data extends BaseJsonRpcType {
     }
 
     const strValue = this.bufferValue.toString("hex");
-    return length === undefined? `0x${strValue}` : `0x${Data.stringToFixedByteLength(strValue, length)}`;
+    return `0x${Data.stringToFixedByteLength(strValue, length)}`;
   }
 
   public toBuffer(byteLength?: number): Buffer {
-    const length = byteLength || this._byteLength;
-
     if (this.bufferValue == null) {
       return BUFFER_EMPTY;
     }
 
+    const length = byteLength || this._byteLength;
     if (length == undefined || length === this.bufferValue.length) {
       return this.bufferValue;
     }
@@ -43,10 +42,7 @@ export class Data extends BaseJsonRpcType {
     return length === undefined? this.bufferValue: Data.bufferToFixedByteLength(this.bufferValue, length);
   }
 
-  public static from(value: JsonRpcDataInputArg | Data, byteLength?: number) {
-    if (value instanceof Data) {
-      return value;
-    }
+  public static from(value: JsonRpcDataInputArg, byteLength?: number) {
     return new Data(value, byteLength);
   }
 

--- a/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
@@ -43,7 +43,7 @@ export class Data extends BaseJsonRpcType {
     return length === undefined? this.bufferValue: Data.bufferToFixedByteLength(this.bufferValue, length);
   }
 
-  public static from(value: JsonRpcDataInputArg, byteLength?: number) {
+  public static from(value: JsonRpcDataInputArg | Data, byteLength?: number) {
     if (value instanceof Data) {
       return value;
     }

--- a/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
@@ -39,7 +39,7 @@ export class Data extends BaseJsonRpcType {
       return this.bufferValue;
     }
 
-    return length === undefined? this.bufferValue: Data.bufferToFixedByteLength(this.bufferValue, length);
+    return Data.bufferToFixedByteLength(this.bufferValue, length);
   }
 
   public static from(value: JsonRpcDataInputArg, byteLength?: number) {

--- a/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-data.ts
@@ -71,7 +71,8 @@ export class Data extends BaseJsonRpcType {
     const fixedLengthValue = Buffer.allocUnsafe(byteLength);
 
     const sourceStart = 0;
-    const targetStart = value.length > byteLength ? 0 : byteLength - value.length;
+    const targetStart =
+      value.length > byteLength ? 0 : byteLength - value.length;
     if (targetStart > 0) {
       fixedLengthValue.fill(0, 0, targetStart);
     }

--- a/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
@@ -1,5 +1,7 @@
 import { bufferToBigInt } from "../../utils/buffer-to-bigint";
-import { BaseJsonRpcType, JsonRpcInputArg } from "./json-rpc-base-types";
+import { BaseJsonRpcType } from "./json-rpc-base-types";
+import { JsonRpcInputArg } from "./input-parsers";
+
 const BUFFER_EMPTY = Buffer.alloc(0);
 
 export class Quantity extends BaseJsonRpcType {

--- a/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
@@ -1,10 +1,14 @@
 import { bufferToBigInt } from "../../utils/buffer-to-bigint";
 import { BaseJsonRpcType } from "./json-rpc-base-types";
 import { JsonRpcInputArg } from "./input-parsers";
-
-const BUFFER_EMPTY = Buffer.alloc(0);
+import { BUFFER_EMPTY, BUFFER_ZERO } from "../../utils/constants";
 
 export class Quantity extends BaseJsonRpcType {
+  public static Empty = Quantity.from(BUFFER_EMPTY, true);
+  public static Zero = Quantity.from(BUFFER_ZERO);
+  public static One = Quantity.from(1);
+  public static Gwei = Quantity.from(1000000000);
+
   private static ZERO_VALUE_STRING = "0x0";
 
   _nullable: boolean = false;

--- a/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
@@ -21,7 +21,7 @@ export class Quantity extends BaseJsonRpcType {
   constructor(value: JsonRpcInputArg, nullable?: boolean) {
     super(value);
     if (value === "0x") {
-      throw new Error("Cannot wrap a 0x value as a json-rpc Quantity type; Quantity must contain at least one digit");
+      throw new Error('Cannot wrap "0x" as a json-rpc Quantity type; Quantity must contain at least one digit');
     }
     this._nullable = nullable;
   }

--- a/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
@@ -13,7 +13,7 @@ export class Quantity extends BaseJsonRpcType {
 
   _nullable: boolean = false;
 
-  public static from(value: JsonRpcInputArg, nullable = false) {
+  public static from(value: JsonRpcInputArg | Quantity, nullable = false) {
     if (value instanceof Quantity) return value;
     return new Quantity(value, nullable);
   }
@@ -28,7 +28,7 @@ export class Quantity extends BaseJsonRpcType {
 
   public toString(): string | null {
     if (this.bufferValue == null) {
-      return this._nullable? this.bufferValue : Quantity.ZERO_VALUE_STRING;
+      return this._nullable? <null>this.bufferValue : Quantity.ZERO_VALUE_STRING;
     }
 
     const firstNonZeroByte = this.findFirstNonZeroByteIndex();
@@ -64,7 +64,7 @@ export class Quantity extends BaseJsonRpcType {
 
   public toBigInt(): bigint | null {
     if (this.bufferValue == null) {
-      return this._nullable ? this.bufferValue : 0n;
+      return this._nullable ? <null>this.bufferValue : 0n;
     }
     if (this.bufferValue.length === 0) {
       return 0n;
@@ -74,7 +74,7 @@ export class Quantity extends BaseJsonRpcType {
 
   public toNumber() {
     if (this.bufferValue == null) {
-      return this._nullable ? this.bufferValue : 0;
+      return this._nullable ? <null>this.bufferValue : 0;
     }
 
     const firstNonZeroByte = this.findFirstNonZeroByteIndex();

--- a/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
@@ -21,7 +21,7 @@ export class Quantity extends BaseJsonRpcType {
   constructor(value: JsonRpcInputArg, nullable?: boolean) {
     super(value);
     if (value === "0x") {
-      throw new Error('Cannot wrap "0x" as a json-rpc Quantity type; strings must contain at least one hexadecimal symbol.');
+      throw new Error('Cannot wrap "0x" as a json-rpc Quantity type; strings must contain at least one hexadecimal character.');
     }
     this._nullable = nullable;
   }

--- a/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
@@ -13,7 +13,7 @@ export class Quantity extends BaseJsonRpcType {
 
   _nullable: boolean = false;
 
-  public static from(value: JsonRpcInputArg | Quantity, nullable = false) {
+  public static from(value: JsonRpcInputArg, nullable = false) {
     if (value instanceof Quantity) return value;
     return new Quantity(value, nullable);
   }
@@ -21,14 +21,14 @@ export class Quantity extends BaseJsonRpcType {
   constructor(value: JsonRpcInputArg, nullable?: boolean) {
     super(value);
     if (value === "0x") {
-      throw new Error('Cannot wrap "0x" as a json-rpc Quantity type; Quantity must contain at least one digit');
+      throw new Error('Cannot wrap "0x" as a json-rpc Quantity type; strings must contain at least one hexadecimal symbol.');
     }
     this._nullable = nullable;
   }
 
   public toString(): string | null {
     if (this.bufferValue == null) {
-      return this._nullable? <null>this.bufferValue : Quantity.ZERO_VALUE_STRING;
+      return this._nullable? null : Quantity.ZERO_VALUE_STRING;
     }
 
     const firstNonZeroByte = this.findFirstNonZeroByteIndex();
@@ -64,7 +64,7 @@ export class Quantity extends BaseJsonRpcType {
 
   public toBigInt(): bigint | null {
     if (this.bufferValue == null) {
-      return this._nullable ? <null>this.bufferValue : 0n;
+      return this._nullable ? null : 0n;
     }
     if (this.bufferValue.length === 0) {
       return 0n;
@@ -74,7 +74,7 @@ export class Quantity extends BaseJsonRpcType {
 
   public toNumber() {
     if (this.bufferValue == null) {
-      return this._nullable ? <null>this.bufferValue : 0;
+      return this._nullable ? null : 0;
     }
 
     const firstNonZeroByte = this.findFirstNonZeroByteIndex();
@@ -101,7 +101,7 @@ export class Quantity extends BaseJsonRpcType {
 
   valueOf(): bigint {
     if (this.bufferValue == null) {
-      return <null>this.bufferValue;
+      return null;
     } else {
       return this.toBigInt();
     }

--- a/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
@@ -21,14 +21,16 @@ export class Quantity extends BaseJsonRpcType {
   constructor(value: JsonRpcInputArg, nullable?: boolean) {
     super(value);
     if (value === "0x") {
-      throw new Error('Cannot wrap "0x" as a json-rpc Quantity type; strings must contain at least one hexadecimal character.');
+      throw new Error(
+        'Cannot wrap "0x" as a json-rpc Quantity type; strings must contain at least one hexadecimal character.'
+      );
     }
     this._nullable = nullable;
   }
 
   public toString(): string | null {
     if (this.bufferValue == null) {
-      return this._nullable? null : Quantity.ZERO_VALUE_STRING;
+      return this._nullable ? null : Quantity.ZERO_VALUE_STRING;
     }
 
     const firstNonZeroByte = this.findFirstNonZeroByteIndex();
@@ -87,11 +89,20 @@ export class Quantity extends BaseJsonRpcType {
     let result: number;
     // buffer.readUIntBE only supports up to 48 bits, so if larger then we need to convert to bigint first
     if (length > 6) {
-      const trimmedBuffer = firstNonZeroByte === 0 ? this.bufferValue : this.bufferValue.subarray(firstNonZeroByte, length);
+      const trimmedBuffer =
+        firstNonZeroByte === 0
+          ? this.bufferValue
+          : this.bufferValue.subarray(firstNonZeroByte, length);
       result = Number(bufferToBigInt(trimmedBuffer));
 
       if (!Number.isSafeInteger(result)) {
-        console.warn(`0x${this.bufferValue.toString("hex")} is too large - the maximum safe integer value is 0${Number.MAX_SAFE_INTEGER.toString(16)}`);
+        console.warn(
+          `0x${this.bufferValue.toString(
+            "hex"
+          )} is too large - the maximum safe integer value is 0${Number.MAX_SAFE_INTEGER.toString(
+            16
+          )}`
+        );
       }
     } else {
       result = this.bufferValue.readUIntBE(firstNonZeroByte, length);
@@ -110,7 +121,11 @@ export class Quantity extends BaseJsonRpcType {
 
   private findFirstNonZeroByteIndex(): number {
     let firstNonZeroByte = 0;
-    for (firstNonZeroByte = 0; firstNonZeroByte < this.bufferValue.length; firstNonZeroByte++) {
+    for (
+      firstNonZeroByte = 0;
+      firstNonZeroByte < this.bufferValue.length;
+      firstNonZeroByte++
+    ) {
       if (this.bufferValue[firstNonZeroByte] !== 0) break;
     }
     return firstNonZeroByte;

--- a/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
+++ b/src/packages/utils/src/things/json-rpc/json-rpc-quantity.ts
@@ -85,6 +85,7 @@ export class Quantity extends BaseJsonRpcType {
     }
 
     let result: number;
+    // buffer.readUIntBE only supports up to 48 bits, so if larger then we need to convert to bigint first
     if (length > 6) {
       const trimmedBuffer = firstNonZeroByte === 0 ? this.bufferValue : this.bufferValue.subarray(firstNonZeroByte, length);
       result = Number(bufferToBigInt(trimmedBuffer));

--- a/src/packages/utils/src/utils/constants.ts
+++ b/src/packages/utils/src/utils/constants.ts
@@ -1,6 +1,3 @@
-import { Data } from "../things/json-rpc/json-rpc-data";
-import { Quantity } from "../things/json-rpc/json-rpc-quantity";
-
 export const BUFFER_256_ZERO = Buffer.allocUnsafe(256).fill(0);
 export const ACCOUNT_ZERO = BUFFER_256_ZERO.slice(0, 20);
 export const BUFFER_EMPTY = Buffer.allocUnsafe(0);
@@ -8,11 +5,6 @@ export const BUFFER_ZERO = BUFFER_256_ZERO.slice(0, 1);
 export const BUFFER_32_ZERO = BUFFER_256_ZERO.slice(0, 32);
 export const BUFFER_8_ZERO = BUFFER_256_ZERO.slice(0, 8);
 
-export const DATA_EMPTY = Data.from(BUFFER_EMPTY);
-export const RPCQUANTITY_EMPTY = Quantity.from(BUFFER_EMPTY, true);
-export const RPCQUANTITY_ZERO = Quantity.from(BUFFER_ZERO);
-export const RPCQUANTITY_ONE = Quantity.from(1n);
-export const RPCQUANTITY_GWEI = Quantity.from(1000000000);
 export const WEI = 1000000000000000000n as const;
 
 export const KNOWN_CHAINIDS = new Set([1, 3, 4, 5, 42, 11155111]);

--- a/src/packages/utils/tests/input-parsers.test.ts
+++ b/src/packages/utils/tests/input-parsers.test.ts
@@ -1,0 +1,172 @@
+import assert from "assert";
+import {
+  getParseAndValidateFor,
+  parseAndValidateStringInput,
+  parseAndValidateBigIntInput,
+  parseAndValidateBufferInput,
+  parseAndValidateNullInput,
+  parseAndValidateNumberInput
+} from "../src/things/json-rpc/input-parsers";
+
+describe("json-rpc-input-parsers", () => {
+  describe("getParseAndValidateFor()", () => {
+    [
+      ["", parseAndValidateStringInput],
+      [1, parseAndValidateNumberInput],
+      [1n, parseAndValidateBigIntInput],
+      [Buffer.alloc(0), parseAndValidateBufferInput],
+      [null, parseAndValidateNullInput],
+      [undefined, parseAndValidateNullInput]
+    ].forEach(([input, parser]) => {
+      it(`should get the correct parser for input: ${input}, of type: ${typeof input}`, () => {
+        const actual = getParseAndValidateFor(<any>input);
+        assert(actual === parser, `Wrong parser returned, expected ${(<any>parser).name}, got ${actual.name}`);
+      });
+    });
+
+    [
+      {},
+      [],
+      ()=>{}
+    ].forEach((input) => {
+      it(`should reject non-supported input: ${input}, of type: ${typeof input}`, () => {
+        assert.throws(() => getParseAndValidateFor(<any>input),
+          new Error(`Cannot wrap a "${typeof input}" as a json-rpc type`));
+      });
+    });
+  });
+
+  describe("parseAndValidateStringInput()", () => {
+    [
+      "-0x123",
+      "0xg",
+      "123",
+      "0.123",
+      "-123",
+      "0x0.1",
+      "0x-1",
+      "-0x1",
+    ].forEach(input => {
+      it(`should reject invalid value: ${input}`, () => {
+        assert.throws(() => parseAndValidateStringInput(input));
+      });
+    });
+
+    [
+      ["0x", []],
+      ["0x1", [0x01]],
+      ["0x01", [0x01]],
+      ["0x00000000", [0x00,0x00,0x00,0x00]],
+      ["0x12345678", [0x12,0x34,0x56,0x78]],
+      ["0x123456789abcdef", [0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef]],
+      ["0x123456789ABCDEF", [0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef]],
+      ["0x000000000000000001", [0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x01]]
+    ].forEach(([input, expectedByteArray]) => {
+      it(`should return the correct buffer for special case: ${input}`, () => {
+        const expected = Buffer.from(expectedByteArray);
+        const actual = parseAndValidateStringInput(<string>input);
+        assert.deepEqual(actual, expected);
+      });
+    });
+
+    it("should return the correct buffer for every length up to 50 bytes", () => {
+      for (let i = "0"; i.length <= 100; i  = i + (i.length % 16).toString(16)) {
+        const evenLengthHexString = i.length & 1 ? `0${i}` : i;
+        const expected = Buffer.from(evenLengthHexString, "hex");
+        const input = `0x${i}`;
+        const actual = parseAndValidateStringInput(input);
+        assert.deepEqual(actual, expected, `incorrect value for input ${input}, expected: 0x${expected.toString("hex")}, got: 0x${actual.toString("hex")}`);
+      }
+    });
+  });
+
+  describe("parseAndValidateNumberInput()", () => {
+    [
+      -1,
+      Infinity,
+      -Infinity,
+      NaN,
+      0.1
+    ].forEach(input => {
+      it(`should reject invalid value: ${input}`, () => {
+        assert.throws(() => parseAndValidateNumberInput(input));
+      });
+    });
+
+    [
+      [0, []],
+      [1, [0x01]],
+      [Number.MAX_SAFE_INTEGER, [0x1f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]],
+      [Number.MAX_SAFE_INTEGER + 1, [0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]]
+    ].forEach(([input, expectedByteArray]) => {
+      it(`should return the correct buffer for special case: ${input}`, () => {
+        const expected = Buffer.from(<any>expectedByteArray);
+        const actual = parseAndValidateNumberInput(<number>input);
+        assert.deepEqual(actual, expected);
+      });
+    });
+
+    it("should return the current buffer for lengths up to 6 bytes", () => {
+      // after Number.MAX_SAFE_INTEGER (which is 7 bytes long) we will start to lose precision
+      for (let i = "1"; i.length <= 12; i  = i + (i.length % 16).toString(16)) {
+        const evenLengthHexString = i.length & 1 ? `0${i}` : i;
+        const input = parseInt(i, 16);
+        const expected = Buffer.from(evenLengthHexString, "hex");
+        const actual = parseAndValidateNumberInput(input);
+        assert.deepEqual(actual, expected, `incorrect value for input 0x${input.toString(16)}, expected: 0x${expected.toString("hex")}, got: 0x${actual.toString("hex")}`);
+      }
+    });
+  });
+
+  describe("parseAndValidateBigIntInput()", () => {
+    [
+    -1n
+    ].forEach(input => {
+      it(`should reject invalid value: ${input}`, () => {
+        assert.throws(() => parseAndValidateBigIntInput(input));
+      });
+    });
+
+    [
+      [0n, []],
+      [1n, [0x01]],
+    ].forEach(([input, expectedByteArray]) => {
+      it(`should return the correct buffer for special case: ${input}`, () => {
+        const expected = Buffer.from(<any>expectedByteArray);
+        const actual = parseAndValidateBigIntInput(<bigint>input);
+        assert.deepEqual(actual, expected);
+      });
+    });
+
+    it("should return the correct buffer for every length up to 50 bytes", () => {
+      for (let i = "1"; i.length <= 100; i  = i + (i.length % 16).toString(16)) {
+        const evenLengthHexString = i.length & 1 ? `0${i}` : i;
+        const expected = Buffer.from(evenLengthHexString, "hex");
+        const input = BigInt(`0x${evenLengthHexString}`);
+        const actual = parseAndValidateBigIntInput(input);
+        assert.deepEqual(actual, expected, `incorrect value for input 0x${input.toString(16)}, expected: 0x${expected.toString("hex")}, got: 0x${actual.toString("hex")}`);
+      }
+    });
+  });
+
+  describe("parseAndValidateBufferInput()", () => {
+    it(`should accept a valid input`, () => {
+      parseAndValidateBufferInput(Buffer.alloc(0));
+    });
+
+    it(`should return the value input`, () => {
+      const input = Buffer.alloc(0);
+      const actual = parseAndValidateBufferInput(input);
+      assert.strictEqual(input, actual);
+    });
+  });
+
+  describe("parseAndValidateNullInput()", () => {
+    [null, undefined].forEach(input => {
+      it(`should return the input value: ${input}`, () => {
+        const actual = parseAndValidateBufferInput(input);
+        assert.strictEqual(actual, input);
+      });
+    });
+  });
+});

--- a/src/packages/utils/tests/input-parsers.test.ts
+++ b/src/packages/utils/tests/input-parsers.test.ts
@@ -3,8 +3,7 @@ import {
   getParseAndValidateFor,
   parseAndValidateStringInput,
   parseAndValidateBigIntInput,
-  parseAndValidateBufferInput,
-  parseAndValidateNullInput,
+  noopParseAndValidate,
   parseAndValidateNumberInput
 } from "../src/things/json-rpc/input-parsers";
 
@@ -14,9 +13,9 @@ describe("json-rpc-input-parsers", () => {
       ["", parseAndValidateStringInput],
       [1, parseAndValidateNumberInput],
       [1n, parseAndValidateBigIntInput],
-      [Buffer.alloc(0), parseAndValidateBufferInput],
-      [null, parseAndValidateNullInput],
-      [undefined, parseAndValidateNullInput]
+      [Buffer.alloc(0), noopParseAndValidate],
+      [null, noopParseAndValidate],
+      [undefined, noopParseAndValidate]
     ].forEach(([input, parser]) => {
       it(`should get the correct parser for input: ${input}, of type: ${typeof input}`, () => {
         const actual = getParseAndValidateFor(<any>input);
@@ -149,23 +148,14 @@ describe("json-rpc-input-parsers", () => {
     });
   });
 
-  describe("parseAndValidateBufferInput()", () => {
-    it(`should accept a valid input`, () => {
-      parseAndValidateBufferInput(Buffer.alloc(0));
-    });
-
-    it(`should return the value input`, () => {
-      const input = Buffer.alloc(0);
-      const actual = parseAndValidateBufferInput(input);
-      assert.strictEqual(input, actual);
-    });
-  });
-
-  describe("parseAndValidateNullInput()", () => {
-    [null, undefined].forEach(input => {
-      it(`should return the input value: ${input}`, () => {
-        const actual = parseAndValidateBufferInput(input);
-        assert.strictEqual(actual, input);
+  describe("noopParseAndValidate()", () => {
+    [
+      Buffer.alloc(0), null, undefined
+    ].forEach(input => {
+      const inputName = Buffer.isBuffer(input) ? "Buffer" : JSON.stringify(input);
+      it(`should return the value input: ${inputName}`, () => {
+        const actual = noopParseAndValidate(input);
+        assert.strictEqual(input, actual);
       });
     });
   });

--- a/src/packages/utils/tests/input-parsers.test.ts
+++ b/src/packages/utils/tests/input-parsers.test.ts
@@ -1,40 +1,11 @@
 import assert from "assert";
 import {
-  getParseAndValidateFor,
   parseAndValidateStringInput,
   parseAndValidateBigIntInput,
-  noopParseAndValidate,
   parseAndValidateNumberInput
 } from "../src/things/json-rpc/input-parsers";
 
 describe("json-rpc-input-parsers", () => {
-  describe("getParseAndValidateFor()", () => {
-    [
-      ["", parseAndValidateStringInput],
-      [1, parseAndValidateNumberInput],
-      [1n, parseAndValidateBigIntInput],
-      [Buffer.alloc(0), noopParseAndValidate],
-      [null, noopParseAndValidate],
-      [undefined, noopParseAndValidate]
-    ].forEach(([input, parser]) => {
-      it(`should get the correct parser for input: ${input}, of type: ${typeof input}`, () => {
-        const actual = getParseAndValidateFor(<any>input);
-        assert(actual === parser, `Wrong parser returned, expected ${(<any>parser).name}, got ${actual.name}`);
-      });
-    });
-
-    [
-      {},
-      [],
-      ()=>{}
-    ].forEach((input) => {
-      it(`should reject non-supported input: ${input}, of type: ${typeof input}`, () => {
-        assert.throws(() => getParseAndValidateFor(<any>input),
-          new Error(`Cannot wrap a "${typeof input}" as a json-rpc type`));
-      });
-    });
-  });
-
   describe("parseAndValidateStringInput()", () => {
     [
       "-0x123",
@@ -145,18 +116,6 @@ describe("json-rpc-input-parsers", () => {
         const actual = parseAndValidateBigIntInput(input);
         assert.deepEqual(actual, expected, `incorrect value for input 0x${input.toString(16)}, expected: 0x${expected.toString("hex")}, got: 0x${actual.toString("hex")}`);
       }
-    });
-  });
-
-  describe("noopParseAndValidate()", () => {
-    [
-      Buffer.alloc(0), null, undefined
-    ].forEach(input => {
-      const inputName = Buffer.isBuffer(input) ? "Buffer" : JSON.stringify(input);
-      it(`should return the value input: ${inputName}`, () => {
-        const actual = noopParseAndValidate(input);
-        assert.strictEqual(input, actual);
-      });
     });
   });
 });

--- a/src/packages/utils/tests/input-parsers.test.ts
+++ b/src/packages/utils/tests/input-parsers.test.ts
@@ -7,30 +7,26 @@ import {
 
 describe("json-rpc-input-parsers", () => {
   describe("parseAndValidateStringInput()", () => {
-    [
-      "-0x123",
-      "0xg",
-      "123",
-      "0.123",
-      "-123",
-      "0x0.1",
-      "0x-1",
-      "-0x1",
-    ].forEach(input => {
-      it(`should reject invalid value: ${input}`, () => {
-        assert.throws(() => parseAndValidateStringInput(input));
-      });
-    });
+    ["-0x123", "0xg", "123", "0.123", "-123", "0x0.1", "0x-1", "-0x1"].forEach(
+      input => {
+        it(`should reject invalid value: ${input}`, () => {
+          assert.throws(() => parseAndValidateStringInput(input));
+        });
+      }
+    );
 
     [
       ["0x", []],
       ["0x1", [0x01]],
       ["0x01", [0x01]],
-      ["0x00000000", [0x00,0x00,0x00,0x00]],
-      ["0x12345678", [0x12,0x34,0x56,0x78]],
-      ["0x123456789abcdef", [0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef]],
-      ["0x123456789ABCDEF", [0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef]],
-      ["0x000000000000000001", [0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x01]]
+      ["0x00000000", [0x00, 0x00, 0x00, 0x00]],
+      ["0x12345678", [0x12, 0x34, 0x56, 0x78]],
+      ["0x123456789abcdef", [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]],
+      ["0x123456789ABCDEF", [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]],
+      [
+        "0x000000000000000001",
+        [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]
+      ]
     ].forEach(([input, expectedByteArray]) => {
       it(`should return the correct buffer for special case: ${input}`, () => {
         const expected = Buffer.from(expectedByteArray);
@@ -40,24 +36,24 @@ describe("json-rpc-input-parsers", () => {
     });
 
     it("should return the correct buffer for every length up to 50 bytes", () => {
-      for (let i = "0"; i.length <= 100; i  = i + (i.length % 16).toString(16)) {
+      for (let i = "0"; i.length <= 100; i = i + (i.length % 16).toString(16)) {
         const evenLengthHexString = i.length & 1 ? `0${i}` : i;
         const expected = Buffer.from(evenLengthHexString, "hex");
         const input = `0x${i}`;
         const actual = parseAndValidateStringInput(input);
-        assert.deepEqual(actual, expected, `incorrect value for input ${input}, expected: 0x${expected.toString("hex")}, got: 0x${actual.toString("hex")}`);
+        assert.deepEqual(
+          actual,
+          expected,
+          `incorrect value for input ${input}, expected: 0x${expected.toString(
+            "hex"
+          )}, got: 0x${actual.toString("hex")}`
+        );
       }
     });
   });
 
   describe("parseAndValidateNumberInput()", () => {
-    [
-      -1,
-      Infinity,
-      -Infinity,
-      NaN,
-      0.1
-    ].forEach(input => {
+    [-1, Infinity, -Infinity, NaN, 0.1].forEach(input => {
       it(`should reject invalid value: ${input}`, () => {
         assert.throws(() => parseAndValidateNumberInput(input));
       });
@@ -78,20 +74,26 @@ describe("json-rpc-input-parsers", () => {
 
     it("should return the current buffer for lengths up to 6 bytes", () => {
       // after Number.MAX_SAFE_INTEGER (which is 7 bytes long) we will start to lose precision
-      for (let i = "1"; i.length <= 12; i  = i + (i.length % 16).toString(16)) {
+      for (let i = "1"; i.length <= 12; i = i + (i.length % 16).toString(16)) {
         const evenLengthHexString = i.length & 1 ? `0${i}` : i;
         const input = parseInt(i, 16);
         const expected = Buffer.from(evenLengthHexString, "hex");
         const actual = parseAndValidateNumberInput(input);
-        assert.deepEqual(actual, expected, `incorrect value for input 0x${input.toString(16)}, expected: 0x${expected.toString("hex")}, got: 0x${actual.toString("hex")}`);
+        assert.deepEqual(
+          actual,
+          expected,
+          `incorrect value for input 0x${input.toString(
+            16
+          )}, expected: 0x${expected.toString("hex")}, got: 0x${actual.toString(
+            "hex"
+          )}`
+        );
       }
     });
   });
 
   describe("parseAndValidateBigIntInput()", () => {
-    [
-    -1n
-    ].forEach(input => {
+    [-1n].forEach(input => {
       it(`should reject invalid value: ${input}`, () => {
         assert.throws(() => parseAndValidateBigIntInput(input));
       });
@@ -99,7 +101,7 @@ describe("json-rpc-input-parsers", () => {
 
     [
       [0n, []],
-      [1n, [0x01]],
+      [1n, [0x01]]
     ].forEach(([input, expectedByteArray]) => {
       it(`should return the correct buffer for special case: ${input}`, () => {
         const expected = Buffer.from(<any>expectedByteArray);
@@ -109,12 +111,20 @@ describe("json-rpc-input-parsers", () => {
     });
 
     it("should return the correct buffer for every length up to 50 bytes", () => {
-      for (let i = "1"; i.length <= 100; i  = i + (i.length % 16).toString(16)) {
+      for (let i = "1"; i.length <= 100; i = i + (i.length % 16).toString(16)) {
         const evenLengthHexString = i.length & 1 ? `0${i}` : i;
         const expected = Buffer.from(evenLengthHexString, "hex");
         const input = BigInt(`0x${evenLengthHexString}`);
         const actual = parseAndValidateBigIntInput(input);
-        assert.deepEqual(actual, expected, `incorrect value for input 0x${input.toString(16)}, expected: 0x${expected.toString("hex")}, got: 0x${actual.toString("hex")}`);
+        assert.deepEqual(
+          actual,
+          expected,
+          `incorrect value for input 0x${input.toString(
+            16
+          )}, expected: 0x${expected.toString("hex")}, got: 0x${actual.toString(
+            "hex"
+          )}`
+        );
       }
     });
   });

--- a/src/packages/utils/tests/json-rpc-data.test.ts
+++ b/src/packages/utils/tests/json-rpc-data.test.ts
@@ -1,174 +1,97 @@
 import assert from "assert";
-import {Data} from "..";
+import {Data} from "../src/things/json-rpc/json-rpc-data";
+
+// note: variations on non-buffer inputs are covered in the tests in ./input-parsers.test.ts
+
+const testData = [
+  //[input, toString(), toBuffer()]
+  [Buffer.from([0x00]), "0x00", Buffer.from([0x00])],
+  [Buffer.from([0x01]), "0x01", Buffer.from([0x01])],
+  [Buffer.from([0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef]), "0x0123456789abcdef", Buffer.from([0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef])],
+];
 
 describe("json-rpc-data", () => {
-  const inputOf32Bytes = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
-  const validValues = [ "0x", "0x1", "0x1234", Buffer.from([]), Buffer.from([0x12,0x34]), inputOf32Bytes ];
-  const invalidValues: any[] = [ "1234", 1234n, NaN/*, undefined, null, 1234, [], {}, "0x-1234"*/ ]; // todo: this should be addressed in rewrite of json-rpc-data
-                                                                                                     // See related https://github.com/trufflesuite/ganache/labels/json-rpc%20refactor
-  const validBytelengths = (() => { let i = 0; return [...new Array(100)].map(_ => i++); })(); // [0...99]
-  const invalidBytelengths: any[] = [ -1, "1", {}, [], null, NaN ];
-
-  function getExpectedString(value: Buffer|string, bytelength?: number) {
-    let expected: string;
-
-    if (typeof value === "string") {
-      expected = value.slice(2);
-    } else if (Buffer.isBuffer(value)) {
-      expected = (<Buffer>value).toString("hex");
-    } else {
-      throw new Error(`Type not supported ${typeof value}`)
-    }
-    if (bytelength !== undefined) {
-      /*
-      If the value is longer than the specified bytelength, then the result must be left padded.
-      ie: "0x01" bytelength 2 becomes "0x0001"
-
-      If the value is longer than the specified bytelength, then the result must be truncated.
-      ie: "0x123456" bytelength 2 becomes "0x1234"
-      */
-      const padCharCount = (bytelength - expected.length / 2) * 2; // (desired byte count - actual byte count) * 2 characters per byte
-      if (padCharCount > 0) {
-        expected = "0".repeat(padCharCount) + expected;
-      } else {
-        expected = expected.slice(0, bytelength * 2);
-      }
-    }
-    return "0x" + expected;
-  }
-
   describe("constructor", () => {
-    it("should accept different values", () => {
-      validValues.forEach(value => {
-        const d = new Data(value);
-      });
-    });
+    it("should create a Data", () => {
+      const input = Buffer.alloc(0);        
+      const data = new Data(input);
 
-    it("should fail with invalid values", () => {
-      invalidValues.forEach(value => {
-        assert.throws(() => {
-          const d = new Data(value);
-        }, undefined, `Should fail to accept value: ${value} of type: ${typeof value}`);
-      });
-    });
-
-    it("should accept valid bytelengths", () => {
-      validBytelengths.forEach(bytelength => {
-        const d = new Data("0x01", bytelength);
-      });
-    });
-
-    it("should fail with invalid bytelengths", () => {
-      invalidBytelengths.forEach(bytelength => {
-        assert.throws(() => {
-          const d = new Data("0x01", bytelength);
-        }, undefined, `Should fail to accept bytelength: ${bytelength} of type: ${typeof bytelength}`);
-      });
+      assert(data instanceof Data);
     });
   });
 
   describe("from()", () => {
-    it("should accept different representations of value", () => {
-      validValues.forEach(value => {
-        const d = Data.from(value);
-      });
+    it("should create a Data", () => {
+      const input = Buffer.alloc(0);
+      const data = Data.from(input);
+
+      assert(data instanceof Data);
     });
 
-    it("should fail with invalid values", () => {
-      invalidValues.forEach(value => {
-        assert.throws(() => {
-          const d = Data.from(value);
-        }, undefined, `Should fail to accept value: ${value} of type: ${typeof value}`);
-      });
-    });
+    it("should return a Data passed as input", () => {
+      const input = Data.from(Buffer.alloc(0));
+      const data = Data.from(<any>input);
 
-    it("should accept valid bytelengths", () => {
-      validBytelengths.forEach(bytelength => {
-        const d = Data.from("0x01", bytelength);
-      });
-    });
-
-    it("should fail with invalid bytelengths", () => {
-      invalidBytelengths.forEach(bytelength => {
-        assert.throws(() => {
-          const d = Data.from("0x01", bytelength);
-        }, undefined, `Should fail to accept bytelength: ${bytelength} of type: ${typeof bytelength}`);
-      });
+      assert.strictEqual(data, input);
     });
   });
 
   describe("toString()", () => {
-    it("should stringify without arguments", () => {
-      validValues.forEach(value => {
-        const d = new Data(value);
-        const s = d.toString();
-        const expected = getExpectedString(value);
+    it("should return nullish inputs", () => {
+      [null, undefined].forEach(input => {
+        const result = new Data(input).toString();
 
-        assert.equal(s, expected);
+        assert.strictEqual(result, input);
       });
     });
 
-    it("should stringify with valid bytelengths", () => {
-      validValues.forEach(value => {
-        const d = new Data(value);
-        validBytelengths.forEach(bytelength => {
-          const s = d.toString(bytelength);
-          const expected = getExpectedString(s, bytelength);
-
-          assert.equal(s, expected);
-        });
+    testData.forEach(([input, expected]) => {
+      it(`should stringify the input input: 0x${(<Buffer>input).toString("hex")}`, () => {
+        const result = new Data(<Buffer>input).toString();
+        assert.equal(result, expected);
       });
     });
 
-    it("should fail with invalid bytelengths", () => {
-      validValues.forEach(value => {
-        const d = new Data(value);
-        invalidBytelengths.forEach(bytelength => {
-          assert.throws(() => {
-            const s = d.toString(<any>bytelength);
-          }, undefined, `Should fail to accept bytelength: ${bytelength} of type: ${typeof bytelength}`);
-        });
-      });
+    it("should truncate to a shorter byteLength", () => {
+      const result = new Data(Buffer.from([0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef])).toString(1);
+      assert.equal(result, "0x01");
     });
 
-    it("should stringify with valid bytelengths provided to constructor", () => {
-      validValues.forEach(value => {
-        validBytelengths.forEach(bytelength => {
-          const d = new Data(value, bytelength);
-          const s = d.toString();
-          const expected = getExpectedString(s, bytelength);
-
-          assert.equal(s, expected);
-        });
-      });
+    it("should pad to a longer byteLength", () => {
+      const result = new Data(Buffer.from([0x01])).toString(10);
+      assert.equal(result, "0x00000000000000000001");
     });
   });
 
   describe("toBuffer()", () => {
-    it("should create a buffer", () => {
-      const expected = Buffer.from([0x12, 0x34]);
-      const d = new Data("0x1234");
-      const b = d.toBuffer();
-
-      assert.deepEqual(b, expected);
+    it("should coalesce for empty buffer", () => {
+      const result = new Data(Buffer.alloc(0)).toBuffer();
+      assert.deepEqual(result, Buffer.alloc(0));
     });
 
-    // todo: this should be addressed in rewrite of json-rpc-data https://github.com/trufflesuite/ganache/labels/json-rpc%20refactor
-    it.skip("should create a buffer with a smaller bytelength", () => {
-      const expected = Buffer.from([0x12, 0x34]);
-      const d = new Data("0x123456789abcdef", 2);
-      const b = d.toBuffer();
-
-      assert.deepEqual(b, expected);
+    it("should coallesce nullish inputs", () => {
+      [null, undefined].forEach(input => {
+        const result = new Data(input).toBuffer();
+        assert.deepEqual(result, Buffer.alloc(0));
+      });
     });
 
-    // todo: this should be addressed in rewrite of json-rpc-data https://github.com/trufflesuite/ganache/labels/json-rpc%20refactor
-    it.skip("should create a buffer with a larger bytelength", () => {
-      const expected = Buffer.from([0x00, 0x00, 0x12, 0x34]);
-      const d = new Data("0x1234", 4);
-      const b = d.toBuffer();
+    it("should truncate to a shorter byteLength", () => {
+      const result = new Data(Buffer.from([0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef])).toBuffer(1);
+      assert.deepEqual(result, Buffer.from([0x01]));
+    });
 
-      assert.deepEqual(b, expected);
+    it("should pad to a longer byteLength", () => {
+      const result = new Data(Buffer.from([0x01])).toBuffer(10);
+      const expected = Buffer.from([0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x01]);
+      assert.deepEqual(result, expected);
+    });
+
+    testData.forEach(([input, _, expected]) => {
+      it(`should output the correct buffer for the input: 0x${(<Buffer>input).toString("hex")}`, () => {
+        const result = new Data(<Buffer>input).toBuffer();
+        assert.deepEqual(result, expected);
+      });
     });
   });
 });

--- a/src/packages/utils/tests/json-rpc-data.test.ts
+++ b/src/packages/utils/tests/json-rpc-data.test.ts
@@ -30,7 +30,7 @@ describe("json-rpc-data", () => {
   });
 
   describe("toString()", () => {
-    it('should return "0x" for nullish inputs', () => {
+    it('should return "0x" for null-like inputs', () => {
       [null, undefined].forEach(input => {
         const result = new Data(input).toString();
 
@@ -39,7 +39,7 @@ describe("json-rpc-data", () => {
     });
 
     testData.forEach(([input, expected]) => {
-      it(`should stringify the input input: 0x${(<Buffer>input).toString("hex")}`, () => {
+      it(`should stringify the input: 0x${(<Buffer>input).toString("hex")}`, () => {
         const result = new Data(<Buffer>input).toString();
         assert.equal(result, expected);
       });
@@ -57,12 +57,12 @@ describe("json-rpc-data", () => {
   });
 
   describe("toBuffer()", () => {
-    it("should coalesce for empty buffer", () => {
+    it("should return an empty buffer for an empty buffer input", () => {
       const result = new Data(Buffer.alloc(0)).toBuffer();
       assert.deepEqual(result, Buffer.alloc(0));
     });
 
-    it("should coallesce nullish inputs", () => {
+    it("should return an empty buffer for null-like inputs", () => {
       [null, undefined].forEach(input => {
         const result = new Data(input).toBuffer();
         assert.deepEqual(result, Buffer.alloc(0));

--- a/src/packages/utils/tests/json-rpc-data.test.ts
+++ b/src/packages/utils/tests/json-rpc-data.test.ts
@@ -13,7 +13,7 @@ const testData = [
 describe("json-rpc-data", () => {
   describe("constructor", () => {
     it("should create a Data", () => {
-      const input = Buffer.alloc(0);        
+      const input = Buffer.alloc(0);
       const data = new Data(input);
 
       assert(data instanceof Data);
@@ -37,11 +37,11 @@ describe("json-rpc-data", () => {
   });
 
   describe("toString()", () => {
-    it("should return nullish inputs", () => {
+    it('should return "0x" for nullish inputs', () => {
       [null, undefined].forEach(input => {
         const result = new Data(input).toString();
 
-        assert.strictEqual(result, input);
+        assert.strictEqual(result, "0x");
       });
     });
 

--- a/src/packages/utils/tests/json-rpc-data.test.ts
+++ b/src/packages/utils/tests/json-rpc-data.test.ts
@@ -27,13 +27,6 @@ describe("json-rpc-data", () => {
 
       assert(data instanceof Data);
     });
-
-    it("should return a Data passed as input", () => {
-      const input = Data.from(Buffer.alloc(0));
-      const data = Data.from(<any>input);
-
-      assert.strictEqual(data, input);
-    });
   });
 
   describe("toString()", () => {

--- a/src/packages/utils/tests/json-rpc-data.test.ts
+++ b/src/packages/utils/tests/json-rpc-data.test.ts
@@ -87,4 +87,20 @@ describe("json-rpc-data", () => {
       });
     });
   });
+
+  describe("isNull()", () => {
+    it("should return true for null-like inputs", () => {
+      [null, undefined, Buffer.alloc(0)].forEach(input => {
+        const data = new Data(input);
+        assert(data.isNull());
+      });
+    });
+
+    it("should return false for any non-empty buffer", () => {
+      [Buffer.allocUnsafe(1), Buffer.allocUnsafe(2)].forEach(input => {
+        const data = new Data(input);
+        assert.equal(data.isNull(), false);
+      });
+    });
+  });
 });

--- a/src/packages/utils/tests/json-rpc-data.test.ts
+++ b/src/packages/utils/tests/json-rpc-data.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import {Data} from "../src/things/json-rpc/json-rpc-data";
+import { Data } from "../src/things/json-rpc/json-rpc-data";
 
 // note: variations on non-buffer inputs are covered in the tests in ./input-parsers.test.ts
 
@@ -7,7 +7,11 @@ const testData = [
   //[input, toString(), toBuffer()]
   [Buffer.from([0x00]), "0x00", Buffer.from([0x00])],
   [Buffer.from([0x01]), "0x01", Buffer.from([0x01])],
-  [Buffer.from([0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef]), "0x0123456789abcdef", Buffer.from([0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef])],
+  [
+    Buffer.from([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]),
+    "0x0123456789abcdef",
+    Buffer.from([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef])
+  ]
 ];
 
 describe("json-rpc-data", () => {
@@ -39,14 +43,18 @@ describe("json-rpc-data", () => {
     });
 
     testData.forEach(([input, expected]) => {
-      it(`should stringify the input: 0x${(<Buffer>input).toString("hex")}`, () => {
+      it(`should stringify the input: 0x${(<Buffer>input).toString(
+        "hex"
+      )}`, () => {
         const result = new Data(<Buffer>input).toString();
         assert.equal(result, expected);
       });
     });
 
     it("should truncate to a shorter byteLength", () => {
-      const result = new Data(Buffer.from([0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef])).toString(1);
+      const result = new Data(
+        Buffer.from([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef])
+      ).toString(1);
       assert.equal(result, "0x01");
     });
 
@@ -70,18 +78,24 @@ describe("json-rpc-data", () => {
     });
 
     it("should truncate to a shorter byteLength", () => {
-      const result = new Data(Buffer.from([0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef])).toBuffer(1);
+      const result = new Data(
+        Buffer.from([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef])
+      ).toBuffer(1);
       assert.deepEqual(result, Buffer.from([0x01]));
     });
 
     it("should pad to a longer byteLength", () => {
       const result = new Data(Buffer.from([0x01])).toBuffer(10);
-      const expected = Buffer.from([0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x01]);
+      const expected = Buffer.from([
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+      ]);
       assert.deepEqual(result, expected);
     });
 
     testData.forEach(([input, _, expected]) => {
-      it(`should output the correct buffer for the input: 0x${(<Buffer>input).toString("hex")}`, () => {
+      it(`should output the correct buffer for the input: 0x${(<Buffer>(
+        input
+      )).toString("hex")}`, () => {
         const result = new Data(<Buffer>input).toBuffer();
         assert.deepEqual(result, expected);
       });

--- a/src/packages/utils/tests/json-rpc-quantity.test.ts
+++ b/src/packages/utils/tests/json-rpc-quantity.test.ts
@@ -1,0 +1,137 @@
+import assert from "assert";
+import {Quantity} from "../src/things/json-rpc/json-rpc-quantity";
+
+// note: variations on non-buffer inputs are covered in the tests in ./input-parsers.test.ts
+
+const testData = [
+  //[input, toString(), toNumber(), toBuffer()]
+  [Buffer.alloc(0), "0x0", 0, Buffer.alloc(0)],
+  [Buffer.from([0x00]), "0x0", 0, Buffer.alloc(0)],
+  [Buffer.from([0x01]), "0x1", 1, Buffer.from([0x01])],
+  [Buffer.from([0x00, 0x00, 0x00, 0x00, 0x01]), "0x1", 1, Buffer.from([0x01])],
+  [Buffer.from([0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef]), "0x123456789abcdef", 0x0123456789abcdef, Buffer.from([0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef])],
+];
+
+describe("json-rpc-quantity", () => {
+  describe("constructor", () => {
+    it("should create a Quantity", () => {
+      const input = Buffer.alloc(0);        
+      const quantity = new Quantity(input);
+      const nullable = new Quantity(input, true);
+
+      assert(quantity instanceof Quantity);
+      assert(nullable instanceof Quantity);
+    });
+  });
+
+  describe("from()", () => {
+    it("should create a Quantity", () => {
+      const input = Buffer.alloc(0);
+      const quantity = Quantity.from(input);
+      const nullable = Quantity.from(input, true);
+
+      assert(quantity instanceof Quantity);
+      assert(nullable instanceof Quantity);
+    });
+
+    it("should return a Quantity passed as input", () => {
+      const input = Quantity.from(Buffer.alloc(0));
+      const quantity = Quantity.from(<any>input);
+
+      assert.strictEqual(quantity, input);
+    });
+  });
+
+  describe("toString()", () => {
+    it("should return nullish inputs", () => {
+      [null, undefined].forEach(input => {
+        const result = new Quantity(input, true).toString();
+
+        assert.strictEqual(result, input);
+      });
+    });
+
+    it("should return null for empty buffer", () => {
+      const result = new Quantity(Buffer.alloc(0), true).toString();
+      assert.equal(result, null);
+    });
+
+    it("should coallesce nullish inputs", () => {
+      [null, undefined].forEach(input => {
+        const result = new Quantity(input, false).toString();
+
+        assert.equal(result, "0x0");
+      });
+    });
+
+    testData.forEach(([input, expected]) => {
+      it(`should stringify the input input: 0x${(<Buffer>input).toString("hex")}`, () => {
+        const result = new Quantity(input).toString();
+        assert.equal(result, expected);
+      });
+    });
+  });
+
+  describe("toNumber()", () => {
+    it("should return nullish inputs", () => {
+      [null, undefined].forEach(input => {
+        const result = new Quantity(input, true).toNumber();
+
+        assert.strictEqual(result, input);
+      });
+    });
+
+    // todo: should we return null for nullable quantities?
+    it.skip("should return null for empty input", () => {
+      const result = new Quantity(Buffer.alloc(0), true).toNumber();
+      assert.equal(result, null);
+    });
+
+    it("should coallesce nullish inputs", () => {
+      [null, undefined].forEach(input => {
+        const result = new Quantity(input, false).toNumber();
+
+        assert.equal(result, 0);
+      });
+    });
+
+    testData.forEach(([input, _, expected]) => {
+      it(`should output the correct number for the input input: 0x${(<Buffer>input).toString("hex")}`, () => {
+        const result = new Quantity(input).toNumber();
+        assert.equal(result, expected);
+      });
+    });
+  });
+
+  describe("toBuffer()", () => {
+    // todo: should we return null for nullable quantities?
+    it.skip("should return nullish inputs", () => {
+      [null, undefined].forEach(input => {
+        const result = new Quantity(input, true).toBuffer();
+
+        assert.deepEqual(result, input);
+      });
+    });
+
+    // todo: should we return null for nullable quantities?
+    it("should coalesce for empty buffer", () => {
+      const result = new Quantity(Buffer.alloc(0), true).toBuffer();
+      assert.deepEqual(result, Buffer.alloc(0));
+    });
+
+    it("should coallesce nullish inputs", () => {
+      [null, undefined].forEach(input => {
+        const result = new Quantity(input, false).toBuffer();
+
+        assert.deepEqual(result, Buffer.alloc(0));
+      });
+    });
+
+    testData.forEach(([input, _, __, expected]) => {
+      it(`should output the correct buffer for the input input: 0x${(<Buffer>input).toString("hex")}`, () => {
+        const result = new Quantity(input).toBuffer();
+        assert.deepEqual(result, expected);
+      });
+    });
+  });
+});

--- a/src/packages/utils/tests/json-rpc-quantity.test.ts
+++ b/src/packages/utils/tests/json-rpc-quantity.test.ts
@@ -51,9 +51,14 @@ describe("json-rpc-quantity", () => {
       });
     });
 
-    it("should return null for empty buffer", () => {
+    it("should return 0x0 for empty buffer", () => {
       const result = new Quantity(Buffer.alloc(0), true).toString();
-      assert.equal(result, null);
+      assert.equal(result, "0x0");
+    });
+
+    it("should return 0x0 for a non-empty buffer of 0x00 bytes", () => {
+      const result = new Quantity(Buffer.alloc(10), true).toString();
+      assert.equal(result, "0x0");
     });
 
     it("should coallesce nullish inputs", () => {

--- a/src/packages/utils/tests/json-rpc-quantity.test.ts
+++ b/src/packages/utils/tests/json-rpc-quantity.test.ts
@@ -22,6 +22,12 @@ describe("json-rpc-quantity", () => {
       assert(quantity instanceof Quantity);
       assert(nullable instanceof Quantity);
     });
+
+    it(`should reject a valid of "0x"`, () => {
+      assert.throws(() => new Quantity("0x"),
+       new Error(`Cannot wrap "0x" as a json-rpc Quantity type; strings must contain at least one hexadecimal symbol.`)
+      );
+    });
   });
 
   describe("from()", () => {
@@ -43,11 +49,11 @@ describe("json-rpc-quantity", () => {
   });
 
   describe("toString()", () => {
-    it("should return nullish inputs", () => {
+    it("should return null for `null | undefined` inputs", () => {
       [null, undefined].forEach(input => {
         const result = new Quantity(input, true).toString();
 
-        assert.strictEqual(result, input);
+        assert.strictEqual(result, null);
       });
     });
 
@@ -73,21 +79,20 @@ describe("json-rpc-quantity", () => {
   });
 
   describe("toNumber()", () => {
-    it("should return nullish inputs", () => {
+    it("should return null for `null | undefined` inputs", () => {
       [null, undefined].forEach(input => {
         const result = new Quantity(input, true).toNumber();
 
-        assert.strictEqual(result, input);
+        assert.strictEqual(result, null);
       });
     });
 
-    // todo: should we return null for nullable quantities?
-    it.skip("should return null for empty input", () => {
+    it("should return null for empty input", () => {
       const result = new Quantity(Buffer.alloc(0), true).toNumber();
       assert.equal(result, null);
     });
 
-    it("should coallesce nullish inputs", () => {
+    it("should coallesce nullish inputs to 0", () => {
       [null, undefined].forEach(input => {
         const result = new Quantity(input, false).toNumber();
 
@@ -104,16 +109,16 @@ describe("json-rpc-quantity", () => {
   });
 
   describe("toBuffer()", () => {
-    // todo: should we return null for nullable quantities?
-    it.skip("should return nullish inputs", () => {
+    // todo: as per https://github.com/trufflesuite/ganache/issues/3174
+    // if value is null, and nullable is true, then it should probably return null
+    it("should return null inputs", () => {
       [null, undefined].forEach(input => {
         const result = new Quantity(input, true).toBuffer();
 
-        assert.deepEqual(result, input);
+        assert.deepEqual(result, Buffer.alloc(0));
       });
     });
 
-    // todo: should we return null for nullable quantities?
     it("should coalesce for empty buffer", () => {
       const result = new Quantity(Buffer.alloc(0), true).toBuffer();
       assert.deepEqual(result, Buffer.alloc(0));

--- a/src/packages/utils/tests/json-rpc-quantity.test.ts
+++ b/src/packages/utils/tests/json-rpc-quantity.test.ts
@@ -51,11 +51,6 @@ describe("json-rpc-quantity", () => {
       });
     });
 
-    it("should return 0x0 for empty buffer", () => {
-      const result = new Quantity(Buffer.alloc(0), true).toString();
-      assert.equal(result, "0x0");
-    });
-
     it("should return 0x0 for a non-empty buffer of 0x00 bytes", () => {
       const result = new Quantity(Buffer.alloc(10), true).toString();
       assert.equal(result, "0x0");

--- a/src/packages/utils/tests/json-rpc-quantity.test.ts
+++ b/src/packages/utils/tests/json-rpc-quantity.test.ts
@@ -25,7 +25,7 @@ describe("json-rpc-quantity", () => {
 
     it(`should reject a valid of "0x"`, () => {
       assert.throws(() => new Quantity("0x"),
-       new Error(`Cannot wrap "0x" as a json-rpc Quantity type; strings must contain at least one hexadecimal symbol.`)
+       new Error(`Cannot wrap "0x" as a json-rpc Quantity type; strings must contain at least one hexadecimal character.`)
       );
     });
   });
@@ -62,7 +62,7 @@ describe("json-rpc-quantity", () => {
       assert.equal(result, "0x0");
     });
 
-    it("should coallesce nullish inputs", () => {
+    it(`should return "0x0" for null-like inputs`, () => {
       [null, undefined].forEach(input => {
         const result = new Quantity(input, false).toString();
 
@@ -71,7 +71,7 @@ describe("json-rpc-quantity", () => {
     });
 
     testData.forEach(([input, expected]) => {
-      it(`should stringify the input input: 0x${(<Buffer>input).toString("hex")}`, () => {
+      it(`should stringify the input: 0x${(<Buffer>input).toString("hex")}`, () => {
         const result = new Quantity(input).toString();
         assert.equal(result, expected);
       });
@@ -92,7 +92,7 @@ describe("json-rpc-quantity", () => {
       assert.equal(result, null);
     });
 
-    it("should coallesce nullish inputs to 0", () => {
+    it("should retrun 0 for null0like inputs", () => {
       [null, undefined].forEach(input => {
         const result = new Quantity(input, false).toNumber();
 
@@ -101,7 +101,7 @@ describe("json-rpc-quantity", () => {
     });
 
     testData.forEach(([input, _, expected]) => {
-      it(`should output the correct number for the input input: 0x${(<Buffer>input).toString("hex")}`, () => {
+      it(`should output the correct number for the input: 0x${(<Buffer>input).toString("hex")}`, () => {
         const result = new Quantity(input).toNumber();
         assert.equal(result, expected);
       });
@@ -119,12 +119,12 @@ describe("json-rpc-quantity", () => {
       });
     });
 
-    it("should coalesce for empty buffer", () => {
+    it("should return an empty buffer for an empty buffer input", () => {
       const result = new Quantity(Buffer.alloc(0), true).toBuffer();
       assert.deepEqual(result, Buffer.alloc(0));
     });
 
-    it("should coallesce nullish inputs", () => {
+    it("should return an empty buffer for null-like inputs", () => {
       [null, undefined].forEach(input => {
         const result = new Quantity(input, false).toBuffer();
 
@@ -133,7 +133,7 @@ describe("json-rpc-quantity", () => {
     });
 
     testData.forEach(([input, _, __, expected]) => {
-      it(`should output the correct buffer for the input input: 0x${(<Buffer>input).toString("hex")}`, () => {
+      it(`should output the correct buffer for the input: 0x${(<Buffer>input).toString("hex")}`, () => {
         const result = new Quantity(input).toBuffer();
         assert.deepEqual(result, expected);
       });

--- a/src/packages/utils/tests/json-rpc-quantity.test.ts
+++ b/src/packages/utils/tests/json-rpc-quantity.test.ts
@@ -5,17 +5,18 @@ import {Quantity} from "../src/things/json-rpc/json-rpc-quantity";
 
 const testData = [
   //[input, toString(), toNumber(), toBuffer()]
-  [Buffer.alloc(0), "0x0", 0, Buffer.alloc(0)],
   [Buffer.from([0x00]), "0x0", 0, Buffer.alloc(0)],
   [Buffer.from([0x01]), "0x1", 1, Buffer.from([0x01])],
   [Buffer.from([0x00, 0x00, 0x00, 0x00, 0x01]), "0x1", 1, Buffer.from([0x01])],
   [Buffer.from([0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef]), "0x123456789abcdef", 0x0123456789abcdef, Buffer.from([0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef])],
 ];
 
+const nullLikeInputs = [null, undefined, Buffer.alloc(0)];
+
 describe("json-rpc-quantity", () => {
   describe("constructor", () => {
     it("should create a Quantity", () => {
-      const input = Buffer.alloc(0);        
+      const input = Buffer.alloc(0);
       const quantity = new Quantity(input);
       const nullable = new Quantity(input, true);
 
@@ -49,8 +50,8 @@ describe("json-rpc-quantity", () => {
   });
 
   describe("toString()", () => {
-    it("should return null for `null | undefined` inputs", () => {
-      [null, undefined].forEach(input => {
+    it("should return null for null-like inputs", () => {
+      nullLikeInputs.forEach(input => {
         const result = new Quantity(input, true).toString();
 
         assert.strictEqual(result, null);
@@ -59,11 +60,12 @@ describe("json-rpc-quantity", () => {
 
     it("should return 0x0 for a non-empty buffer of 0x00 bytes", () => {
       const result = new Quantity(Buffer.alloc(10), true).toString();
+
       assert.equal(result, "0x0");
     });
 
     it(`should return "0x0" for null-like inputs`, () => {
-      [null, undefined].forEach(input => {
+      nullLikeInputs.forEach(input => {
         const result = new Quantity(input, false).toString();
 
         assert.equal(result, "0x0");
@@ -72,15 +74,18 @@ describe("json-rpc-quantity", () => {
 
     testData.forEach(([input, expected]) => {
       it(`should stringify the input: 0x${(<Buffer>input).toString("hex")}`, () => {
-        const result = new Quantity(input).toString();
-        assert.equal(result, expected);
+        [true, false].forEach(nullable => {
+          const result = new Quantity(input, nullable).toString();
+
+          assert.equal(result, expected);
+        });
       });
     });
   });
 
   describe("toNumber()", () => {
     it("should return null for `null | undefined` inputs", () => {
-      [null, undefined].forEach(input => {
+      nullLikeInputs.forEach(input => {
         const result = new Quantity(input, true).toNumber();
 
         assert.strictEqual(result, null);
@@ -89,11 +94,12 @@ describe("json-rpc-quantity", () => {
 
     it("should return null for empty input", () => {
       const result = new Quantity(Buffer.alloc(0), true).toNumber();
+
       assert.equal(result, null);
     });
 
-    it("should retrun 0 for null0like inputs", () => {
-      [null, undefined].forEach(input => {
+    it("should return 0 for null-like inputs", () => {
+      nullLikeInputs.forEach(input => {
         const result = new Quantity(input, false).toNumber();
 
         assert.equal(result, 0);
@@ -102,8 +108,11 @@ describe("json-rpc-quantity", () => {
 
     testData.forEach(([input, _, expected]) => {
       it(`should output the correct number for the input: 0x${(<Buffer>input).toString("hex")}`, () => {
-        const result = new Quantity(input).toNumber();
-        assert.equal(result, expected);
+        [true, false].forEach(nullable => {
+          const result = new Quantity(input, nullable).toNumber();
+
+          assert.equal(result, expected);
+        });
       });
     });
   });
@@ -112,7 +121,7 @@ describe("json-rpc-quantity", () => {
     // todo: as per https://github.com/trufflesuite/ganache/issues/3174
     // if value is null, and nullable is true, then it should probably return null
     it("should return null inputs", () => {
-      [null, undefined].forEach(input => {
+      nullLikeInputs.forEach(input => {
         const result = new Quantity(input, true).toBuffer();
 
         assert.deepEqual(result, Buffer.alloc(0));
@@ -121,11 +130,12 @@ describe("json-rpc-quantity", () => {
 
     it("should return an empty buffer for an empty buffer input", () => {
       const result = new Quantity(Buffer.alloc(0), true).toBuffer();
+
       assert.deepEqual(result, Buffer.alloc(0));
     });
 
     it("should return an empty buffer for null-like inputs", () => {
-      [null, undefined].forEach(input => {
+      nullLikeInputs.forEach(input => {
         const result = new Quantity(input, false).toBuffer();
 
         assert.deepEqual(result, Buffer.alloc(0));
@@ -135,7 +145,30 @@ describe("json-rpc-quantity", () => {
     testData.forEach(([input, _, __, expected]) => {
       it(`should output the correct buffer for the input: 0x${(<Buffer>input).toString("hex")}`, () => {
         const result = new Quantity(input).toBuffer();
+
         assert.deepEqual(result, expected);
+      });
+    });
+  });
+
+  describe("isNull()", () => {
+    it("should return true for null-like inputs, regardless of nullable value", () => {
+      [true, false].forEach(nullable => {
+        nullLikeInputs.forEach(input => {
+          const quantity = new Quantity(input, nullable);
+
+          assert(quantity.isNull());
+        });
+      });
+    });
+
+    it("should return false for any non-empty buffer, regardless of nullable value", () => {
+      [true, false].forEach(nullable => {
+        [Buffer.alloc(1), Buffer.alloc(2)].forEach(input => {
+          const quantity = new Quantity(input, nullable);
+
+          assert.equal(quantity.isNull(), false);
+        });
       });
     });
   });

--- a/src/packages/utils/tests/json-rpc-quantity.test.ts
+++ b/src/packages/utils/tests/json-rpc-quantity.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import {Quantity} from "../src/things/json-rpc/json-rpc-quantity";
+import { Quantity } from "../src/things/json-rpc/json-rpc-quantity";
 
 // note: variations on non-buffer inputs are covered in the tests in ./input-parsers.test.ts
 
@@ -8,7 +8,12 @@ const testData = [
   [Buffer.from([0x00]), "0x0", 0, Buffer.alloc(0)],
   [Buffer.from([0x01]), "0x1", 1, Buffer.from([0x01])],
   [Buffer.from([0x00, 0x00, 0x00, 0x00, 0x01]), "0x1", 1, Buffer.from([0x01])],
-  [Buffer.from([0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef]), "0x123456789abcdef", 0x0123456789abcdef, Buffer.from([0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef])],
+  [
+    Buffer.from([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]),
+    "0x123456789abcdef",
+    0x0123456789abcdef,
+    Buffer.from([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef])
+  ]
 ];
 
 const nullLikeInputs = [null, undefined, Buffer.alloc(0)];
@@ -25,8 +30,11 @@ describe("json-rpc-quantity", () => {
     });
 
     it(`should reject a valid of "0x"`, () => {
-      assert.throws(() => new Quantity("0x"),
-       new Error(`Cannot wrap "0x" as a json-rpc Quantity type; strings must contain at least one hexadecimal character.`)
+      assert.throws(
+        () => new Quantity("0x"),
+        new Error(
+          `Cannot wrap "0x" as a json-rpc Quantity type; strings must contain at least one hexadecimal character.`
+        )
       );
     });
   });
@@ -73,7 +81,9 @@ describe("json-rpc-quantity", () => {
     });
 
     testData.forEach(([input, expected]) => {
-      it(`should stringify the input: 0x${(<Buffer>input).toString("hex")}`, () => {
+      it(`should stringify the input: 0x${(<Buffer>input).toString(
+        "hex"
+      )}`, () => {
         [true, false].forEach(nullable => {
           const result = new Quantity(input, nullable).toString();
 
@@ -107,7 +117,9 @@ describe("json-rpc-quantity", () => {
     });
 
     testData.forEach(([input, _, expected]) => {
-      it(`should output the correct number for the input: 0x${(<Buffer>input).toString("hex")}`, () => {
+      it(`should output the correct number for the input: 0x${(<Buffer>(
+        input
+      )).toString("hex")}`, () => {
         [true, false].forEach(nullable => {
           const result = new Quantity(input, nullable).toNumber();
 
@@ -143,7 +155,9 @@ describe("json-rpc-quantity", () => {
     });
 
     testData.forEach(([input, _, __, expected]) => {
-      it(`should output the correct buffer for the input: 0x${(<Buffer>input).toString("hex")}`, () => {
+      it(`should output the correct buffer for the input: 0x${(<Buffer>(
+        input
+      )).toString("hex")}`, () => {
         const result = new Quantity(input).toBuffer();
 
         assert.deepEqual(result, expected);


### PR DESCRIPTION
As part of an ongoing effort to make Ganache :zap: Lightning-Fast :zap:, the internal representations of JSON-RPC data (`Data`, `Quantity`, and `Address`) have been rewritten to be quicker, and does not change how you should use Ganache.

These classes also now validate input values correctly, following the guidelines  [established by the Ethereum Foundation](https://ethereum.org/en/developers/docs/apis/json-rpc/). This makes Ganache behave more correctly, but may cause some failures in existing code bases where invalid values are being passed into RPC functions.

This change has a significant impact on forking performance. [The Convex Shutdown benchmark](https://github.com/mds1/convex-shutdown-simulation) simulates a call to Convex's `systemShutdown` method. With a hot cache, Ganache's performance, with and without this change is below:


| Ganache Version | Cached     |
| -----------------|------------|
| 7.2.0 - before      | 0m28.015s |
| 7.3.0 - after         | 0m19.312s |

Which is an approximately 31% speed up!

_Note: Benchmarks were performed on macOS 12.2.1 with M1 Pro CPU and 16 GB LPDDR5._
