### PR TITLE
fix: ensure `console.log` event context is defined

### DIFF
--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -1091,7 +1091,10 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
         const logs = maybeGetLogs(event);
         if (logs) {
           options.logging.logger.log(...logs);
-          this.emit("ganache:vm:tx:console.log", { context, logs });
+          this.emit("ganache:vm:tx:console.log", {
+            context: transactionContext,
+            logs
+          });
         }
 
         if (!this.#emitStepEvent) return;


### PR DESCRIPTION
This also add tests to make sure the event's `context` is as expected.