### PR TITLE
feat: fire reorg events on snapshot/revert

### DIFF
--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -818,7 +818,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
       })
     );
 
-    await this.#database.batch(async () => {
+    await this.#database.batch(() => {
       const { blocks, transactions, transactionReceipts, blockLogs } = this;
       // point to the new "latest" again
       blocks.updateLatestIndex(newLatestBlockNumber);

--- a/src/chains/ethereum/ethereum/tests/api/evm/snapshot.sol
+++ b/src/chains/ethereum/ethereum/tests/api/evm/snapshot.sol
@@ -2,9 +2,11 @@
 pragma solidity ^0.8.11;
 
 contract snapshot {
+    event Increment(uint256 indexed value);
     uint256 public n = 42;
 
     function inc() public {
         n += 1;
+        emit Increment(n);
     }
 }

--- a/src/chains/ethereum/ethereum/tests/api/evm/snapshot.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/evm/snapshot.test.ts
@@ -483,7 +483,7 @@ describe("api", () => {
         // and mine one more block just to force the any executable transactions
         // to be immediately mined
 
-        const gotTxsProm = new Promise((resolve, reject) => {
+        const gotTxsProm = new Promise(resolve => {
           let count = 0;
           const unsubscribe = provider.on("message", m => {
             if (!reverted && m.data.result.hash === snapshotBlockHash) {

--- a/src/chains/ethereum/transaction/src/transaction-receipt.ts
+++ b/src/chains/ethereum/transaction/src/transaction-receipt.ts
@@ -153,7 +153,7 @@ export class TransactionReceipt {
     const transactionHash = transaction.hash;
     const transactionIndex = transaction.index;
     blockLog.blockNumber = blockNumber;
-    raw[3].forEach(l => blockLog.append(transactionIndex, transactionHash, l));
+    raw[3].forEach(l => blockLog.append(blockLog[0], transactionIndex, transactionHash, l));
     const logs = [...blockLog.toJSON()];
     if (block.header.baseFeePerGas) {
       transaction.updateEffectiveGasPrice(block.header.baseFeePerGas);


### PR DESCRIPTION
This change makes it so that ganache behaves as if the chain has been reorged when `evm_revert` is called. When `evm_revert` rolls back the current head of the chain, the following things happen:

1. Subscribers to `newHeads` events receive a message indicating that the head has been rolled back to the requested snapshot.
2. Subscribers to `logs` events receive a message indicating the removal of any logs that were emitted by transactions that were rolled back by the `evm_revert`.
2. Filters are updated to indicate the removal of any logs that were previously emitted by transactions that were rolled back by the `evm_revert`.

fixes #91 and #411