### PR TITLE
fix: `eth_getTransactionByBlockNumberAndIndex` and `eth_getTransactionByBlockHashAndIndex` to respect non-zero transaction index

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -1242,7 +1242,7 @@ export default class EthereumApi implements Api {
       .catch<Block>(_ => null);
     if (!block) return null;
     const transactions = block.getTransactions();
-    return transactions[parseInt(Quantity.from(index).toString(), 10)].toJSON(
+    return transactions[Quantity.from(index).toNumber()].toJSON(
       blockchain.common
     );
   }
@@ -1289,7 +1289,7 @@ export default class EthereumApi implements Api {
     const block = await blockchain.blocks.get(number).catch<Block>(_ => null);
     if (!block) return null;
     const transactions = block.getTransactions();
-    return transactions[parseInt(Quantity.from(index).toString(), 10)].toJSON(
+    return transactions[Quantity.from(index).toNumber()].toJSON(
       blockchain.common
     );
   }

--- a/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
@@ -429,28 +429,48 @@ describe("api", () => {
     it("eth_getTransactionByBlockNumberAndIndex", async () => {
       await provider.send("eth_subscribe", ["newHeads"]);
       const gasPrice = await provider.send("eth_gasPrice", []);
-      const txHash = await provider.send("eth_sendTransaction", [
-        {
-          from: accounts[0],
-          to: accounts[1],
-          value: "0x1",
-          gasPrice
-        }
-      ]);
+
+      await provider.send("miner_stop");
+      const txArgs = {
+        from: accounts[0],
+        to: accounts[1],
+        value: "0x1",
+        gasPrice
+      };
+
+      const tx1Hash = await provider.send("eth_sendTransaction", [txArgs]);
+      const tx2Hash = await provider.send("eth_sendTransaction", [txArgs]);
+      await provider.send("miner_start");
+
       await provider.once("message");
 
-      const tx = await provider.send(
+      const retrievedTx1 = await provider.send(
         "eth_getTransactionByBlockNumberAndIndex",
         ["0x1", "0x0"]
       );
       assert.strictEqual(
-        tx.hash,
+        retrievedTx1.hash,
         "0xab338178ffd130f1b7724a687ef20afcc75d44020184f82127ab1bc59f17d7e2",
         "Unexpected transaction hash."
       );
       assert.strictEqual(
-        tx.hash,
-        txHash,
+        retrievedTx1.hash,
+        tx1Hash,
+        "eth_getTransactionByBlockNumberAndIndex transaction hash doesn't match tx hash"
+      );
+
+      const retrievedTx2 = await provider.send(
+        "eth_getTransactionByBlockNumberAndIndex",
+        ["0x1", "0x1"]
+      );
+      assert.strictEqual(
+        retrievedTx2.hash,
+        "0x32b957c5669ff38b7baa8bfb9c4f84811f70ae3fb44fb2ad63e70ee959c88471",
+        "Unexpected transaction hash."
+      );
+      assert.strictEqual(
+        retrievedTx2.hash,
+        tx2Hash,
         "eth_getTransactionByBlockNumberAndIndex transaction hash doesn't match tx hash"
       );
     });
@@ -458,30 +478,51 @@ describe("api", () => {
     it("eth_getTransactionByBlockHashAndIndex", async () => {
       await provider.send("eth_subscribe", ["newHeads"]);
       const gasPrice = await provider.send("eth_gasPrice", []);
-      const txHash = await provider.send("eth_sendTransaction", [
-        {
-          from: accounts[0],
-          to: accounts[1],
-          value: "0x1",
-          gasPrice
-        }
-      ]);
-      const _message = await provider.once("message");
-      const block = await provider.send("eth_getBlockByNumber", ["0x1"]);
 
-      const tx = await provider.send("eth_getTransactionByBlockHashAndIndex", [
-        block.hash,
-        "0x0"
-      ]);
+      await provider.send("miner_stop");
+      const txArgs = {
+        from: accounts[0],
+        to: accounts[1],
+        value: "0x1",
+        gasPrice
+      };
+
+      const tx1Hash = await provider.send("eth_sendTransaction", [txArgs]);
+      const tx2Hash = await provider.send("eth_sendTransaction", [txArgs]);
+      await provider.send("miner_start");
+
+      await provider.once("message");
+      
+      const {hash: blockHash} = await provider.send("eth_getBlockByNumber", ["0x1"]);
+      const retrievedTx1 = await provider.send(
+        "eth_getTransactionByBlockHashAndIndex",
+        [blockHash, "0x0"]
+      );
+
       assert.strictEqual(
-        tx.hash,
+        retrievedTx1.hash,
         "0xab338178ffd130f1b7724a687ef20afcc75d44020184f82127ab1bc59f17d7e2",
         "Unexpected transaction hash."
       );
       assert.strictEqual(
-        tx.hash,
-        txHash,
-        "eth_getTransactionByBlockNumberAndIndex transaction hash doesn't match tx hash"
+        retrievedTx1.hash,
+        tx1Hash,
+        "eth_getTransactionByBlockHashAndIndex transaction hash doesn't match tx hash"
+      );
+
+      const retrievedTx2 = await provider.send(
+        "eth_getTransactionByBlockHashAndIndex",
+        [blockHash, "0x1"]
+      );
+      assert.strictEqual(
+        retrievedTx2.hash,
+        "0x32b957c5669ff38b7baa8bfb9c4f84811f70ae3fb44fb2ad63e70ee959c88471",
+        "Unexpected transaction hash."
+      );
+      assert.strictEqual(
+        retrievedTx2.hash,
+        tx2Hash,
+        "eth_getTransactionByBlockHashAndIndex transaction hash doesn't match tx hash"
       );
     });
 


### PR DESCRIPTION
Previously both `eth_getTransactionByBlockNumberAndIndex` and `eth_getTransactionByBlockHashAndIndex` would incorrectly return the first transaction in the block, regardless of the value passed as `index`.

With this fix, any transaction can be retrieved by providing its index within the given block.