### PR TITLE
fix: add `" "` after the HTTP/1.1 Response Status-Code

### DIFF
--- a/src/packages/core/src/servers/utils/http-response-codes.ts
+++ b/src/packages/core/src/servers/utils/http-response-codes.ts
@@ -1,3 +1,19 @@
+/**
+ * HTTP/1.1 Response Status-Codes, including the _required_ space character.
+ *
+ * e.g., `"200 "` or `"404 "`
+ *
+ * RFC Grammar:
+ *
+ * ```ebnf
+ * Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF
+ * ```
+ *
+ * The Status-Codes defined here fullfill the `Status-Code SP` part of the above
+ * grammar.
+ *
+ * See https://datatracker.ietf.org/doc/html/rfc2616#section-6.1 for details.
+ */
 enum HttpResponseCodes {
   OK = "200 ",
   NO_CONTENT = "204 ",

--- a/src/packages/core/src/servers/utils/http-response-codes.ts
+++ b/src/packages/core/src/servers/utils/http-response-codes.ts
@@ -1,9 +1,9 @@
 enum HttpResponseCodes {
-  OK = "200",
-  NO_CONTENT = "204",
-  BAD_REQUEST = "400",
-  NOT_FOUND = "404",
-  METHOD_NOT_ALLOWED = "405",
-  IM_A_TEAPOT = "418"
+  OK = "200 ",
+  NO_CONTENT = "204 ",
+  BAD_REQUEST = "400 ",
+  NOT_FOUND = "404 ",
+  METHOD_NOT_ALLOWED = "405 ",
+  IM_A_TEAPOT = "418 "
 }
 export default HttpResponseCodes;


### PR DESCRIPTION
This change brings Ganache into strict compliance with the [HTTP/1.1 Status-Line specification](https://datatracker.ietf.org/doc/html/rfc2616#section-6.1). Nearly all established HTTP/1.1 response parsers handle HTTP/1.1 Status-Lines that omit the Status-Code trailing space character, but it doesn't hurt to follow the specification strictly.

This change fixes #3400