### PR TITLE
fix: switch to user-provided logger rather than `console.log`

### DIFF
--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -618,7 +618,9 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
 
   resume(_threads: number = 1) {
     if (!this.#isPaused()) {
-      console.log("Warning: startMining called when miner was already started");
+      this.#options.logging.logger.log(
+        "Warning: startMining called when miner was already started"
+      );
       return;
     }
 

--- a/src/chains/ethereum/ethereum/src/forking/handlers/ws-handler.ts
+++ b/src/chains/ethereum/ethereum/src/forking/handlers/ws-handler.ts
@@ -1,5 +1,5 @@
 import { EthereumInternalOptions } from "@ganache/ethereum-options";
-import { AbortError, CodedError } from "@ganache/ethereum-utils";
+import { AbortError } from "@ganache/ethereum-utils";
 import { AbortSignal } from "abort-controller";
 import WebSocket from "ws";
 import { Handler } from "../types";

--- a/src/chains/ethereum/ethereum/src/forking/handlers/ws-handler.ts
+++ b/src/chains/ethereum/ethereum/src/forking/handlers/ws-handler.ts
@@ -40,11 +40,11 @@ export class WsHandler extends BaseHandler implements Handler {
     // handler too.
     this.connection.binaryType = "nodebuffer";
 
-    this.open = this.connect(this.connection);
+    this.open = this.connect(this.connection, options);
     this.connection.onclose = () => {
       // try to connect again...
       // TODO: backoff and eventually fail
-      this.open = this.connect(this.connection);
+      this.open = this.connect(this.connection, options);
     };
     this.abortSignal.addEventListener("abort", () => {
       this.connection.onclose = null;
@@ -98,7 +98,7 @@ export class WsHandler extends BaseHandler implements Handler {
     }
   }
 
-  private connect(connection: WebSocket) {
+  private connect(connection: WebSocket, options: EthereumInternalOptions) {
     let open = new Promise((resolve, reject) => {
       connection.onopen = resolve;
       connection.onerror = reject;
@@ -109,7 +109,7 @@ export class WsHandler extends BaseHandler implements Handler {
         connection.onerror = null;
       },
       err => {
-        console.log(err);
+        options.logging.logger.log(err);
       }
     );
     return open;


### PR DESCRIPTION
The Ganache options allow you to set a custom logger to handle any logging that Ganache does*. When using Ganache programatically, this can be done as follows:

```TypeScript
const logger = {
  log: (message?: any, ...optionalParams: any[]) => {
    // whatever custom log stuff you want
  }
};

const provider = Ganache.provider({
  logging: { logger }
});
```

However, there were still a few hold-out `console.log`s in our code, which logged directly to the console rather than the user-provided log function. This change fixes this issue.

_*Pro Tip: You can actually update that `logger` function while Ganache is running to temporarily change how you handle logs, if you're into that sort of thing._