### PR TITLE
test: correct webpack infura key validation error message grammar

### DIFF
--- a/src/packages/ganache/webpack/webpack.common.config.ts
+++ b/src/packages/ganache/webpack/webpack.common.config.ts
@@ -28,7 +28,7 @@ if (
 if (INFURA_KEY) {
   if (!/^[a-f0-9]{32}$/.test(INFURA_KEY)) {
     throw new Error(
-      "INFURA_KEY must 32 characters long and contain only the characters a-f0-9"
+      "INFURA_KEY must be 32 characters long and contain only the characters a-f0-9"
     );
   }
 }


### PR DESCRIPTION
Fixes: 
"INFURA_KEY must 32 characters..."
"INFURA_KEY must **be** 32 characters..."