### PR TITLE
fix: remove redundant await in `evm_mine`

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -303,31 +303,17 @@ export default class EthereumApi implements Api {
       if (blocks == null) {
         blocks = 1;
       }
-      const strictMiner = options.miner.instamine === "strict";
       // TODO(perf): add an option to mine a bunch of blocks in a batch so
       // we can save them all to the database in one go.
       // Developers like to move the blockchain forward by thousands of blocks
       // at a time and doing this would make it way faster
       for (let i = 0; i < blocks; i++) {
-        const { transactions, blockNumber } = await blockchain.mine(
+        const { transactions } = await blockchain.mine(
           Capacity.FillBlock,
           timestamp,
           true
         );
 
-        if (strictMiner) {
-          // in strict mode we have to wait until the blocks are fully saved
-          // before mining the next ones, in eager mode they've already been
-          // saved
-          await new Promise(resolve => {
-            const off = blockchain.on("block", ({ header: { number } }) => {
-              if (number.toBuffer().equals(blockNumber)) {
-                off();
-                resolve(void 0);
-              }
-            });
-          });
-        }
         if (vmErrorsOnRPCResponse) {
           assertExceptionalTransactions(transactions);
         }

--- a/src/chains/ethereum/ethereum/tests/api/evm/evm.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/evm/evm.test.ts
@@ -79,7 +79,7 @@ describe("api", () => {
       });
     });
 
-    describe.only("evm_mine", () => {
+    describe("evm_mine", () => {
       const providerOptions: EthereumProviderOptions[] = [
         { miner: { instamine: "eager" } },
         { miner: { instamine: "strict" } }
@@ -100,13 +100,6 @@ describe("api", () => {
             );
             assert.strictEqual(currentBlock, initialBlock + 5);
           });
-
-        const provider = await getProvider();
-        const initialBlock = parseInt(await provider.send("eth_blockNumber"));
-        await provider.request({ method: "evm_mine", params: [{ blocks: 5 }] });
-        const currentBlock = parseInt(await provider.send("eth_blockNumber"));
-        assert.strictEqual(currentBlock, initialBlock + 5);
-      });
 
           it("should mine a block on demand", async () => {
             const provider = await getProvider(option);


### PR DESCRIPTION
In v7.3.0 we released a fix to the `evm_mine` RPC method that ended up breaking `evm_mine` in strict instamine mode. The previous fix ensured that blocks were saved _before_ `evm_mine` would return. However, in strict instamine mode, we had an explicit call to wait for the blocks to be saved. After the last release, this attempt to wait for blocks to be saved became redundant and cause `evm_mine` to hang indefinitely. This is now fixed, and we've added some tests to verify that `evm_mine` continues working in strict instamine mode.

Fixes #3243 