### PR TITLE
build: ensure webpack's `INFURA_KEY` is exactly 32 lowercase hex characters

### DIFF
--- a/src/packages/ganache/webpack/webpack.common.config.ts
+++ b/src/packages/ganache/webpack/webpack.common.config.ts
@@ -26,7 +26,7 @@ if (
 
 // validate INFURA_KEY
 if (INFURA_KEY) {
-  if (!/[a-z0-9]{32}/.test(INFURA_KEY)) {
+  if (!/^[a-z0-9]{32}$/.test(INFURA_KEY)) {
     throw new Error(
       "INFURA_KEY must 32 characters long and contain only the characters a-f0-9"
     );

--- a/src/packages/ganache/webpack/webpack.common.config.ts
+++ b/src/packages/ganache/webpack/webpack.common.config.ts
@@ -26,7 +26,7 @@ if (
 
 // validate INFURA_KEY
 if (INFURA_KEY) {
-  if (!/^[a-z0-9]{32}$/.test(INFURA_KEY)) {
+  if (!/^[a-f0-9]{32}$/.test(INFURA_KEY)) {
     throw new Error(
       "INFURA_KEY must 32 characters long and contain only the characters a-f0-9"
     );


### PR DESCRIPTION
Our build process checks if the `INFURA_KEY` environment variable looks valid, but it was doing it wrong. It now actually checks for lowercase hex strings.