### PR TITLE
fix: after `provider.disconnect()` is called, Ganache should stop serving requests

### DIFF
--- a/src/chains/ethereum/ethereum/src/provider.ts
+++ b/src/chains/ethereum/ethereum/src/provider.ts
@@ -138,9 +138,9 @@ export class EthereumProvider
   }>
   implements Provider<EthereumApi>
 {
-  readonly #options: EthereumInternalOptions;
-  readonly #api: EthereumApi;
-  readonly #wallet: Wallet;
+  #options: EthereumInternalOptions;
+  #api: EthereumApi;
+  #wallet: Wallet;
   readonly #executor: Executor;
   readonly #blockchain: Blockchain;
 
@@ -419,22 +419,19 @@ export class EthereumProvider
   };
 
   /**
-   * Disconnect the provider, the underlying blockchain will be stopped. Any tasks currently executing will be completed,
-   * any pending tasks will be rejected. The returned Promise will resolve when the provider is disconnected, and a
-   * "disconnect" event will be emitted.
-   * @returns Promise<void> - resolves when the provider has disconnected
+   * Disconnect the provider instance. This will cause the underlying blockchain to be stopped, and any pending
+   * tasks to be rejected. Await the returned Promise to ensure that everything has been cleanly shut down
+   * before terminating the process.
+   * @return Promise<void> - indicating that the provider has been cleanly disconnected
    */
   public disconnect = async () => {
     const executor = this.#executor;
-
-    // we await executor.stop() here to ensure that any currently executing tasks are complete before pulling the
-    // rug out by stopping the blockchain.
-    await executor.stop();
-
-    // we call rejectPendingTasks() _after_ executor.stop() has resolved, to ensure that all tasks are executed in
-    // FIFO order
-    executor.rejectPendingTasks();
+    // We make a best effort to resolve any currently executing tasks, before rejecting pending tasks. This relies on
+    // this.#blockchain.stop() waiting to resolve until after all executing tasks have settled. Executor does not
+    // guarantee that no tasks are currently executing, before rejecting any remaining pending tasks.
+    executor.stop();
     await this.#blockchain.stop();
+    executor.rejectPendingTasks();
 
     this.emit("disconnect");
   };

--- a/src/chains/ethereum/ethereum/src/provider.ts
+++ b/src/chains/ethereum/ethereum/src/provider.ts
@@ -425,14 +425,13 @@ export class EthereumProvider
    * @return Promise<void> - indicating that the provider has been cleanly disconnected
    */
   public disconnect = async () => {
-    const coordinator = this.#executor.getCoordinator();
-
+    const executor = this.#executor;
     // We make a best effort to resolve any currently executing tasks, before rejecting pending tasks. This relies on
     // this.#blockchain.stop() waiting to resolve until after all executing tasks have settled. Executor does not
     // guarantee that no tasks are currently executing, before rejecting any remaining pending tasks.
-    coordinator.stop();
+    executor.stop();
     await this.#blockchain.stop();
-    coordinator.rejectPendingTasks();
+    executor.rejectPendingTasks();
 
     this.emit("disconnect");
   };

--- a/src/chains/ethereum/ethereum/src/provider.ts
+++ b/src/chains/ethereum/ethereum/src/provider.ts
@@ -420,9 +420,9 @@ export class EthereumProvider
   };
 
   public disconnect = async () => {
+    this.#executor.disconnect();
     await this.#blockchain.stop();
     this.emit("disconnect");
-    return;
   };
 
   //#region legacy

--- a/src/chains/ethereum/ethereum/src/provider.ts
+++ b/src/chains/ethereum/ethereum/src/provider.ts
@@ -420,9 +420,8 @@ export class EthereumProvider
 
   /**
    * Disconnect the provider instance. This will cause the underlying blockchain to be stopped, and any pending
-   * tasks to be rejected. Await the returned Promise to ensure that everything has been cleanly shut down before
-   * terminating the process.
-   * @return Promise<void> - indicating that the provider has been cleanly disconnected
+   * tasks to be rejected. Emits a `disconnect` event once successfully disconnected.
+   * @returns Fullfills with `undefined` once the provider has been disconnected.
    */
   public disconnect = async () => {
     // executor.stop() will stop accepting new tasks, but will not wait for inflight tasks. These may reject with
@@ -430,7 +429,7 @@ export class EthereumProvider
     this.#executor.stop();
     await this.#blockchain.stop();
 
-    this.#executor.rejectPendingTasks();
+    this.#executor.end();
     this.emit("disconnect");
   };
 

--- a/src/chains/ethereum/ethereum/src/provider.ts
+++ b/src/chains/ethereum/ethereum/src/provider.ts
@@ -420,19 +420,17 @@ export class EthereumProvider
 
   /**
    * Disconnect the provider instance. This will cause the underlying blockchain to be stopped, and any pending
-   * tasks to be rejected. Await the returned Promise to ensure that everything has been cleanly shut down
-   * before terminating the process.
+   * tasks to be rejected. Await the returned Promise to ensure that everything has been cleanly shut down before
+   * terminating the process.
    * @return Promise<void> - indicating that the provider has been cleanly disconnected
    */
   public disconnect = async () => {
-    const executor = this.#executor;
-    // We make a best effort to resolve any currently executing tasks, before rejecting pending tasks. This relies on
-    // this.#blockchain.stop() waiting to resolve until after all executing tasks have settled. Executor does not
-    // guarantee that no tasks are currently executing, before rejecting any remaining pending tasks.
-    executor.stop();
+    // executor.stop() will stop accepting new tasks, but will not wait for inflight tasks. These may reject with
+    // (unhelpful) internal errors. See https://github.com/trufflesuite/ganache/issues/3499
+    this.#executor.stop();
     await this.#blockchain.stop();
-    executor.rejectPendingTasks();
 
+    this.#executor.rejectPendingTasks();
     this.emit("disconnect");
   };
 

--- a/src/chains/ethereum/ethereum/src/provider.ts
+++ b/src/chains/ethereum/ethereum/src/provider.ts
@@ -429,9 +429,11 @@ export class EthereumProvider
     // We make a best effort to resolve any currently executing tasks, before rejecting pending tasks. This relies on
     // this.#blockchain.stop() waiting to resolve until after all executing tasks have settled. Executor does not
     // guarantee that no tasks are currently executing, before rejecting any remaining pending tasks.
-    executor.stop();
-    await this.#blockchain.stop();
+
+    // await executor.stop() to ensure that all currently processing tasks are complete
+    await executor.stop();
     executor.rejectPendingTasks();
+    await this.#blockchain.stop();
 
     this.emit("disconnect");
   };

--- a/src/chains/ethereum/ethereum/tests/provider.test.ts
+++ b/src/chains/ethereum/ethereum/tests/provider.test.ts
@@ -473,7 +473,7 @@ describe("provider", () => {
           });
         });
 
-        it("rejects requests after disconnect() is called", async () => {
+        it("immediately and syncronously stops accepting request when `disconnect()` is called", async () => {
           provider.disconnect();
           const whenBlockByNumber = provider.request({
             method: "eth_getBlockByNumber",

--- a/src/chains/ethereum/ethereum/tests/provider.test.ts
+++ b/src/chains/ethereum/ethereum/tests/provider.test.ts
@@ -423,6 +423,16 @@ describe("provider", () => {
         }
       );
     });
+
+    it("stops responding to RPC methods once disconnected", async () => {
+      const provider = await getProvider();
+      await provider.disconnect();
+
+      await assert.rejects(
+        provider.send("eth_getBlockByNumber", ["latest"]),
+        new Error("Cannot process request, Ganache is disconnected.")
+      );
+    });
   });
 
   describe("web3 compatibility", () => {

--- a/src/chains/ethereum/ethereum/tests/provider.test.ts
+++ b/src/chains/ethereum/ethereum/tests/provider.test.ts
@@ -423,16 +423,6 @@ describe("provider", () => {
         }
       );
     });
-
-    it("stops responding to RPC methods once disconnected", async () => {
-      const provider = await getProvider();
-      await provider.disconnect();
-
-      await assert.rejects(
-        provider.send("eth_getBlockByNumber", ["latest"]),
-        new Error("Cannot process request, Ganache is disconnected.")
-      );
-    });
   });
 
   describe("web3 compatibility", () => {
@@ -469,6 +459,107 @@ describe("provider", () => {
       assert(subscription != null);
       assert.deepStrictEqual(subscriptionId, "0x1");
       assert.notStrictEqual(hash, "");
+    });
+  });
+
+  describe.only("disconnect()", () => {
+    let provider: EthereumProvider;
+
+    [true, false].forEach(asyncRequestProcessing => {
+      describe(`asyncRequestProcessing: ${asyncRequestProcessing}`, () => {
+        beforeEach("Instantiate provider", async () => {
+          provider = await getProvider({
+            chain: { asyncRequestProcessing }
+          });
+        });
+
+        it("stops responding to RPC methods once disconnected", async () => {
+          await provider.disconnect();
+
+          await assert.rejects(
+            provider.send("eth_getBlockByNumber", ["latest"]),
+            new Error("Cannot process request, Ganache is disconnected.")
+          );
+        });
+
+        it("raises the 'disconnect' event", async () => {
+          const whenDisconnected = provider.once("disconnect");
+          await provider.disconnect();
+          await assert.doesNotReject(
+            whenDisconnected,
+            'The provider should raise the "disconnect" event'
+          );
+        });
+
+        // todo: Reinstate this test when https://github.com/trufflesuite/ganache/issues/3499 is fixed
+        it.skip("successfully processes requests executed before disconnect is called", async () => {
+          const whenBlockByNumber = provider.request({
+            method: "eth_getProof",
+            params: ["0xC7D9E2d5FE0Ff5C43102158C31BbC4aA2fDe10d8", [], "latest"]
+          });
+          const whenDisconnected = provider.disconnect();
+
+          await assert.doesNotReject(
+            whenBlockByNumber,
+            "A call to .request() on the provider before disconnect is called should succeed"
+          );
+          await assert.doesNotReject(
+            whenDisconnected,
+            'The provider should raise the "disconnect" event'
+          );
+        });
+
+        it("rejects requests after disconnect is called", async () => {
+          const whenDisconnected = provider.disconnect();
+          const whenBlockByNumber = provider.request({
+            method: "eth_getBlockByNumber",
+            params: ["latest"]
+          });
+
+          await assert.rejects(
+            whenBlockByNumber,
+            new Error("Cannot process request, Ganache is disconnected.")
+          );
+          await assert.doesNotReject(
+            whenDisconnected,
+            'The provider should raise the "disconnect" event'
+          );
+        });
+      });
+    });
+
+    describe("without asyncRequestProcessing", () => {
+      beforeEach("Instantiate provider", async () => {
+        provider = await getProvider({
+          chain: { asyncRequestProcessing: false }
+        });
+      });
+
+      // we only test this with asyncRequestProcessing: false, because it's impossible to force requests
+      // to be "pending" when asyncRequestProcessing: true
+      it("successfully processes started requests, but reject pending requests", async () => {
+        const active = provider.request({
+          method: "eth_getBlockByNumber",
+          params: ["latest"]
+        });
+        const pending = provider.request({
+          method: "eth_getBlockByNumber",
+          params: ["latest"]
+        });
+
+        const whenDisconnected = provider.disconnect();
+
+        await assert.rejects(
+          pending,
+          new Error("Cannot process request, Ganache is disconnected."),
+          "pending tasks should reject"
+        );
+        await assert.doesNotReject(active, "active tasks should not reject");
+        await assert.doesNotReject(
+          whenDisconnected,
+          'The provider should raise the "disconnect" event'
+        );
+      });
     });
   });
 });

--- a/src/chains/ethereum/ethereum/tests/provider.test.ts
+++ b/src/chains/ethereum/ethereum/tests/provider.test.ts
@@ -423,16 +423,6 @@ describe("provider", () => {
         }
       );
     });
-
-    it("stops responding to RPC methods once disconnected", async () => {
-      const provider = await getProvider();
-      await provider.disconnect();
-
-      await assert.rejects(
-        provider.send("eth_getBlockByNumber", ["latest"]),
-        new Error("Cannot process request, Ganache is disconnected.")
-      );
-    });
   });
 
   describe("web3 compatibility", () => {
@@ -469,6 +459,106 @@ describe("provider", () => {
       assert(subscription != null);
       assert.deepStrictEqual(subscriptionId, "0x1");
       assert.notStrictEqual(hash, "");
+    });
+  });
+
+  describe("disconnect()", () => {
+    let provider: EthereumProvider;
+
+    [true, false].forEach(asyncRequestProcessing => {
+      describe(`asyncRequestProcessing: ${asyncRequestProcessing}`, () => {
+        beforeEach("Instantiate provider", async () => {
+          provider = await getProvider({
+            chain: { asyncRequestProcessing }
+          });
+        });
+
+        it("stops responding to RPC methods once disconnected", async () => {
+          await provider.disconnect();
+
+          await assert.rejects(
+            provider.send("eth_getBlockByNumber", ["latest"]),
+            new Error("Cannot process request, Ganache is disconnected.")
+          );
+        });
+
+        it("raises the 'disconnect' event", async () => {
+          const whenDisconnected = provider.once("disconnect");
+          await provider.disconnect();
+          await assert.doesNotReject(
+            whenDisconnected,
+            'The provider should raise the "disconnect" event'
+          );
+        });
+
+        it("successfully processes requests executed before disconnect is called", async () => {
+          const whenBlockByNumber = provider.request({
+            method: "eth_getBlockByNumber",
+            params: ["latest"]
+          });
+          const whenDisconnected = provider.disconnect();
+
+          await assert.doesNotReject(
+            whenBlockByNumber,
+            "A call to .request() on the provider before disconnect is called should succeed"
+          );
+          await assert.doesNotReject(
+            whenDisconnected,
+            'The provider should raise the "disconnect" event'
+          );
+        });
+
+        it("rejects requests after disconnect is called", async () => {
+          const whenDisconnected = provider.disconnect();
+          const whenBlockByNumber = provider.request({
+            method: "eth_getBlockByNumber",
+            params: ["latest"]
+          });
+
+          await assert.rejects(
+            whenBlockByNumber,
+            new Error("Cannot process request, Ganache is disconnected.")
+          );
+          await assert.doesNotReject(
+            whenDisconnected,
+            'The provider should raise the "disconnect" event'
+          );
+        });
+      });
+    });
+
+    describe("without asyncRequestProcessing", () => {
+      beforeEach("Instantiate provider", async () => {
+        provider = await getProvider({
+          chain: { asyncRequestProcessing: false }
+        });
+      });
+
+      // we only test this with asyncRequestProcessing: false, because it's impossible to force requests
+      // to be "pending" when asyncRequestProcessing: true
+      it("successfully processes started requests, but reject pending requests", async () => {
+        const active = provider.request({
+          method: "eth_getBlockByNumber",
+          params: ["latest"]
+        });
+        const pending = provider.request({
+          method: "eth_getBlockByNumber",
+          params: ["latest"]
+        });
+
+        const whenDisconnected = provider.disconnect();
+
+        await assert.rejects(
+          pending,
+          new Error("Cannot process request, Ganache is disconnected."),
+          "pending tasks should reject"
+        );
+        await assert.doesNotReject(active, "active tasks should not reject");
+        await assert.doesNotReject(
+          whenDisconnected,
+          'The provider should raise the "disconnect" event'
+        );
+      });
     });
   });
 });

--- a/src/packages/core/src/connector-loader.ts
+++ b/src/packages/core/src/connector-loader.ts
@@ -47,9 +47,12 @@ const initialize = <T extends FlavorName = typeof DefaultFlavor>(
   // provider is ready we unpause.. This lets us accept queue requests before
   // we've even fully initialized.
 
+  // The function referenced by requestcoordinator.resume will be changed when
+  // requestCoordinator.stop() is called. Ensure that no references to the
+  // function are held, otherwise internal errors may be surfaced.
   return {
     connector,
-    promise: connectPromise.then(requestCoordinator.resume)
+    promise: connectPromise.then(() => requestCoordinator.resume())
   };
 };
 

--- a/src/packages/core/tests/connector-loader.test.ts
+++ b/src/packages/core/tests/connector-loader.test.ts
@@ -1,0 +1,18 @@
+import assert from "assert";
+import loader from "../src/connector-loader";
+
+describe("connector-loader", () => {
+  describe("initialize", () => {
+    it("the returned promise should reject, if disconnect() is called before the provider is ready", async () => {
+      const { promise, connector } = loader.initialize({});
+      connector.provider.disconnect();
+
+      // This assertion ensures that the "stopped" queue() method that is
+      // assigned in request-coordinator.stop() is called correctly.
+      await assert.rejects(
+        promise,
+        new Error("Cannot resume processing requests, Ganache is disconnected.")
+      );
+    });
+  });
+});

--- a/src/packages/utils/src/utils/executor.ts
+++ b/src/packages/utils/src/utils/executor.ts
@@ -20,8 +20,11 @@ export class Executor {
     this.#requestCoordinator.stop();
   }
 
-  public rejectPendingTasks() {
-    this.#requestCoordinator.rejectPendingTasks();
+  /**
+   * Finalise shutdown of the underlying RequestCoordinator.
+   */
+  public end() {
+    this.#requestCoordinator.end();
   }
 
   /**

--- a/src/packages/utils/src/utils/executor.ts
+++ b/src/packages/utils/src/utils/executor.ts
@@ -12,8 +12,8 @@ export class Executor {
     this.#requestCoordinator = requestCoordinator;
   }
 
-  public stop(): Promise<void> {
-    return this.#requestCoordinator.stop();
+  public stop() {
+    this.#requestCoordinator.stop();
   }
 
   public rejectPendingTasks() {

--- a/src/packages/utils/src/utils/executor.ts
+++ b/src/packages/utils/src/utils/executor.ts
@@ -12,9 +12,14 @@ export class Executor {
     this.#requestCoordinator = requestCoordinator;
   }
 
-  public disconnect() {
-    this.#requestCoordinator.disconnect();
+  public stop() {
+    this.#requestCoordinator.stop();
   }
+
+  public rejectPendingTasks() {
+    this.#requestCoordinator.rejectPendingTasks();
+  }
+
 
   /**
    * Executes the method with the given methodName on the API

--- a/src/packages/utils/src/utils/executor.ts
+++ b/src/packages/utils/src/utils/executor.ts
@@ -12,6 +12,10 @@ export class Executor {
     this.#requestCoordinator = requestCoordinator;
   }
 
+  /**
+   * Stop processing requests. We pass this call through to the requestCoordinator, which means that api 
+   * validation will continue to work after calling stop() in execute().
+   */
   public stop() {
     this.#requestCoordinator.stop();
   }
@@ -19,7 +23,6 @@ export class Executor {
   public rejectPendingTasks() {
     this.#requestCoordinator.rejectPendingTasks();
   }
-
 
   /**
    * Executes the method with the given methodName on the API

--- a/src/packages/utils/src/utils/executor.ts
+++ b/src/packages/utils/src/utils/executor.ts
@@ -12,6 +12,10 @@ export class Executor {
     this.#requestCoordinator = requestCoordinator;
   }
 
+  public disconnect() {
+    this.#requestCoordinator.disconnect();
+  }
+
   /**
    * Executes the method with the given methodName on the API
    * @param methodName - The name of the JSON-RPC method to execute.

--- a/src/packages/utils/src/utils/executor.ts
+++ b/src/packages/utils/src/utils/executor.ts
@@ -13,7 +13,7 @@ export class Executor {
   }
 
   /**
-   * Stop processing requests. We pass this call through to the requestCoordinator, which means that api 
+   * Stop processing requests. We pass this call through to the requestCoordinator, which means that api
    * validation will continue to work after calling stop() in execute().
    */
   public stop() {
@@ -58,6 +58,11 @@ export class Executor {
         // just double check, in case a API breaks the rules and adds non-fns
         // to their API interface.
         if (typeof fn === "function") {
+          // The function referenced by requestcoordinator.queue will be changed
+          // when requestCoordinator.stop() is called. Ensure that no references
+          // to the function are held, otherwise internal errors may be
+          // surfaced.
+
           // queue up this method for actual execution:
           return this.#requestCoordinator.queue(fn, api, params);
         }

--- a/src/packages/utils/src/utils/executor.ts
+++ b/src/packages/utils/src/utils/executor.ts
@@ -12,8 +12,8 @@ export class Executor {
     this.#requestCoordinator = requestCoordinator;
   }
 
-  public stop() {
-    this.#requestCoordinator.stop();
+  public stop(): Promise<void> {
+    return this.#requestCoordinator.stop();
   }
 
   public rejectPendingTasks() {

--- a/src/packages/utils/src/utils/request-coordinator.ts
+++ b/src/packages/utils/src/utils/request-coordinator.ts
@@ -96,10 +96,11 @@ export class RequestCoordinator {
   }
 
   /**
-   * All pending tasks will reject with an error indicating that Ganache is disconnected.
+   * Finalise shutdown of the RequestCoordinator. Rejects all pending tasks in order. Should be
+   * called after all in-flight tasks have resolved in order to maintain overall FIFO order.
    */
-  public rejectPendingTasks() {
-    for(const current of this.pending) {
+  public end() {
+    for (const current of this.pending) {
       current.reject(
         new Error("Cannot process request, Ganache is disconnected.")
       );
@@ -119,11 +120,13 @@ export class RequestCoordinator {
     argumentsList: OverloadedParameters<T>
   ) => {
     if (this.#stopped) {
-      return Promise.reject(new Error("Cannot process request, Ganache is disconnected."));
+      return Promise.reject(
+        new Error("Cannot process request, Ganache is disconnected.")
+      );
     }
 
     return new Promise<{ value: ReturnType<typeof fn> }>((resolve, reject) => {
-      // const executor is `async` to force the return value into a Promise.
+      // const execute is `async` to force the return value into a Promise.
       const execute = async () => {
         try {
           const value = Reflect.apply(

--- a/src/packages/utils/src/utils/request-coordinator.ts
+++ b/src/packages/utils/src/utils/request-coordinator.ts
@@ -100,14 +100,10 @@ export class RequestCoordinator {
    * called after all in-flight tasks have resolved in order to maintain overall FIFO order.
    */
   public end() {
-    for (const current of this.pending) {
-      current.reject(
-        new Error("Cannot process request, Ganache is disconnected.")
-      );
-    }
-
-    if (this.pending.length > 0) {
-      this.pending.splice(0, this.pending.length);
+    while (this.pending.length > 0) {
+      this.pending
+        .shift()
+        .reject(new Error("Cannot process request, Ganache is disconnected."));
     }
   }
 

--- a/src/packages/utils/tests/request-coordinator.test.ts
+++ b/src/packages/utils/tests/request-coordinator.test.ts
@@ -35,7 +35,7 @@ describe("request-coordinator", () => {
     });
 
     it("should stop when tasks are queued", async () => {
-      const uncompletable = coordinator.queue(() => new Promise<void>(noop), this, []);
+      coordinator.queue(() => new Promise<void>(noop), this, []);
       await coordinator.stop();
 
       assert(coordinator.paused);
@@ -78,6 +78,11 @@ describe("request-coordinator", () => {
 
         await assert.doesNotReject(stopped);
       });
+    });
+
+    it("should reject if called a second time", async () => {
+      coordinator.stop();
+      await assert.rejects(coordinator.stop(), new Error("Already stopped."));
     });
   });
 

--- a/src/packages/utils/tests/request-coordinator.test.ts
+++ b/src/packages/utils/tests/request-coordinator.test.ts
@@ -3,7 +3,7 @@ import { RequestCoordinator } from "../src/utils/request-coordinator";
 
 describe("request-coordinator", () => {
   const thisArg = {};
-  const paramsArg: any[] = [];
+  const paramsArg: [] = [];
   const noop = () => undefined;
   let coordinator: RequestCoordinator;
 

--- a/src/packages/utils/tests/request-coordinator.test.ts
+++ b/src/packages/utils/tests/request-coordinator.test.ts
@@ -2,21 +2,22 @@ import assert from "assert";
 import { RequestCoordinator } from "../src/utils/request-coordinator";
 
 describe("request-coordinator", () => {
+  const noop = () => undefined;
   let coordinator: RequestCoordinator;
 
   beforeEach("instantiate RequestCoordinator", () => {
     coordinator = new RequestCoordinator(0);
   });
 
-  describe("disconnect", () => {
+  describe("stop()", () => {
     it("should pause processing", () => {
-      coordinator.disconnect();
+      coordinator.stop();
 
       assert(coordinator.paused);
     });
 
     it("should not allow processing to be resumed", () => {
-      coordinator.disconnect();
+      coordinator.stop();
 
       assert.throws(
         () => coordinator.resume(),
@@ -25,21 +26,49 @@ describe("request-coordinator", () => {
     });
 
     it("should not allow new requests to be queued", async () => {
-      coordinator.disconnect();
+      coordinator.stop();
 
       await assert.rejects(
-        coordinator.queue(() => null, this, []),
+        coordinator.queue(noop, this, []),
         new Error("Cannot process request, Ganache is disconnected.")
       );
     });
+  });
 
-    it("should reject all queued requests", async () => {
-      const taskPromise = coordinator.queue(() => null, this, []);
-      coordinator.disconnect();
-      await assert.rejects(
-        taskPromise,
-        new Error("Cannot process request, Ganache is disconnected.")
-      );
+  describe("rejectAllPendingRequests()", () => {
+    it("should reject pending requests in the order that they were received", async () => {
+      coordinator.pause();
+
+      let taskIndex = 0;
+      const pendingAssertions: Promise<any>[] = [];
+      for (let i = 0; i < 10; i++) {
+        const task = coordinator.queue(noop, this, []);
+
+        let nextRejectionIndex = taskIndex;
+        pendingAssertions.push(task.catch(_ => {
+          assert.strictEqual(i, nextRejectionIndex, `Rejected in incorrect order, waiting on task at index ${nextRejectionIndex}, got ${i}.`);
+        }));
+
+        taskIndex++;
+
+        pendingAssertions.push(assert.rejects(task, new Error("Cannot process request, Ganache is disconnected.")));
+      }
+
+      coordinator.rejectPendingTasks();
+      await Promise.all(pendingAssertions);
+    });
+
+    it("should clear the pending tasks queue", () => {
+      coordinator.pause();
+
+      for (let i = 0; i < 10; i++) {
+        coordinator.queue(noop, this, []);
+      }
+
+      assert.equal(coordinator.pending.length, 10, "Incorrect pending queue length before calling rejectAllPendingRequests");
+
+      coordinator.rejectPendingTasks();
+      assert.equal(coordinator.pending.length, 0, "Incorrect pending queue length after calling rejectAllPendingRequests");
     });
   });
 });

--- a/src/packages/utils/tests/request-coordinator.test.ts
+++ b/src/packages/utils/tests/request-coordinator.test.ts
@@ -2,6 +2,8 @@ import assert from "assert";
 import { RequestCoordinator } from "../src/utils/request-coordinator";
 
 describe("request-coordinator", () => {
+  const thisArg = {};
+  const paramsArg: any[] = [];
   const noop = () => undefined;
   let coordinator: RequestCoordinator;
 
@@ -10,7 +12,7 @@ describe("request-coordinator", () => {
   });
 
   describe("stop()", () => {
-    it("should pause processing", () => {
+    it("should set `paused` property to `true`", () => {
       coordinator.stop();
 
       assert(coordinator.paused);
@@ -29,7 +31,7 @@ describe("request-coordinator", () => {
       coordinator.stop();
 
       await assert.rejects(
-        coordinator.queue(noop, this, []),
+        coordinator.queue(noop, thisArg, paramsArg),
         new Error("Cannot process request, Ganache is disconnected.")
       );
     });
@@ -43,10 +45,10 @@ describe("request-coordinator", () => {
       const pendingAssertions: Promise<any>[] = [];
 
       for (let taskIndex = 0; taskIndex < 10; taskIndex++) {
-        const task = coordinator.queue(noop, this, []);
+        const task = coordinator.queue(noop, thisArg, paramsArg);
 
         pendingAssertions.push(
-          task.catch(_ => {
+          task.finally(() => {
             assert.strictEqual(
               taskIndex,
               nextRejectionIndex,
@@ -78,7 +80,7 @@ describe("request-coordinator", () => {
       coordinator.pause();
 
       for (let i = 0; i < 10; i++) {
-        coordinator.queue(noop, this, []);
+        coordinator.queue(noop, thisArg, paramsArg);
       }
 
       assert.equal(

--- a/src/packages/utils/tests/request-coordinator.test.ts
+++ b/src/packages/utils/tests/request-coordinator.test.ts
@@ -56,6 +56,8 @@ describe("request-coordinator", () => {
 
       coordinator.rejectPendingTasks();
       await Promise.all(pendingAssertions);
+
+      assert.equal(coordinator.pending.length, 0, "Coordinator pending list should be empty");
     });
 
     it("should clear the pending tasks queue", () => {

--- a/src/packages/utils/tests/request-coordinator.test.ts
+++ b/src/packages/utils/tests/request-coordinator.test.ts
@@ -48,7 +48,7 @@ describe("request-coordinator", () => {
         const task = coordinator.queue(noop, thisArg, paramsArg);
 
         pendingAssertions.push(
-          task.finally(() => {
+          task.catch(() => {
             assert.strictEqual(
               taskIndex,
               nextRejectionIndex,

--- a/src/packages/utils/tests/request-coordinator.test.ts
+++ b/src/packages/utils/tests/request-coordinator.test.ts
@@ -33,6 +33,52 @@ describe("request-coordinator", () => {
         new Error("Cannot process request, Ganache is disconnected.")
       );
     });
+
+    it("should stop when tasks are queued", async () => {
+      const uncompletable = coordinator.queue(() => new Promise<void>(noop), this, []);
+      await coordinator.stop();
+
+      assert(coordinator.paused);
+    });
+
+    describe("should wait for in-flight tasks to complete before resolving", () => {
+      it("when the task resolves", async () => {
+        const inProgressTask = coordinator.queue(noop, this, []);
+        coordinator.resume();
+
+        let isStopped = false;
+        const stopped = coordinator.stop().then(() => (isStopped = true));
+
+        await inProgressTask;
+        assert(
+          !isStopped,
+          "return result of RequestCoordinator.stop() resolved before the pending task completed"
+        );
+
+        await assert.doesNotReject(stopped);
+      });
+
+      it("when the task rejects", async () => {
+        const inProgressTask = coordinator.queue(
+          () => Promise.reject(),
+          this,
+          []
+        );
+        coordinator.resume();
+
+        let isStopped = false;
+        const stopped = coordinator.stop().then(() => (isStopped = true));
+
+        // the promise returned from coordinator.queue will resolve, even though the underlying promise rejects
+        await inProgressTask;
+        assert(
+          !isStopped,
+          "return result of RequestCoordinator.stop() resolved before the pending task completed"
+        );
+
+        await assert.doesNotReject(stopped);
+      });
+    });
   });
 
   describe("rejectAllPendingRequests()", () => {
@@ -45,30 +91,34 @@ describe("request-coordinator", () => {
         const task = coordinator.queue(noop, this, []);
 
         let nextRejectionIndex = taskIndex;
-        pendingAssertions.push(task.catch(_ => {
-          assert.strictEqual(i, nextRejectionIndex, `Rejected in incorrect order, waiting on task at index ${nextRejectionIndex}, got ${i}.`);
-        }));
+        pendingAssertions.push(
+          task.catch(_ => {
+            assert.strictEqual(
+              i,
+              nextRejectionIndex,
+              `Rejected in incorrect order, waiting on task at index ${nextRejectionIndex}, got ${i}.`
+            );
+          })
+        );
 
         taskIndex++;
 
-        pendingAssertions.push(assert.rejects(task, new Error("Cannot process request, Ganache is disconnected.")));
+        pendingAssertions.push(
+          assert.rejects(
+            task,
+            new Error("Cannot process request, Ganache is disconnected.")
+          )
+        );
       }
 
       coordinator.rejectPendingTasks();
       await Promise.all(pendingAssertions);
-    });
 
-    it("should clear the pending tasks queue", () => {
-      coordinator.pause();
-
-      for (let i = 0; i < 10; i++) {
-        coordinator.queue(noop, this, []);
-      }
-
-      assert.equal(coordinator.pending.length, 10, "Incorrect pending queue length before calling rejectAllPendingRequests");
-
-      coordinator.rejectPendingTasks();
-      assert.equal(coordinator.pending.length, 0, "Incorrect pending queue length after calling rejectAllPendingRequests");
+      assert.equal(
+        coordinator.pending.length,
+        0,
+        "Incorrect pending queue length after calling rejectAllPendingRequests"
+      );
     });
   });
 });

--- a/src/packages/utils/tests/request-coordinator.test.ts
+++ b/src/packages/utils/tests/request-coordinator.test.ts
@@ -1,0 +1,48 @@
+import assert from "assert";
+import { RequestCoordinator } from "../src/utils/request-coordinator";
+
+describe("request-coordinator", () => {
+  let coordinator: RequestCoordinator;
+
+  beforeEach("instantiate RequestCoordinator", () => {
+    coordinator = new RequestCoordinator(0);
+  });
+
+  describe("disconnect", () => {
+    it("should pause processing", () => {
+      coordinator.disconnect();
+
+      assert(coordinator.paused);
+    });
+
+    it("should not allow processing to be resumed", () => {
+      coordinator.disconnect();
+
+      assert.throws(
+        () => coordinator.resume(),
+        new Error("Cannot resume processing requests, Ganache is disconnected.")
+      );
+    });
+
+    it("should not allow new requests to be queued", async () => {
+      coordinator.disconnect();
+
+      await assert.rejects(
+        coordinator.queue(() => null, this, []),
+        new Error("Cannot process request, Ganache is disconnected.")
+      );
+    });
+
+    it("should reject all queued requests", async () => {
+      const neverEndingTask = () => {
+        return new Promise(() => {});
+      };
+      const taskPromise = coordinator.queue(neverEndingTask, this, []);
+      coordinator.disconnect();
+      await assert.rejects(
+        taskPromise,
+        new Error("Cannot process request, Ganache is disconnected.")
+      );
+    });
+  });
+});

--- a/src/packages/utils/tests/request-coordinator.test.ts
+++ b/src/packages/utils/tests/request-coordinator.test.ts
@@ -34,10 +34,7 @@ describe("request-coordinator", () => {
     });
 
     it("should reject all queued requests", async () => {
-      const neverEndingTask = () => {
-        return new Promise(() => {});
-      };
-      const taskPromise = coordinator.queue(neverEndingTask, this, []);
+      const taskPromise = coordinator.queue(() => null, this, []);
       coordinator.disconnect();
       await assert.rejects(
         taskPromise,


### PR DESCRIPTION
Previously, when `provider.disconnect()` was called, a lot of the internals of Ganache would be stopped, but just enough was kept alive to serve requests. This could stop consumers from shutting down cleanly.

Now all pending requests, and any new requests will be rejected with a helpful error.

For example, before this change, the following would successfully return the block number:
```javascript
const provider = Ganache.provider();
await provider.disconnect();
const blockNumber = await provider.send("eth_blockNumber");
```

But now:
```
Error: Cannot process request, Ganache is disconnected.
```

Caveat: any request that has _started_ to process, but not yet complete, may fail with an unexpected error. See #3499 for details.

Fixes #3293