### PR TITLE
docs: update `--verbose` cli help text

### DIFF
--- a/src/chains/ethereum/options/src/logging-options.ts
+++ b/src/chains/ethereum/options/src/logging-options.ts
@@ -49,7 +49,7 @@ export type LoggingConfig = {
     };
 
     /**
-     * Set to `true` to log all RPC requests and responses.
+     * Set to `true` to log detailed RPC requests.
      *
      * @defaultValue false
      */
@@ -105,7 +105,7 @@ export const LoggingOptions: Definitions<LoggingConfig> = {
   },
   verbose: {
     normalize,
-    cliDescription: "Set to `true` to log all RPC requests and responses.",
+    cliDescription: "Set to `true` to log detailed RPC requests.",
     default: () => false,
     legacyName: "verbose",
     cliAliases: ["v", "verbose"],

--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -276,7 +276,7 @@ Logging:
   -q, --logging.quiet                   Set to true to disable logging.
                                         deprecated aliases: --quiet                 [boolean] [default: false]
 
-  -v, --logging.verbose                 Set to true to log all RPC requests and responses.
+  -v, --logging.verbose                 Set to true to log detailed RPC requests.
                                         deprecated aliases: --verbose               [boolean] [default: false]
 
 


### PR DESCRIPTION
The documentation for the `--verbose` CLI flag was inaccurate. Now it isn't.