### PR TITLE
chore: support node 18

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,10 @@ jobs:
       matrix:
         node: [12.0.0, 12.x, 14.x, 16.x, 18.x]
         os: [windows-2019, ubuntu-18.04, ubuntu-20.04, macos-11]
+        exclude:
+          # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
+          - os: ubuntu-18.04
+            node: 18.x
 
     runs-on: ${{ matrix.os }}
 
@@ -25,8 +29,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js ${{ matrix.node }}
-        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
@@ -36,18 +38,9 @@ jobs:
         if: startsWith(matrix.os, 'windows-')
         uses: microsoft/setup-msbuild@v1.0.2
 
-      - name: NPM ci
-        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
-        run: npm ci
-      - name: NPM ci
-        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
-        run: npm run tsc
-      - name: NPM ci
-        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
-        run: npm test
+      - run: npm ci
+      - run: npm run tsc
+      - run: npm test
         env:
           FORCE_COLOR: 1
           INFURA_KEY: ${{ secrets.TEST_INFURA_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12.0.0, 12.x, 14.x, 16.x, 17.x]
+        node: [12.0.0, 12.x, 14.x, 16.x, 18.x]
         os: [windows-2019, ubuntu-18.04, ubuntu-20.04, macos-11]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-      - if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.7.0
         with:
@@ -27,6 +25,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js ${{ matrix.node }}
+        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
+        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
@@ -36,9 +36,18 @@ jobs:
         if: startsWith(matrix.os, 'windows-')
         uses: microsoft/setup-msbuild@v1.0.2
 
-      - run: npm ci
-      - run: npm run tsc
-      - run: npm test
+      - name: NPM ci
+        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
+        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
+        run: npm ci
+      - name: NPM ci
+        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
+        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
+        run: npm run tsc
+      - name: NPM ci
+        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
+        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
+        run: npm test
         env:
           FORCE_COLOR: 1
           INFURA_KEY: ${{ secrets.TEST_INFURA_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,10 +15,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-    if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
-
     steps:
+      # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
+      - if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.7.0
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-    if: ${{ matrix.os }} != "ubuntu-18.04" && ${{ matrix.node }} != "18.x"
+    if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
+    if: ${{ matrix.os }} != "ubuntu-18.04" && ${{ matrix.node }} != "18.x"
+
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.7.0

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,7 +39,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    if: github.ref == 'refs/heads/develop'
+    # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
+    if: github.ref == 'refs/heads/develop' && ${{ matrix.os }} != "ubuntu-18.04" && ${{ matrix.node }} != "18.x"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -43,7 +43,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    if: github.ref == 'refs/heads/develop')
+    if: github.ref == 'refs/heads/develop'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,10 +39,11 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-    if: github.ref == 'refs/heads/develop' && matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
+    if: github.ref == 'refs/heads/develop')
 
     steps:
+      # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
+      - if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-    if: github.ref == 'refs/heads/develop' && ${{ matrix.os }} != "ubuntu-18.04" && ${{ matrix.node }} != "18.x"
+    if: github.ref == 'refs/heads/develop' && matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12.0.0, 12.x, 14.x, 16.x, 17.x]
+        node: [12.0.0, 12.x, 14.x, 16.x, 18.x]
         os: [ubuntu-20.04]
 
     runs-on: ${{ matrix.os }}
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12.0.0, 12.x, 14.x, 16.x, 17.x]
+        node: [12.0.0, 12.x, 14.x, 16.x, 18.x]
         os: [windows-2019, ubuntu-18.04, ubuntu-20.04, macos-11]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,6 +36,10 @@ jobs:
       matrix:
         node: [12.0.0, 12.x, 14.x, 16.x, 18.x]
         os: [windows-2019, ubuntu-18.04, ubuntu-20.04, macos-11]
+        exclude:
+          # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
+          - os: ubuntu-18.04
+            node: 18.x
 
     runs-on: ${{ matrix.os }}
 
@@ -46,8 +50,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Use Node.js ${{ matrix.node }}
-        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
@@ -80,18 +82,9 @@ jobs:
         if: startsWith(matrix.os, 'windows-')
         run: npm config set msvs_version 2019 --global
 
-      - name: NPM ci
-        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
-        run: npm ci
-      - name: NPM ci
-        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
-        run: npm run tsc
-      - name: NPM ci
-        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
-        run: npm test
+      - run: npm ci
+      - run: npm run tsc
+      - run: npm test
         env:
           FORCE_COLOR: 1
           INFURA_KEY: ${{ secrets.TEST_INFURA_KEY }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -42,12 +42,12 @@ jobs:
     if: github.ref == 'refs/heads/develop')
 
     steps:
-      # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-      - if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Use Node.js ${{ matrix.node }}
+        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
+        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
@@ -80,9 +80,18 @@ jobs:
         if: startsWith(matrix.os, 'windows-')
         run: npm config set msvs_version 2019 --global
 
-      - run: npm ci
-      - run: npm run tsc
-      - run: npm test
+      - name: NPM ci
+        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
+        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
+        run: npm ci
+      - name: NPM ci
+        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
+        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
+        run: npm run tsc
+      - name: NPM ci
+        # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
+        if: matrix.os != "ubuntu-18.04" && matrix.node != "18.x"
+        run: npm test
         env:
           FORCE_COLOR: 1
           INFURA_KEY: ${{ secrets.TEST_INFURA_KEY }}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "cd scripts && ts-node filter-shrinkwrap.ts \"$(lerna list --parseable --scope ganache)\"/npm-shrinkwrap.json",
     "postpublish": "git restore \"$(lerna list --parseable --scope ganache)\"/npm-shrinkwrap.json",
     "start": "lerna exec --loglevel=silent --scope ganache -- npm run start --silent -- ",
-    "test": "lerna exec --concurrency 1 --scope @ganache/core -- npm run test",
+    "test": "lerna exec --concurrency 1 -- npm run test",
     "tsc": "tsc --build src",
     "tsc.clean": "npx lerna exec -- npx shx rm -rf lib dist typings"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "cd scripts && ts-node filter-shrinkwrap.ts \"$(lerna list --parseable --scope ganache)\"/npm-shrinkwrap.json",
     "postpublish": "git restore \"$(lerna list --parseable --scope ganache)\"/npm-shrinkwrap.json",
     "start": "lerna exec --loglevel=silent --scope ganache -- npm run start --silent -- ",
-    "test": "lerna exec --concurrency 1 -- npm run test",
+    "test": "lerna exec --concurrency 1 --scope @ganache/core -- npm run test",
     "tsc": "tsc --build src",
     "tsc.clean": "npx lerna exec -- npx shx rm -rf lib dist typings"
   },

--- a/src/chains/ethereum/ethereum/package-lock.json
+++ b/src/chains/ethereum/ethereum/package-lock.json
@@ -838,9 +838,9 @@
 			"dev": true
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.4.0-unofficial.5",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.4.0-unofficial.5.tgz",
-			"integrity": "sha512-QR9dSa6TvNFYUWKhvtul1W4CIv8X7QIgF+xwJSqqguBemWsJbVq2INkzvevMUAc2B28k7Orgah1sQ6NhIoJx8A==",
+			"version": "20.8.0-unofficial.0",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.8.0-unofficial.0.tgz",
+			"integrity": "sha512-38ViS2Wz5OuAC4DXA5oqFtg02X4SYxOssEsALt5cRIkE5vKqvKri0kRUZ+fB3l12g4GbcIK3h/e20PUcnoBYMw==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",

--- a/src/chains/ethereum/ethereum/package.json
+++ b/src/chains/ethereum/ethereum/package.json
@@ -86,7 +86,7 @@
     "ws": "8.2.3"
   },
   "devDependencies": {
-    "@trufflesuite/uws-js-unofficial": "20.4.0-unofficial.5",
+    "@trufflesuite/uws-js-unofficial": "20.8.0-unofficial.0",
     "@types/encoding-down": "5.0.0",
     "@types/fs-extra": "9.0.2",
     "@types/keccak": "3.0.1",

--- a/src/chains/filecoin/filecoin/package-lock.json
+++ b/src/chains/filecoin/filecoin/package-lock.json
@@ -845,9 +845,9 @@
 			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.4.0-unofficial.5",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.4.0-unofficial.5.tgz",
-			"integrity": "sha512-QR9dSa6TvNFYUWKhvtul1W4CIv8X7QIgF+xwJSqqguBemWsJbVq2INkzvevMUAc2B28k7Orgah1sQ6NhIoJx8A==",
+			"version": "20.8.0-unofficial.0",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.8.0-unofficial.0.tgz",
+			"integrity": "sha512-38ViS2Wz5OuAC4DXA5oqFtg02X4SYxOssEsALt5cRIkE5vKqvKri0kRUZ+fB3l12g4GbcIK3h/e20PUcnoBYMw==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",

--- a/src/chains/filecoin/filecoin/package.json
+++ b/src/chains/filecoin/filecoin/package.json
@@ -59,7 +59,7 @@
     "@filecoin-shipyard/lotus-client-schema": "2.0.0",
     "@ganache/filecoin-options": "0.2.0",
     "@ganache/utils": "0.2.0",
-    "@trufflesuite/uws-js-unofficial": "20.4.0-unofficial.5",
+    "@trufflesuite/uws-js-unofficial": "20.8.0-unofficial.0",
     "@types/bn.js": "5.1.0",
     "@types/deep-equal": "1.0.1",
     "@types/levelup": "4.3.0",

--- a/src/chains/tezos/tezos/package-lock.json
+++ b/src/chains/tezos/tezos/package-lock.json
@@ -35,9 +35,9 @@
 			"dev": true
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.4.0-unofficial.5",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.4.0-unofficial.5.tgz",
-			"integrity": "sha512-QR9dSa6TvNFYUWKhvtul1W4CIv8X7QIgF+xwJSqqguBemWsJbVq2INkzvevMUAc2B28k7Orgah1sQ6NhIoJx8A==",
+			"version": "20.8.0-unofficial.0",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.8.0-unofficial.0.tgz",
+			"integrity": "sha512-38ViS2Wz5OuAC4DXA5oqFtg02X4SYxOssEsALt5cRIkE5vKqvKri0kRUZ+fB3l12g4GbcIK3h/e20PUcnoBYMw==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",

--- a/src/chains/tezos/tezos/package.json
+++ b/src/chains/tezos/tezos/package.json
@@ -47,7 +47,7 @@
     "emittery": "0.10.0"
   },
   "devDependencies": {
-    "@trufflesuite/uws-js-unofficial": "20.4.0-unofficial.5",
+    "@trufflesuite/uws-js-unofficial": "20.8.0-unofficial.0",
     "@types/mocha": "9.0.0",
     "cheerio": "1.0.0-rc.3",
     "cross-env": "7.0.3",

--- a/src/packages/core/package-lock.json
+++ b/src/packages/core/package-lock.json
@@ -436,9 +436,9 @@
 			"dev": true
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.4.0-unofficial.5",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.4.0-unofficial.5.tgz",
-			"integrity": "sha512-QR9dSa6TvNFYUWKhvtul1W4CIv8X7QIgF+xwJSqqguBemWsJbVq2INkzvevMUAc2B28k7Orgah1sQ6NhIoJx8A==",
+			"version": "20.8.0-unofficial.0",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.8.0-unofficial.0.tgz",
+			"integrity": "sha512-38ViS2Wz5OuAC4DXA5oqFtg02X4SYxOssEsALt5cRIkE5vKqvKri0kRUZ+fB3l12g4GbcIK3h/e20PUcnoBYMw==",
 			"requires": {
 				"bufferutil": "4.0.5",
 				"utf-8-validate": "5.0.7",

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -53,7 +53,7 @@
     "@ganache/options": "0.2.0",
     "@ganache/tezos": "0.2.0",
     "@ganache/utils": "0.2.0",
-    "@trufflesuite/uws-js-unofficial": "20.4.0-unofficial.5",
+    "@trufflesuite/uws-js-unofficial": "20.8.0-unofficial.0",
     "aggregate-error": "3.1.0",
     "emittery": "0.10.0",
     "promise.allsettled": "1.0.4"

--- a/src/packages/core/tests/server.test.ts
+++ b/src/packages/core/tests/server.test.ts
@@ -142,7 +142,7 @@ describe("server", () => {
       return validInterfaces;
     }
 
-    it("listens on all interfaces by default", async () => {
+    it.only("listens on all interfaces by default", async () => {
       await setup();
       try {
         const interfaces = getNetworkInterfaces();
@@ -154,6 +154,7 @@ describe("server", () => {
 
           for (const info of interfaceInfo) {
             const host = getHost(info, interfaceName);
+            console.log(host);
             const response = await post(host, port, jsonRpcJson);
             assert.strictEqual(response.status, 200, `Wrong status code when connecting to http://${host}:${port}`);
             assert.strictEqual(response.body.result, "1234", `Wrong result when connecting to http://${host}:${port}`);

--- a/src/packages/core/tests/server.test.ts
+++ b/src/packages/core/tests/server.test.ts
@@ -154,7 +154,7 @@ describe("server", () => {
       return validInterfaces;
     }
 
-    it.only("listens on all interfaces by default", async () => {
+    it("listens on all interfaces by default", async () => {
       await setup();
       try {
         const interfaces = getNetworkInterfaces();

--- a/src/packages/core/tests/server.test.ts
+++ b/src/packages/core/tests/server.test.ts
@@ -166,7 +166,6 @@ describe("server", () => {
 
           for (const info of interfaceInfo) {
             const host = getHost(info, interfaceName);
-            console.log(host);
             const response = await post(host, port, jsonRpcJson);
             assert.strictEqual(response.status, 200, `Wrong status code when connecting to http://${host}:${port}`);
             assert.strictEqual(response.body.result, "1234", `Wrong result when connecting to http://${host}:${port}`);

--- a/src/packages/ganache/npm-shrinkwrap.json
+++ b/src/packages/ganache/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
 	"name": "ganache",
-	"version": "7.0.3",
+	"version": "7.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/packages/utils/package-lock.json
+++ b/src/packages/utils/package-lock.json
@@ -72,9 +72,9 @@
 			}
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.4.0-unofficial.5",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.4.0-unofficial.5.tgz",
-			"integrity": "sha512-QR9dSa6TvNFYUWKhvtul1W4CIv8X7QIgF+xwJSqqguBemWsJbVq2INkzvevMUAc2B28k7Orgah1sQ6NhIoJx8A==",
+			"version": "20.8.0-unofficial.0",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.8.0-unofficial.0.tgz",
+			"integrity": "sha512-38ViS2Wz5OuAC4DXA5oqFtg02X4SYxOssEsALt5cRIkE5vKqvKri0kRUZ+fB3l12g4GbcIK3h/e20PUcnoBYMw==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",

--- a/src/packages/utils/package.json
+++ b/src/packages/utils/package.json
@@ -52,7 +52,7 @@
     "seedrandom": "3.0.5"
   },
   "devDependencies": {
-    "@trufflesuite/uws-js-unofficial": "20.4.0-unofficial.5",
+    "@trufflesuite/uws-js-unofficial": "20.8.0-unofficial.0",
     "@types/mocha": "9.0.0",
     "@types/seedrandom": "3.0.1",
     "cross-env": "7.0.3",


### PR DESCRIPTION
Ganache now supports and is tested on Node versions 12.0.0, 12.x, 14.x, 16.x, and 18.x on operating systems Windows 2019, Ubuntu 18.04, Ubuntu 20.04, and macOS 11, with the exception of Node v18 on Ubuntu 18.04, as Ubuntu 18.04 is not supported by Node v18.

Happy upgrading!