### PR TITLE
chore: create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# global code owner:
+*       @davidmurdoch


### PR DESCRIPTION
This is just sets up an initial `CODEOWNERS` file so we can improve our code review process in the near future.