### PR TITLE
chore(dep): bump nanoid from 3.1.25 to 3.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5548,7 +5548,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -5603,6 +5602,11 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 					"dev": true
+				},
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
 				},
 				"p-limit": {
 					"version": "3.1.0",
@@ -5692,12 +5696,6 @@
 				"object-assign": "^4.0.1",
 				"thenify-all": "^1.0.0"
 			}
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
-			"dev": true
 		},
 		"negotiator": {
 			"version": "0.6.2",

--- a/src/chains/ethereum/address/package-lock.json
+++ b/src/chains/ethereum/address/package-lock.json
@@ -1246,7 +1246,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -1287,6 +1286,11 @@
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
 					}
+				},
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
 				}
 			}
 		},
@@ -1294,12 +1298,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"node-preload": {

--- a/src/chains/ethereum/block/package-lock.json
+++ b/src/chains/ethereum/block/package-lock.json
@@ -1508,7 +1508,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -1549,6 +1548,11 @@
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
 					}
+				},
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
 				}
 			}
 		},
@@ -1556,12 +1560,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"node-addon-api": {

--- a/src/chains/ethereum/console.log/package-lock.json
+++ b/src/chains/ethereum/console.log/package-lock.json
@@ -1767,7 +1767,6 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
@@ -1776,18 +1775,19 @@
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+          "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+        }
       }
     },
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
-    "nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true
     },
     "node-addon-api": {

--- a/src/chains/ethereum/ethereum/package-lock.json
+++ b/src/chains/ethereum/ethereum/package-lock.json
@@ -5103,7 +5103,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -5162,6 +5161,11 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 					"dev": true
+				},
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
 				},
 				"supports-color": {
 					"version": "8.1.1",
@@ -5256,12 +5260,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
 			"integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"napi-macros": {

--- a/src/chains/ethereum/options/package-lock.json
+++ b/src/chains/ethereum/options/package-lock.json
@@ -642,7 +642,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -651,18 +650,19 @@
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
+			},
+			"dependencies": {
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+				}
 			}
 		},
 		"ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"nise": {

--- a/src/chains/ethereum/transaction/package-lock.json
+++ b/src/chains/ethereum/transaction/package-lock.json
@@ -1948,7 +1948,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -1995,6 +1994,11 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 					"dev": true
+				},
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
 				}
 			}
 		},
@@ -2002,12 +2006,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"node-addon-api": {

--- a/src/chains/ethereum/utils/package-lock.json
+++ b/src/chains/ethereum/utils/package-lock.json
@@ -1182,7 +1182,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -1215,6 +1214,11 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 					"dev": true
+				},
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
 				}
 			}
 		},
@@ -1222,12 +1226,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
-			"dev": true
 		},
 		"node-addon-api": {
 			"version": "2.0.2",

--- a/src/chains/filecoin/filecoin/package-lock.json
+++ b/src/chains/filecoin/filecoin/package-lock.json
@@ -8101,7 +8101,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -8164,10 +8163,9 @@
 					"dev": true
 				},
 				"nanoid": {
-					"version": "3.1.25",
-					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-					"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
-					"dev": true
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
 				},
 				"p-limit": {
 					"version": "3.1.0",

--- a/src/chains/filecoin/options/package-lock.json
+++ b/src/chains/filecoin/options/package-lock.json
@@ -1146,7 +1146,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -1155,18 +1154,19 @@
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
+			},
+			"dependencies": {
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+				}
 			}
 		},
 		"ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"neo-async": {

--- a/src/chains/tezos/options/package-lock.json
+++ b/src/chains/tezos/options/package-lock.json
@@ -514,7 +514,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -523,18 +522,19 @@
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
+			},
+			"dependencies": {
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+				}
 			}
 		},
 		"ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"normalize-path": {

--- a/src/chains/tezos/tezos/package-lock.json
+++ b/src/chains/tezos/tezos/package-lock.json
@@ -1693,7 +1693,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -1753,6 +1752,11 @@
 					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 					"dev": true
 				},
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+				},
 				"supports-color": {
 					"version": "8.1.1",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -1801,12 +1805,6 @@
 				"object-assign": "^4.0.1",
 				"thenify-all": "^1.0.0"
 			}
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
-			"dev": true
 		},
 		"negotiator": {
 			"version": "0.6.2",

--- a/src/packages/cli/package-lock.json
+++ b/src/packages/cli/package-lock.json
@@ -800,7 +800,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -811,6 +810,11 @@
 				"yargs-unparser": "2.0.0"
 			},
 			"dependencies": {
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+				},
 				"supports-color": {
 					"version": "8.1.1",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -826,12 +830,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"node-addon-api": {

--- a/src/packages/colors/package-lock.json
+++ b/src/packages/colors/package-lock.json
@@ -514,7 +514,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -523,18 +522,19 @@
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
+			},
+			"dependencies": {
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+				}
 			}
 		},
 		"ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"normalize-path": {

--- a/src/packages/core/package-lock.json
+++ b/src/packages/core/package-lock.json
@@ -1659,7 +1659,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -1683,6 +1682,11 @@
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
 					}
+				},
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
 				}
 			}
 		},
@@ -1690,12 +1694,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"node-gyp-build": {

--- a/src/packages/flavors/package-lock.json
+++ b/src/packages/flavors/package-lock.json
@@ -498,7 +498,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -509,6 +508,11 @@
 				"yargs-unparser": "2.0.0"
 			},
 			"dependencies": {
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+				},
 				"supports-color": {
 					"version": "8.1.1",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -524,12 +528,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"normalize-path": {

--- a/src/packages/ganache/npm-shrinkwrap.json
+++ b/src/packages/ganache/npm-shrinkwrap.json
@@ -2118,7 +2118,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -2143,6 +2142,11 @@
 						"path-is-absolute": "^1.0.0"
 					}
 				},
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+				},
 				"serialize-javascript": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -2158,12 +2162,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"napi-macros": {

--- a/src/packages/options/package-lock.json
+++ b/src/packages/options/package-lock.json
@@ -583,7 +583,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -592,18 +591,19 @@
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
+			},
+			"dependencies": {
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+				}
 			}
 		},
 		"ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"normalize-path": {

--- a/src/packages/promise-queue/package-lock.json
+++ b/src/packages/promise-queue/package-lock.json
@@ -519,7 +519,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -528,18 +527,19 @@
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
+			},
+			"dependencies": {
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+				}
 			}
 		},
 		"ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"normalize-path": {

--- a/src/packages/rlp/package-lock.json
+++ b/src/packages/rlp/package-lock.json
@@ -1251,7 +1251,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -1292,6 +1291,11 @@
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
 					}
+				},
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
 				}
 			}
 		},
@@ -1299,12 +1303,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"node-preload": {

--- a/src/packages/secp256k1/package-lock.json
+++ b/src/packages/secp256k1/package-lock.json
@@ -1298,7 +1298,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -1339,6 +1338,11 @@
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
 					}
+				},
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
 				}
 			}
 		},
@@ -1346,12 +1350,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"node-addon-api": {

--- a/src/packages/utils/package-lock.json
+++ b/src/packages/utils/package-lock.json
@@ -634,7 +634,6 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -643,18 +642,19 @@
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
+			},
+			"dependencies": {
+				"nanoid": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+					"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+				}
 			}
 		},
 		"ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
-		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"nise": {


### PR DESCRIPTION
This forcibly bumps _mocha_'s version of nanoid from 3.1.25 to 3.3.4 in our lock files.

The package nanoid from 3.0.0, before 3.1.31, are vulnerable to Information Exposure via the valueOf() function which allows to reproduce the last id generated.

See: CVE-2021-23566

Ganache was not affected by this bug.