### PR TITLE
chore: update internal `hasOwn` JSDoc so it is correct

### DIFF
--- a/src/packages/utils/src/utils/has-own.ts
+++ b/src/packages/utils/src/utils/has-own.ts
@@ -12,9 +12,9 @@ const _hasOwn: hasOwn = {}.hasOwnProperty.call.bind({}.hasOwnProperty) as any;
  * Safe for use on user-supplied data.
  *
  * @param obj - The object that will be checked.
- * @param v - A property name.
+ * @param prop - A property name.
  * @returns `true` if the object has a property with the specified name,
- * otherwise false.
+ * otherwise `false`.
  */
 export const hasOwn = <X extends unknown, Y extends string | number | symbol>(
   obj: X,


### PR DESCRIPTION
The JSDoc comment for our internal `hasOwn` helper was out of date with the implementation. Now it's not.