### PR TITLE
chore: add relevant keywords to ganache's package.json

### DIFF
--- a/src/packages/ganache/package.json
+++ b/src/packages/ganache/package.json
@@ -39,6 +39,10 @@
   },
   "keywords": [
     "ganache",
+    "ganache-core",
+    "ganache-cli",
+    "@trufflesuite/ganache",
+    "@truffle/ganache",
     "ethereum",
     "evm",
     "blockchain",


### PR DESCRIPTION
Users reported that it was difficult to find the `ganache` package in the npm registry because they were used to searching for `ganache-cli` and `ganache-core`. This change adds those terms to our `package.json`'s `"keywords"` list, which hopefully alleviates the problem.

Fixes #3143