### PR TITLE
ci: drop ubuntu-18.04, add ubuntu-22.04

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,11 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [14.0.0, 14.x, 16.x, 18.x]
-        os: [windows-2019, ubuntu-18.04, ubuntu-20.04, macos-12]
-        exclude:
-          # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-          - os: ubuntu-18.04
-            node: 18.x
+        os: [windows-2019, ubuntu-20.04, ubuntu-22.04, macos-12]
 
     runs-on: ${{ matrix.os }}
 
@@ -47,7 +43,7 @@ jobs:
 
       - name: Check bundle size
         # this should match the os and version used in the release.yml
-        if: startsWith(matrix.os, 'ubuntu-20.04') && startsWith(matrix.node, '14.')
+        if: startsWith(matrix.os, 'ubuntu-22.04') && startsWith(matrix.node, '14.')
         # 1. build ganache
         # 2. pack it into a tarball
         # 3. measure the _unpacked_ tarball's size
@@ -69,7 +65,7 @@ jobs:
           INFURA_KEY: "badc0de0deadc0debadc0de0deadc0de"
       - name: Upload artifact
         # this should match the os and version used in the release.yml
-        if: startsWith(matrix.os, 'ubuntu-20.04') && startsWith(matrix.node, '14.')
+        if: startsWith(matrix.os, 'ubuntu-22.04') && startsWith(matrix.node, '14.')
         uses: actions/upload-artifact@v3
         with:
           name: Candidate

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [14.0.0, 14.x, 16.x, 18.x]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
 
     runs-on: ${{ matrix.os }}
 
@@ -35,11 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [14.0.0, 14.x, 16.x, 18.x]
-        os: [windows-2019, ubuntu-18.04, ubuntu-20.04, macos-12]
-        exclude:
-          # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
-          - os: ubuntu-18.04
-            node: 18.x
+        os: [windows-2019, ubuntu-20.04, ubuntu-22.04, macos-12]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     # this should match the os version used by the "check bundle size" step in
     # pr.yml
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       TAG: ${{ steps.set_tag_output.outputs.TAG }}
       VERSION: ${{ steps.set_version_output.outputs.VERSION }}
@@ -169,7 +169,7 @@ jobs:
 
   publish-docker:
     needs: release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # because the docker publish action is an action we made, we have to
       # check out the repo


### PR DESCRIPTION
Updating CI, including the "Release" action, to use Ubuntu 22.04, while also dropping support for `ubuntu-18.04`.