### PR TITLE
chore: enforce `concurrency: production` in Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+# allow only one "Release" workflow to run at a time
+concurrency: production
+
 on:
   push:
     branches: [alpha, beta, rc, master]


### PR DESCRIPTION
This ensures we don't trigger multiple Releases at once. See https://docs.github.com/en/actions/deployment/about-deployments/deploying-with-github-actions#using-concurrency for details on how this works.