### PR TITLE
test: make bundle-size-check test work again

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,4 +65,4 @@ jobs:
         env:
           # use a fake infura key for the bundle size check so this test will
           # run successfully on external contributor Pull Requests
-          INFURA_KEY: "badcode0deadcodebadcode0deadcode"
+          INFURA_KEY: "badc0de0deadc0debadc0de0deadc0de"


### PR DESCRIPTION
[This change](https://github.com/trufflesuite/ganache/commit/cce546965aaa343346bc01b6cde964397011d800) combined with [this one](https://github.com/trufflesuite/ganache/pull/3409) caused the bundle-size-check to fail for all PRs. The INFURA_KEY env var was updated to work for all PRs, including external contributors, but it used an invalid character. The INFURA_KEY validation was incorrect, and the invalid key passed validation. Once the INFURA_KEY validation was fixed the invalid key was now failing validation, causing all PRs to fail the CI check. This change updated the INFURA_KEY so that it passes validation.