### PR TITLE
docs: add documentation of `eth_call` overrides

### DIFF
--- a/src/chains/ethereum/ethereum/RPC-METHODS.md
+++ b/src/chains/ethereum/ethereum/RPC-METHODS.md
@@ -155,6 +155,7 @@ Executes a new message call immediately without creating a transaction on the bl
 
 - `transaction: any` : The transaction call object as seen in source.
 - `blockNumber: QUANTITY | TAG` : Integer block number, or the string "latest", "earliest" or "pending".
+- `overrides: CallOverrides`: State overrides to apply during the simulation.
 
 ##### Returns
 

--- a/src/chains/ethereum/ethereum/RPC-METHODS.md
+++ b/src/chains/ethereum/ethereum/RPC-METHODS.md
@@ -156,17 +156,15 @@ Executes a new message call immediately without creating a transaction on the bl
 - `transaction: any` : The transaction call object as seen in source.
 - `blockNumber: QUANTITY | TAG` : Integer block number, or the string "latest", "earliest" or "pending".
 - `overrides: CallOverrides`: State overrides to apply during the simulation.
-
-`CallOverrides` - An address-to-state mapping, where each entry specifies some
+  - `CallOverrides` - An address-to-state mapping, where each entry specifies some
 state to be ephemerally overridden prior to executing the call. Each address maps to an object containing:
+    - `balance: QUANTITY` (optional) - The balance to set for the account before executing the call.
+    - `nonce: QUANTITY` (optional) - The nonce to set for the account before executing the call.
+    - `code: DATA` (optional) - The EVM bytecode to set for the account before executing the call.
+    - `state: OBJECT` (optional\*) - Key-value mapping to override _all_ slots in the account storage before executing the call.
+    - `stateDiff: OBJECT` (optional\*) - Key-value mapping to override _individual_ slots in the account storage before executing the call.
 
-- `balance`: `QUANTITY` (optional) - The balance to set for the account before executing the call.
-- `nonce`: `QUANTITY` (optional) - The nonce to set for the account before executing the call.
-- `code`: `DATA` (optional) - The EVM bytecode to set for the account before executing the call.
-- `state`: `OBJECT` (optional\*) - Key-value mapping to override _all_ slots in the account storage before executing the call.
-- `stateDiff`: `OBJECT` (optional\*) - Key-value mapping to override _individual_ slots in the account storage before executing the call.
-
-  _Note - `state` and `stateDiff` fields are mutually exclusive._
+    _Note - `state` and `stateDiff` fields are mutually exclusive._
 
 ##### Returns
 

--- a/src/chains/ethereum/ethereum/RPC-METHODS.md
+++ b/src/chains/ethereum/ethereum/RPC-METHODS.md
@@ -164,7 +164,7 @@ state to be ephemerally overridden prior to executing the call. Each address map
     - `state: OBJECT` (optional\*) - Key-value mapping to override _all_ slots in the account storage before executing the call.
     - `stateDiff: OBJECT` (optional\*) - Key-value mapping to override _individual_ slots in the account storage before executing the call.
 
-    _Note - `state` and `stateDiff` fields are mutually exclusive._
+    _\*Note - `state` and `stateDiff` fields are mutually exclusive._
 
 ##### Returns
 

--- a/src/chains/ethereum/ethereum/RPC-METHODS.md
+++ b/src/chains/ethereum/ethereum/RPC-METHODS.md
@@ -157,6 +157,17 @@ Executes a new message call immediately without creating a transaction on the bl
 - `blockNumber: QUANTITY | TAG` : Integer block number, or the string "latest", "earliest" or "pending".
 - `overrides: CallOverrides`: State overrides to apply during the simulation.
 
+`CallOverrides` - An address-to-state mapping, where each entry specifies some
+state to be ephemerally overridden prior to executing the call. Each address maps to an object containing:
+
+- `balance`: `QUANTITY` (optional) - The balance to set for the account before executing the call.
+- `nonce`: `QUANTITY` (optional) - The nonce to set for the account before executing the call.
+- `code`: `DATA` (optional) - The EVM bytecode to set for the account before executing the call.
+- `state`: `OBJECT` (optional\*) - Key-value mapping to override _all_ slots in the account storage before executing the call.
+- `stateDiff`: `OBJECT` (optional\*) - Key-value mapping to override _individual_ slots in the account storage before executing the call.
+
+  _Note - `state` and `stateDiff` fields are mutually exclusive._
+
 ##### Returns
 
 `Promise<DATA>` : The return value of executed contract.


### PR DESCRIPTION
This PR adds some documentation of the `eth_call` overrides object to or RPC method docs,  fixing #3002.