### PR TITLE
fix: only mine one block in interval mining

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -344,7 +344,7 @@ export default class EthereumApi implements Api {
         assertExceptionalTransactions(transactions);
       }
     }
-
+    await blockchain.awaitBlockSaving();
     return "0x0";
   }
 

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -344,7 +344,6 @@ export default class EthereumApi implements Api {
         assertExceptionalTransactions(transactions);
       }
     }
-    await blockchain.awaitBlockSaving();
     return "0x0";
   }
 

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -344,6 +344,7 @@ export default class EthereumApi implements Api {
         assertExceptionalTransactions(transactions);
       }
     }
+
     return "0x0";
   }
 

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -362,7 +362,9 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
             unref((this.#timer = setTimeout(next, minerOpts.blockTime * 1e3)));
           // when interval mining, only one block should be mined. the block
           // can, however, be filled
-          const next = () => mineAll(Capacity.FillBlock, true).then(wait);
+          const next = () => {
+            mineAll(Capacity.FillBlock, true).then(wait);
+          };
           wait();
         }
         //#endregion

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -359,7 +359,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
           // interval mining
           const wait = () =>
             // unref, so we don't hold the chain open if nothing can interact with it
-            unref((this.#timer = setTimeout(next, minerOpts.blockTime * 1e3)));
+            (this.#timer = setTimeout(next, minerOpts.blockTime * 1e3));
           // when interval mining, only one block should be mined. the block
           // can, however, be filled
           const next = () => {

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -358,7 +358,6 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
         } else {
           // interval mining
           const wait = () =>
-            // unref, so we don't hold the chain open if nothing can interact with it
             (this.#timer = setTimeout(next, minerOpts.blockTime * 1e3));
           // when interval mining, only one block should be mined. the block
           // can, however, be filled

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -353,12 +353,15 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
         if (instamine) {
           // insta mining
           // whenever the transaction pool is drained mine the txs into blocks
+          // only one transaction should be added per block
           txPool.on("drain", mineAll.bind(null, Capacity.Single));
         } else {
           // interval mining
           const wait = () =>
             // unref, so we don't hold the chain open if nothing can interact with it
             unref((this.#timer = setTimeout(next, minerOpts.blockTime * 1e3)));
+          // when interval mining, only one block should be mined. the block
+          // can, however, be filled
           const next = () => mineAll(Capacity.FillBlock, true).then(wait);
           wait();
         }

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -586,11 +586,6 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
     };
   };
 
-  awaitBlockSaving = async () => {
-    await this.#blockBeingSavedPromise;
-    return;
-  };
-
   #isPaused = () => {
     return (this.#state & Status.paused) !== 0;
   };

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -346,8 +346,10 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
 
         //#region automatic mining
         const nullResolved = Promise.resolve(null);
-        const mineAll = (maxTransactions: Capacity) =>
-          this.#isPaused() ? nullResolved : this.mine(maxTransactions);
+        const mineAll = (maxTransactions: Capacity, onlyOneBlock = false) =>
+          this.#isPaused()
+            ? nullResolved
+            : this.mine(maxTransactions, null, onlyOneBlock);
         if (instamine) {
           // insta mining
           // whenever the transaction pool is drained mine the txs into blocks
@@ -357,7 +359,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
           const wait = () =>
             // unref, so we don't hold the chain open if nothing can interact with it
             unref((this.#timer = setTimeout(next, minerOpts.blockTime * 1e3)));
-          const next = () => mineAll(Capacity.FillBlock).then(wait);
+          const next = () => mineAll(Capacity.FillBlock, true).then(wait);
           wait();
         }
         //#endregion

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -586,6 +586,11 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
     };
   };
 
+  awaitBlockSaving = async () => {
+    await this.#blockBeingSavedPromise;
+    return;
+  };
+
   #isPaused = () => {
     return (this.#state & Status.paused) !== 0;
   };

--- a/src/chains/ethereum/ethereum/src/miner/miner.ts
+++ b/src/chains/ethereum/ethereum/src/miner/miner.ts
@@ -500,7 +500,14 @@ export default class Miner extends Emittery<{
 
   #reset = () => {
     this.#origins.clear();
-    this.#priced.clear();
+    const priced = this.#priced;
+    const length = priced.length;
+    const pricedArray = priced.array;
+    for (let i = 0; i < length; i++) {
+      const bestFromOrigin = pricedArray[i];
+      bestFromOrigin.locked = false;
+    }
+    priced.clear();
     this.#isBusy = false;
   };
 

--- a/src/chains/ethereum/ethereum/src/miner/miner.ts
+++ b/src/chains/ethereum/ethereum/src/miner/miner.ts
@@ -500,6 +500,15 @@ export default class Miner extends Emittery<{
 
   #reset = () => {
     this.#origins.clear();
+    // HACK: see: https://github.com/trufflesuite/ganache/issues/3093
+    //
+    //When the priced heap is reset, meaning we're clearing out the heap
+    // and origins list to be set again when the miner is called, loop over
+    // the priced heap transactions and "unlock" them (set tx.locked = false)
+    //
+    // The real fix would include fixing the use of locked, as it's
+    // currently overloaded to mean "is in priced heap" and also "is being
+    // mined".
     const priced = this.#priced;
     const length = priced.length;
     const pricedArray = priced.array;

--- a/src/chains/ethereum/ethereum/tests/blockchain.test.ts
+++ b/src/chains/ethereum/ethereum/tests/blockchain.test.ts
@@ -72,7 +72,7 @@ describe("blockchain", async () => {
       // wait for our two transactions to be mined by waiting for the chain to
       // emit the block events. verify that it's the correct transaction, and
       // store the timestamp
-      const assertBlocks = new Promise((resolve, reject) => {
+      const assertBlocks = new Promise<boolean>((resolve, reject) => {
         const off = blockchain.on("block", async (block: Block) => {
           const transactions = block.getTransactions();
           if (transactions.length === 0) return;
@@ -99,7 +99,8 @@ describe("blockchain", async () => {
             }
           } catch (e) {
             off();
-            reject(e);
+            console.error(e);
+            reject(false);
           }
         });
       });

--- a/src/chains/ethereum/ethereum/tests/blockchain.test.ts
+++ b/src/chains/ethereum/ethereum/tests/blockchain.test.ts
@@ -103,8 +103,8 @@ describe("blockchain", async () => {
           }
         });
       });
-      const success = (await assertBlocks) as any;
-      assert.equal(success, true, success);
+      const success = await assertBlocks;
+      assert(success, "expected to mine two blocks with one transaction each");
       // assert that second block's timestamp is at least `blockTime` greater
       // than the first block's. meaning, these blocks weren't mined one after
       // the other

--- a/src/chains/ethereum/ethereum/tests/blockchain.test.ts
+++ b/src/chains/ethereum/ethereum/tests/blockchain.test.ts
@@ -1,0 +1,106 @@
+import assert from "assert";
+import {
+  EIP1559FeeMarketRpcTransaction,
+  TransactionFactory
+} from "@ganache/ethereum-transaction";
+import { EthereumOptionsConfig } from "@ganache/ethereum-options";
+import Wallet from "../src/wallet";
+import Blockchain from "../src/blockchain";
+import { Block } from "@ganache/ethereum-block";
+
+describe("blockchain", async () => {
+  describe("interval mining", () => {
+    it("mines only one block, even when pool is full enough for multiple", async () => {
+      // setup options
+      // block gas limit to only fit one tx
+      // interval mining mode
+      // eager instamine so tx is fully mined when we race them
+      const gasLimit = "0x5208";
+      const blockTime = 1;
+      const optionsJson = {
+        miner: {
+          blockGasLimit: gasLimit,
+          blockTime,
+          instamine: "strict" as const
+        }
+      };
+      const options = EthereumOptionsConfig.normalize(optionsJson);
+
+      // setup wallet/blockchain
+      const wallet = new Wallet(options.wallet);
+      const initialAccounts = wallet.initialAccounts;
+      const blockchain = new Blockchain(options, initialAccounts[0].address);
+      await blockchain.initialize(wallet.initialAccounts);
+      const common = blockchain.common;
+
+      // setup two transactions
+      const [from, to] = wallet.addresses;
+      const secretKey = wallet.unlockedAccounts.get(from);
+      const rpcTx: EIP1559FeeMarketRpcTransaction = {
+        from,
+        to,
+        gasLimit,
+        maxFeePerGas: "0xffffffff",
+        type: "0x2",
+        nonce: "0x0"
+      };
+      const transaction1 = TransactionFactory.fromRpc(rpcTx, common);
+      const transaction2 = TransactionFactory.fromRpc(
+        { ...rpcTx, nonce: "0x1" },
+        common
+      );
+
+      const transaction1Promise = blockchain.queueTransaction(
+        transaction1,
+        secretKey
+      );
+      const transaction2Promise = blockchain.queueTransaction(
+        transaction2,
+        secretKey
+      );
+      const transactionHashes = await Promise.all([
+        transaction1Promise,
+        transaction2Promise
+      ]);
+
+      const timestamps: number[] = [];
+      let i = 0;
+      const startingBlockNumber =
+        blockchain.blocks.latest.header.number.toNumber();
+      const assertBlocks = new Promise(resolve => {
+        const off = blockchain.on("block", async (block: Block) => {
+          const transactions = block.getTransactions();
+          if (transactions.length === 0) return;
+          try {
+            console.log("mined one!");
+            const blockNumber = block.header.number.toString();
+            const expectedBlockNumber = startingBlockNumber + i + 1;
+            assert.equal(blockNumber, `0x${expectedBlockNumber.toString(16)}`);
+            assert.equal(transactions.length, 1);
+
+            const transaction = transactions[0];
+            assert.equal(transaction.nonce.toString(), `0x${i.toString(16)}`);
+            assert.equal(
+              transaction.hash.toString(),
+              transactionHashes[i].toString()
+            );
+
+            timestamps.push(block.header.timestamp.toNumber());
+            i++;
+            console.log("i", i);
+            if (i === 2) {
+              resolve(void 0);
+              off();
+            }
+          } catch (e) {
+            console.log(e);
+          }
+        });
+      });
+      // enough time for two blocks to be mined, plus some padding
+      await new Promise(resolve => setTimeout(resolve, blockTime * 1000 * 2.2));
+      //await assertBlocks;
+      assert(timestamps[1] >= timestamps[0] + blockTime);
+    }).timeout(0);
+  });
+});

--- a/src/chains/ethereum/ethereum/tests/blockchain.test.ts
+++ b/src/chains/ethereum/ethereum/tests/blockchain.test.ts
@@ -67,7 +67,7 @@ describe("blockchain", async () => {
       let i = 0;
       const startingBlockNumber =
         blockchain.blocks.latest.header.number.toNumber();
-      const assertBlocks = new Promise(resolve => {
+      const assertBlocks = new Promise((resolve, reject) => {
         const off = blockchain.on("block", async (block: Block) => {
           const transactions = block.getTransactions();
           if (transactions.length === 0) return;
@@ -91,15 +91,16 @@ describe("blockchain", async () => {
             if (i === 2) {
               resolve(void 0);
               off();
+              resolve(true);
             }
           } catch (e) {
-            console.log(e);
+            off();
+            reject(e);
           }
         });
       });
-      // enough time for two blocks to be mined, plus some padding
-      await new Promise(resolve => setTimeout(resolve, blockTime * 1000 * 2.2));
-      //await assertBlocks;
+      const success = (await assertBlocks) as any;
+      assert.equal(success, true, success);
       assert(timestamps[1] >= timestamps[0] + blockTime);
     }).timeout(0);
   });


### PR DESCRIPTION
In a real Ethereum node, blocks are committed [approximately every 15 seconds](https://ethereum.org/en/developers/docs/blocks/#why-blocks). Ganache allows users to configure how often this mining takes place in this "interval" mining mode with the `--miner.blockTime` flag, and it allows users to "instamine" transactions by setting `--miner.blockTime=0` (the default).

For each block that is made in a real Ethereum node, the transactions that are included on the block is based off of many factors including the number of transactions in the transaction pool, the gas price and gas limit of those transactions, and the block's gas limit. Regardless of the ordering, the number of transactions included on the block is limited by that block gas limit. Then, once a single block is mined, approximately 15 seconds elapses before another block is generated.

In the interval mining mode before this change, Ganache would begin mining after the `blockTime` elapses, but it would mine all transactions in the pool, regardless of how many blocks it would take. This change fixes Ganache's behavior to be more like a real Ethereum node. Now only one block will be mined whenever `blockTime` elapses, even if that means leaving some transactions in the transaction pool until the next block is generated. This change fixes #3030.