### PR TITLE
ci: avoid timeouts in mac-os github actions

### DIFF
--- a/src/chains/ethereum/console.log/tests/index.test.ts
+++ b/src/chains/ethereum/console.log/tests/index.test.ts
@@ -426,7 +426,7 @@ contract ${CONTRACT_NAME} {
         const contractAddress = await deploy(code);
         const method = get4ByteForSignature(`testLog(string,uint256)`);
         await runTxTest(params, method, contractAddress);
-      });
+      }).timeout(10000); // github action's mac runner is slow
 
       describe("debug_storageRangeAt", () => {
         beforeEach("stop the miner", async () => {


### PR DESCRIPTION
A recently introduced test borders on the edge of "just fast enough" and "too slow" and was causing intermittent test timeouts in the our GitHub Actions macOS runner. This changes increases the timeout of this test to give it plenty of overhead.