### PR TITLE
test: fix intermittent test failure caused by incorrect use of `Quantity` in test

### DIFF
--- a/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/call.test.ts
@@ -894,10 +894,8 @@ describe("api", () => {
             data: Data.from("0xabcdef1234"),
             block: block
           };
-          ethereumJsFromAddress = new EthereumJsAddress(
-            Quantity.toBuffer(from)
-          );
-          ethereumJsToAddress = new EthereumJsAddress(Quantity.toBuffer(to));
+          ethereumJsFromAddress = new EthereumJsAddress(Address.toBuffer(from));
+          ethereumJsToAddress = new EthereumJsAddress(Address.toBuffer(to));
           // set up a real transaction
           transaction = {
             from,


### PR DESCRIPTION
A [recent change](https://github.com/trufflesuite/ganache/pull/2983) improved the accuracy of internal types and caused a test to become flaky. Whenever the `from` or `to` values in the test contained leading `00`s (like `0x00C7656EC7ab88b098defB751B7401B5f6d8976F`) the test would fail.

Before the change in #2983 `Quantity.from("0x0011223344").toBuffer()` would return `Buffer< 00 11 22 33 44 >`; after #2983 leading `00` bytes are stripped off, returning `Buffer< 11 22 33 44 >`. This change would cause the test to fail because the Ethereum JS `Address` class validates the length of the input buffer, and throws if it is not exactly 20 bytes.

We now use an `Address` class to handle the addresses in this test.