### PR TITLE
fix: reduce bundle size and check size in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,6 +59,7 @@ jobs:
           cd ./src/packages/ganache &&
           npm pack &&
           size="$(zcat ganache-*.tgz | wc -c)" &&
-          test $size -gt 100000000 && exit $size || exit 0
+          echo "Bundle size: $size" &&
+          test $size -lt 100000000
         env:
           INFURA_KEY: ${{ secrets.INFURA_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,3 +44,21 @@ jobs:
         env:
           FORCE_COLOR: 1
           INFURA_KEY: ${{ secrets.TEST_INFURA_KEY }}
+
+      - name: check bundle size
+        # this should match the os and version used in the release.yml
+        if: startsWith(matrix.os, 'ubuntu-20.04') && startsWith(matrix.node, '14.')
+        # 1. build ganache
+        # 2. pack it into a tarball
+        # 3. measure the _unpacked_ tarball's size
+        # 4. test to make sure the tarball is less than ~100MB
+        # 5. exit with non-zero exit code (the size of the unpacked tarball) if
+        #    the test fails.
+        run: |
+          npm run build &&
+          cd ./src/packages/ganache &&
+          npm pack &&
+          size="$(zcat ganache-*.tgz | wc -c)" &&
+          test $size -gt 100000000 && exit $size || exit 0
+        env:
+          INFURA_KEY: ${{ secrets.INFURA_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,8 +52,7 @@ jobs:
         # 2. pack it into a tarball
         # 3. measure the _unpacked_ tarball's size
         # 4. test to make sure the tarball is less than ~100MB
-        # 5. exit with non-zero exit code (the size of the unpacked tarball) if
-        #    the test fails.
+        # 5. exit with non-zero exit code if the test fails.
         run: |
           npm run build &&
           cd ./src/packages/ganache &&

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,7 +51,8 @@ jobs:
         # 1. build ganache
         # 2. pack it into a tarball
         # 3. measure the _unpacked_ tarball's size
-        # 4. test to make sure the tarball is less than ~100MB
+        # 4. test to make sure the tarball is less than 99MB because jsDelivr
+        #    CDN doesn't allow bundles greater than 100MB.
         # 5. exit with non-zero exit code if the test fails.
         run: |
           npm run build &&
@@ -59,6 +60,6 @@ jobs:
           npm pack &&
           size="$(zcat ganache-*.tgz | wc -c)" &&
           echo "Bundle size: $size" &&
-          test "$size" -lt 100000000
+          test "$size" -lt 99000000
         env:
           INFURA_KEY: ${{ secrets.INFURA_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,7 +45,7 @@ jobs:
           FORCE_COLOR: 1
           INFURA_KEY: ${{ secrets.TEST_INFURA_KEY }}
 
-      - name: check bundle size
+      - name: Check bundle size
         # this should match the os and version used in the release.yml
         if: startsWith(matrix.os, 'ubuntu-20.04') && startsWith(matrix.node, '14.')
         # 1. build ganache

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,6 +59,6 @@ jobs:
           npm pack &&
           size="$(zcat ganache-*.tgz | wc -c)" &&
           echo "Bundle size: $size" &&
-          test $size -lt 100000000
+          test "$size" -lt 100000000
         env:
           INFURA_KEY: ${{ secrets.INFURA_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,6 +60,7 @@ jobs:
           npm pack &&
           size="$(zcat ganache-*.tgz | wc -c)" &&
           echo "Bundle size: $size" &&
+          echo "Bundle size is $([[ "$size" -lt 99000000 ]] && echo "ok" || echo "not ok")" &&
           test "$size" -lt 99000000
         env:
           INFURA_KEY: ${{ secrets.INFURA_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   release:
+    # this should match the os version used by the "check bundle size" step in
+    # pr.yml
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -16,6 +18,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           # use node 14 until we can evaluate using npm 7+ and lock file version 2
+          # this should match the node version used by the "check bundle size"
+          # step in pr.yml
           node-version: 14
 
       - name: Import Robot GPG key

--- a/src/chains/ethereum/ethereum/package-lock.json
+++ b/src/chains/ethereum/ethereum/package-lock.json
@@ -754,9 +754,9 @@
 			"dev": true
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.10.0-unofficial.0",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.0.tgz",
-			"integrity": "sha512-c1Lt38TtthUnOYKLncJAEyxShawsa1ErLy6T2aVF6zI5SgAaXWeDqzNXsjFI2cRH8rOL3/msGIDeTG+MSHU80A==",
+			"version": "20.10.0-unofficial.1",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.1.tgz",
+			"integrity": "sha512-35K4XHmqWHLD9k0UsveCJG3NJ0zqdYG3cfRE8Z0984aNwNN+uf5nSNLcrUSs5szJExbknmSwJyHPOLtD+AiEeg==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",

--- a/src/chains/ethereum/ethereum/package.json
+++ b/src/chains/ethereum/ethereum/package.json
@@ -87,7 +87,7 @@
     "ws": "8.2.3"
   },
   "devDependencies": {
-    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.0",
+    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.1",
     "@types/abstract-leveldown": "7.2.0",
     "@types/encoding-down": "5.0.0",
     "@types/fs-extra": "9.0.2",

--- a/src/chains/filecoin/filecoin/package-lock.json
+++ b/src/chains/filecoin/filecoin/package-lock.json
@@ -845,9 +845,9 @@
 			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.10.0-unofficial.0",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.0.tgz",
-			"integrity": "sha512-c1Lt38TtthUnOYKLncJAEyxShawsa1ErLy6T2aVF6zI5SgAaXWeDqzNXsjFI2cRH8rOL3/msGIDeTG+MSHU80A==",
+			"version": "20.10.0-unofficial.1",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.1.tgz",
+			"integrity": "sha512-35K4XHmqWHLD9k0UsveCJG3NJ0zqdYG3cfRE8Z0984aNwNN+uf5nSNLcrUSs5szJExbknmSwJyHPOLtD+AiEeg==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",

--- a/src/chains/filecoin/filecoin/package.json
+++ b/src/chains/filecoin/filecoin/package.json
@@ -59,7 +59,7 @@
     "@filecoin-shipyard/lotus-client-schema": "2.0.0",
     "@ganache/filecoin-options": "0.4.1",
     "@ganache/utils": "0.4.1",
-    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.0",
+    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.1",
     "@types/abstract-leveldown": "7.2.0",
     "@types/bn.js": "5.1.0",
     "@types/deep-equal": "1.0.1",

--- a/src/chains/tezos/tezos/package-lock.json
+++ b/src/chains/tezos/tezos/package-lock.json
@@ -35,9 +35,9 @@
 			"dev": true
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.10.0-unofficial.0",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.0.tgz",
-			"integrity": "sha512-c1Lt38TtthUnOYKLncJAEyxShawsa1ErLy6T2aVF6zI5SgAaXWeDqzNXsjFI2cRH8rOL3/msGIDeTG+MSHU80A==",
+			"version": "20.10.0-unofficial.1",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.1.tgz",
+			"integrity": "sha512-35K4XHmqWHLD9k0UsveCJG3NJ0zqdYG3cfRE8Z0984aNwNN+uf5nSNLcrUSs5szJExbknmSwJyHPOLtD+AiEeg==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",

--- a/src/chains/tezos/tezos/package.json
+++ b/src/chains/tezos/tezos/package.json
@@ -47,7 +47,7 @@
     "emittery": "0.10.0"
   },
   "devDependencies": {
-    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.0",
+    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.1",
     "@types/mocha": "9.0.0",
     "cheerio": "1.0.0-rc.3",
     "cross-env": "7.0.3",

--- a/src/packages/core/package-lock.json
+++ b/src/packages/core/package-lock.json
@@ -436,9 +436,9 @@
 			"dev": true
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.10.0-unofficial.0",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.0.tgz",
-			"integrity": "sha512-c1Lt38TtthUnOYKLncJAEyxShawsa1ErLy6T2aVF6zI5SgAaXWeDqzNXsjFI2cRH8rOL3/msGIDeTG+MSHU80A==",
+			"version": "20.10.0-unofficial.1",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.1.tgz",
+			"integrity": "sha512-35K4XHmqWHLD9k0UsveCJG3NJ0zqdYG3cfRE8Z0984aNwNN+uf5nSNLcrUSs5szJExbknmSwJyHPOLtD+AiEeg==",
 			"requires": {
 				"bufferutil": "4.0.5",
 				"utf-8-validate": "5.0.7",

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -53,7 +53,7 @@
     "@ganache/options": "0.4.1",
     "@ganache/tezos": "0.4.1",
     "@ganache/utils": "0.4.1",
-    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.0",
+    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.1",
     "aggregate-error": "3.1.0",
     "emittery": "0.10.0",
     "promise.allsettled": "1.0.4"

--- a/src/packages/utils/package-lock.json
+++ b/src/packages/utils/package-lock.json
@@ -72,9 +72,9 @@
 			}
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.10.0-unofficial.0",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.0.tgz",
-			"integrity": "sha512-c1Lt38TtthUnOYKLncJAEyxShawsa1ErLy6T2aVF6zI5SgAaXWeDqzNXsjFI2cRH8rOL3/msGIDeTG+MSHU80A==",
+			"version": "20.10.0-unofficial.1",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.1.tgz",
+			"integrity": "sha512-35K4XHmqWHLD9k0UsveCJG3NJ0zqdYG3cfRE8Z0984aNwNN+uf5nSNLcrUSs5szJExbknmSwJyHPOLtD+AiEeg==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",

--- a/src/packages/utils/package.json
+++ b/src/packages/utils/package.json
@@ -52,7 +52,7 @@
     "seedrandom": "3.0.5"
   },
   "devDependencies": {
-    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.0",
+    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.1",
     "@types/mocha": "9.0.0",
     "@types/seedrandom": "3.0.1",
     "cross-env": "7.0.3",


### PR DESCRIPTION
[jsDelivr](https://www.jsdelivr.com/) has an unpacked bundle size limit of 100MB, which we recently exceeded, breaking our CDN recommendation in our README.md.

This change reduces the bundle size to under 100MB and also adds a check to our pr.yml CI Action that will fail if the new bundle size is greater than 100 MB.