### PR TITLE
fix: ensure `COINBASE` instruction is correct in `debug_traceTransaction`

### DIFF
--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -1394,7 +1394,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
     const newBlock = new RuntimeBlock(
       Quantity.from((parentBlock.header.number.toBigInt() || 0n) + 1n),
       parentBlock.hash(),
-      parentBlock.header.miner,
+      targetBlock.header.miner,
       parentBlock.header.gasLimit.toBuffer(),
       BUFFER_ZERO,
       // make sure we use the same timestamp as the target block


### PR DESCRIPTION
Previously, the instruction `COINBASE` was returning the address of the prior block's miner, which resulted in an incorrect debug trace. This corrects it to the miner of the traced transaction's block.