### PR TITLE
test: make bundle-size-check test run on external contributor PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,4 +65,4 @@ jobs:
         env:
           # use a fake infura key for the bundle size check so this test will
           # run successfully on external contributor Pull Requests
-          INFURA_KEY: 00000000000000000000000000000000
+          INFURA_KEY: "deadc0dedeadc0dedeadc0dedeadc0de"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,4 +65,4 @@ jobs:
         env:
           # use a fake infura key for the bundle size check so this test will
           # run successfully on external contributor Pull Requests
-          INFURA_KEY: DUMMY_INFURA_KEY_FOR_SIZE_CHECK!
+          INFURA_KEY: 00000000000000000000000000000000

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,4 +63,6 @@ jobs:
           echo "Bundle size is $([[ "$size" -lt 99000000 ]] && echo "ok" || echo "not ok")" &&
           test "$size" -lt 99000000
         env:
-          INFURA_KEY: ${{ secrets.INFURA_KEY }}
+          # use a fake infura key for the bundle size check so this test will
+          # run successfully on external contributor Pull Requests
+          INFURA_KEY: DUMMY_INFURA_KEY_FOR_SIZE_CHECK!

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,4 +65,4 @@ jobs:
         env:
           # use a fake infura key for the bundle size check so this test will
           # run successfully on external contributor Pull Requests
-          INFURA_KEY: "deadc0dedeadc0dedeadc0dedeadc0de"
+          INFURA_KEY: "badcode0deadcodebadcode0deadcode"


### PR DESCRIPTION
A [recent addition](https://github.com/trufflesuite/ganache/commit/783ae6325d617afaf633fc8b045e524669ed9c54) to our CI tests that ensures we do not exceed our bundle size limit causes external contributor PRs to fail this check. The reason for the failure is because this check requires an environment secret that is not available to the GitHub Action Environment that runs external contributor pull requests. This change replaces the secret with a fake value that allows the test to run as if the real secret was supplied.

Fixes #3340