### PR TITLE
fix: properly handle 'estimate' for `defaultTransactionGasLimit` option on the CLI

### DIFF
--- a/src/chains/ethereum/options/src/miner-options.ts
+++ b/src/chains/ethereum/options/src/miner-options.ts
@@ -195,6 +195,18 @@ const toBigIntOrString = (str: string) => {
     return BigInt(str);
   }
 };
+/**
+ * Handles defaultTransactionGasLimit special case of 'estimate' for tx value.
+ *
+ * @param str - the string literal 'estimate' or string that that represents a bigint, number, or hexadecimal value.
+ */
+const estimateOrToBigIntOrString = (str: string) => {
+  if (str === "estimate") {
+    return str;
+  } else {
+    return toBigIntOrString(str);
+  }
+};
 
 /**
  * Attempts to convert strings that don't start with `0x` to a number
@@ -259,7 +271,7 @@ export const MinerOptions: Definitions<MinerConfig> = {
       'Sets the default transaction gas limit in WEI. Set to "estimate" to use an estimate (slows down transaction execution by 40%+).',
     default: () => Quantity.from(90_000),
     cliType: "string",
-    cliCoerce: toBigIntOrString
+    cliCoerce: estimateOrToBigIntOrString
   },
   difficulty: {
     normalize: Quantity.from,


### PR DESCRIPTION
Previously, `estimate` was causing an error when the miner options would attempt to cast the string to BigInt.

This change adds the `estimateOrToBigIntOrString` function to Ethereum's miner options to intercept and handle the `estimate` option on the cli. 

Fixes https://github.com/trufflesuite/ganache/issues/2398