### PR TITLE
fix: nonce generation race conditions

### DIFF
--- a/src/chains/ethereum/ethereum/src/miner/executables.ts
+++ b/src/chains/ethereum/ethereum/src/miner/executables.ts
@@ -1,7 +1,13 @@
 import { TypedTransaction } from "@ganache/ethereum-transaction";
-import { Heap } from "@ganache/utils";
+import { Heap, Quantity } from "@ganache/utils";
 
+export type InProgressData = {
+  transaction: TypedTransaction;
+  originBalance: Quantity;
+};
+
+export type InProgress = Map<string, Set<InProgressData>>;
 export type Executables = {
-  inProgress: Set<TypedTransaction>;
+  inProgress: InProgress;
   pending: Map<string, Heap<TypedTransaction>>;
 };

--- a/src/chains/ethereum/ethereum/src/miner/executables.ts
+++ b/src/chains/ethereum/ethereum/src/miner/executables.ts
@@ -6,8 +6,7 @@ export type InProgressData = {
   originBalance: Quantity;
 };
 
-export type InProgress = Map<string, Set<InProgressData>>;
 export type Executables = {
-  inProgress: InProgress;
+  inProgress: Map<string, Set<InProgressData>>;
   pending: Map<string, Heap<TypedTransaction>>;
 };

--- a/src/chains/ethereum/ethereum/src/miner/miner.ts
+++ b/src/chains/ethereum/ethereum/src/miner/miner.ts
@@ -21,7 +21,7 @@ import { EthereumInternalOptions } from "@ganache/ethereum-options";
 import replaceFromHeap from "./replace-from-heap";
 import { EVMResult } from "@ethereumjs/vm/dist/evm/evm";
 import { Params, TypedTransaction } from "@ganache/ethereum-transaction";
-import { Executables } from "./executables";
+import { Executables, InProgressData } from "./executables";
 import { Block, RuntimeBlock } from "@ganache/ethereum-block";
 import {
   makeStepEvent,
@@ -349,7 +349,7 @@ export default class Miner extends Emittery<{
             const { balance } = await vm.stateManager.getAccount({
               buf: Quantity.toBuffer(origin)
             } as any);
-            const inProgressData = {
+            const inProgressData: InProgressData = {
               transaction: best,
               originBalance: Quantity.from(balance.toBuffer())
             };

--- a/src/chains/ethereum/ethereum/src/miner/miner.ts
+++ b/src/chains/ethereum/ethereum/src/miner/miner.ts
@@ -343,11 +343,28 @@ export default class Miner extends Emittery<{
             numTransactions++;
 
             const pendingOrigin = pending.get(origin);
-            inProgress.add(best);
+            const inProgressOrigin = inProgress.get(origin);
+            const { balance } = await vm.stateManager.getAccount({
+              buf: Quantity.toBuffer(origin)
+            } as any);
+            const inProgressData = {
+              transaction: best,
+              originBalance: Quantity.from(balance.toBuffer())
+            };
+
+            if (inProgressOrigin) {
+              inProgressOrigin.add(inProgressData);
+            } else {
+              inProgress.set(origin, new Set([inProgressData]));
+            }
             best.once("finalized").then(() => {
               // it is in the database (or thrown out) so delete it from the
               // `inProgress` Set
-              inProgress.delete(best);
+              const inProgressOrigin = inProgress.get(origin);
+              inProgressOrigin.delete(inProgressData);
+              if (inProgressOrigin.size === 0) {
+                inProgress.delete(origin);
+              }
             });
 
             // since this transaction was successful, remove it from the "pending"

--- a/src/chains/ethereum/ethereum/src/miner/miner.ts
+++ b/src/chains/ethereum/ethereum/src/miner/miner.ts
@@ -344,6 +344,8 @@ export default class Miner extends Emittery<{
 
             const pendingOrigin = pending.get(origin);
             const inProgressOrigin = inProgress.get(origin);
+            // we cache the account balance with the inProgress transaction for
+            // an optimization in the transaction pool, so fetch it here
             const { balance } = await vm.stateManager.getAccount({
               buf: Quantity.toBuffer(origin)
             } as any);

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -371,7 +371,7 @@ export default class TransactionPool extends Emittery<{ drain: undefined }> {
     if (secretKey) {
       transaction.signAndHash(secretKey.toBuffer());
     }
-    console.log(`txNonce ${txNonce}, origin: ${origin}`);
+
     switch (transactionPlacement) {
       case TriageOption.Executable:
         // if it is executable add it to the executables queue

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -158,10 +158,11 @@ export default class TransactionPool extends Emittery<{ drain: undefined }> {
     secretKey?: Data
   ) {
     const origin = transaction.from.toString();
+    const originsQueue = this.#originsQueue;
     let queueForOrigin: Semaphore;
-    if (!(queueForOrigin = this.#originsQueue.get(origin))) {
+    if (!(queueForOrigin = originsQueue.get(origin))) {
       queueForOrigin = Semaphore(1);
-      this.#originsQueue.set(origin, queueForOrigin);
+      originsQueue.set(origin, queueForOrigin);
     }
     await new Promise(resolve => queueForOrigin.take(resolve));
     try {

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -40,7 +40,7 @@ function shouldReplace(
   }
 
   // if the transaction being replaced is in the middle of being mined, we can't
-  // replpace it so let's back out early
+  // replace it so let's back out early
   if (replacee.locked) {
     throw new CodedError(
       TRANSACTION_LOCKED,

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -78,6 +78,11 @@ function shouldReplace(
   }
 }
 
+/**
+ * Throws insufficient funds error if `balance` < `cost`.
+ * @param cost The transaction cost.
+ * @param balance The account's balance.
+ */
 function validateSufficientFunds(cost: bigint, balance: bigint) {
   if (balance < cost) {
     throw new CodedError(
@@ -509,6 +514,14 @@ export default class TransactionPool extends Emittery<{ drain: undefined }> {
     return null;
   };
 
+  /**
+   * Searches all in progress transactions from the specified origin for the
+   * transaction with the highest nonce.
+   * @param origin The origin to search.
+   * @returns The in progress transaction with the highest nonce from the
+   * specified origin, along with the account's balance after running that
+   * transaction.
+   */
   readonly #getLatestInProgressFromOrigin = (origin: string) => {
     let highestNonceData: InProgressData = {
       transaction: null,

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -158,14 +158,10 @@ export default class TransactionPool extends Emittery<{ drain: undefined }> {
     secretKey?: Data
   ) {
     const origin = transaction.from.toString();
-    console.log(`processing origin ${origin}`);
     let queueForOrigin: Semaphore;
     if (!(queueForOrigin = this.#originsQueue.get(origin))) {
-      console.log("making new semaphore");
       queueForOrigin = Semaphore(1);
       this.#originsQueue.set(origin, queueForOrigin);
-    } else {
-      console.log(`semaphore already existed`);
     }
     await new Promise(resolve => queueForOrigin.take(resolve));
     try {

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -231,8 +231,8 @@ export default class TransactionPool extends Emittery<{ drain: undefined }> {
     const queuedOriginTransactions = origins.get(origin);
 
     let transactionPlacement = TriageOption.FutureQueue;
-    const executables = this.executables.pending;
-    let executableOriginTransactions = executables.get(origin);
+    const pending = this.executables.pending;
+    let executableOriginTransactions = pending.get(origin);
 
     const priceBump = this.#priceBump;
     let length: number;
@@ -352,7 +352,7 @@ export default class TransactionPool extends Emittery<{ drain: undefined }> {
         } else {
           // if we don't yet have an executables queue for this origin make one now
           executableOriginTransactions = Heap.from(transaction, byNonce);
-          executables.set(origin, executableOriginTransactions);
+          pending.set(origin, executableOriginTransactions);
         }
 
         // Now we need to drain any queued transactions that were previously

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -320,7 +320,7 @@ export default class TransactionPool extends Emittery<{ drain: undefined }> {
       } else if (txNonce < effectiveNonce) {
         // it's an error if the transaction's nonce is <= the persisted nonce
         throw new CodedError(
-          `the tx doesn't have the correct nonce. account has nonce of: ${transactorNonce} tx has nonce of: ${txNonce}`,
+          `the tx doesn't have the correct nonce. account has nonce of: ${effectiveNonce} tx has nonce of: ${txNonce}`,
           JsonRpcErrorCode.INVALID_INPUT
         );
       } else if (txNonce === effectiveNonce) {

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -289,9 +289,8 @@ export default class TransactionPool extends Emittery<{ drain: undefined }> {
       );
       validateSufficientFunds(transactionCost, balance.toBigInt());
     } else {
-      // since we don't have any executable transactions at the moment, we need
-      // to find our nonce from the account itself...
-
+      // we don't have any pending executable transactions, but we could have
+      // some inProgress executable transactions
       const {
         transaction: latestInProgressTransaction,
         originBalance: balanceAfterLatestInProgressTransaction
@@ -306,6 +305,8 @@ export default class TransactionPool extends Emittery<{ drain: undefined }> {
         effectiveNonce = highestInProgressNonce.toBigInt() + 1n;
         balance = balanceAfterLatestInProgressTransaction.toBigInt();
       } else {
+        // if we don't have in progress transactions either, we'll need to find
+        // our nonce from the account itself
         const transactor = await this.#blockchain.accounts.getNonceAndBalance(
           from
         );
@@ -316,8 +317,6 @@ export default class TransactionPool extends Emittery<{ drain: undefined }> {
       validateSufficientFunds(transactionCost, balance);
 
       if (txNonce === void 0) {
-        // if we don't have a transactionNonce, just use the account's next
-        // nonce and mark as executable
         txNonce = effectiveNonce;
         transaction.nonce = Quantity.from(txNonce);
         transactionPlacement = TriageOption.Executable;

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -80,9 +80,8 @@ function findHighestNonceByOrigin(set: Set<TypedTransaction>, origin: string) {
   let highestNonce: bigint = null;
   for (const transaction of set) {
     if (
-      (transaction.from.toString() === origin &&
-        transaction.nonce.toBigInt() > highestNonce) ||
-      highestNonce === null
+      transaction.from.toString() === origin &&
+      (highestNonce === null || transaction.nonce.toBigInt() > highestNonce)
     ) {
       highestNonce = transaction.nonce.toBigInt();
     }

--- a/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
+++ b/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
@@ -653,7 +653,16 @@ describe("transaction pool", async () => {
         // up, it will not have changed, so the pool will have to rely on the
         // inProgress transactions to set the nonce of the next transaction
         const pendingOrigin = pending.get(from);
-        inProgress.add(transaction);
+        const inProgressOrigin = inProgress.get(from);
+        const data = {
+          transaction,
+          originBalance: Quantity.from("0x3635c9adc5dea00000")
+        };
+        if (inProgressOrigin) {
+          inProgressOrigin.add(data);
+        } else {
+          inProgress.set(from, new Set([data]));
+        }
         pendingOrigin.removeBest();
       });
       txPool.drain();

--- a/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
+++ b/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
@@ -41,7 +41,8 @@ describe("transaction pool", async () => {
   };
   const options = EthereumOptionsConfig.normalize(optionsJson);
   let futureNonceRpc, executableRpc: Transaction;
-  before(function () {
+
+  const beforeEachSetup = () => {
     const wallet = new Wallet(options.wallet);
     [from] = wallet.addresses;
     secretKey = wallet.unlockedAccounts.get(from);
@@ -95,422 +96,423 @@ describe("transaction pool", async () => {
         latest: { header: { baseFeePerGas: Quantity.from(875000000) } }
       }
     };
-  });
-  beforeEach(async function () {
-    // for each test, we'll need a fresh set of origins
+
     origins = new Map();
-  });
+  };
 
-  it("rejects transactions whose gasLimit is greater than the block gas limit", async () => {
-    // for this tx pool, we'll have the block gas limit low
-    const optionsJson = { miner: { blockGasLimit: "0xff" } };
-    const options = EthereumOptionsConfig.normalize(optionsJson);
-    const txPool = new TransactionPool(options.miner, blockchain, origins);
-    const executableTx = TransactionFactory.fromRpc(executableRpc, common);
-    await assert.rejects(
-      txPool.prepareTransaction(executableTx, secretKey),
-      {
-        code: -32000,
-        message: "exceeds block gas limit"
-      },
-      "transaction with gas limit higher than block gas limit should have been rejected"
-    );
-  });
-  it("rejects transactions whose gasLimit is not enough to run the transaction", async () => {
-    const txPool = new TransactionPool(options.miner, blockchain);
-    // the tx should have a very low gas limit to be rejected
-    const lowGasRpc: Transaction = {
-      from: from,
-      type: "0x2",
-      maxFeePerGas: "0xffffffff",
-      gasLimit: "0xff"
-    };
-    const lowGasTx = TransactionFactory.fromRpc(lowGasRpc, common);
-    await assert.rejects(
-      txPool.prepareTransaction(lowGasTx, secretKey),
-      {
-        code: -32000,
-        message: "intrinsic gas too low"
-      },
-      "transaction with gas limit that is too low to run the transaction should have been rejected"
-    );
-  });
+  describe("rejections", async () => {
+    beforeEach(beforeEachSetup);
+    it("rejects transactions whose gasLimit is greater than the block gas limit", async () => {
+      // for this tx pool, we'll have the block gas limit low
+      const optionsJson = { miner: { blockGasLimit: "0xff" } };
+      const options = EthereumOptionsConfig.normalize(optionsJson);
+      const txPool = new TransactionPool(options.miner, blockchain, origins);
+      const executableTx = TransactionFactory.fromRpc(executableRpc, common);
+      await assert.rejects(
+        txPool.prepareTransaction(executableTx, secretKey),
+        {
+          code: -32000,
+          message: "exceeds block gas limit"
+        },
+        "transaction with gas limit higher than block gas limit should have been rejected"
+      );
+    });
+    it("rejects transactions whose gasLimit is not enough to run the transaction", async () => {
+      const txPool = new TransactionPool(options.miner, blockchain);
+      // the tx should have a very low gas limit to be rejected
+      const lowGasRpc: Transaction = {
+        from: from,
+        type: "0x2",
+        maxFeePerGas: "0xffffffff",
+        gasLimit: "0xff"
+      };
+      const lowGasTx = TransactionFactory.fromRpc(lowGasRpc, common);
+      await assert.rejects(
+        txPool.prepareTransaction(lowGasTx, secretKey),
+        {
+          code: -32000,
+          message: "intrinsic gas too low"
+        },
+        "transaction with gas limit that is too low to run the transaction should have been rejected"
+      );
+    });
 
-  it("rejects transactions whose nonce is lower than the account nonce", async () => {
-    const options = EthereumOptionsConfig.normalize({});
-    // when the tx pool requests a nonce for an account, we'll always respond 1
-    // so if we send a tx with nonce 0, it should reject
-    const fakeNonceChain = {
-      accounts: {
-        getNonceAndBalance: async () => {
-          return { nonce: Quantity.from(1), balance: Quantity.from(1e15) };
+    it("rejects transactions whose nonce is lower than the account nonce", async () => {
+      const options = EthereumOptionsConfig.normalize({});
+      // when the tx pool requests a nonce for an account, we'll always respond 1
+      // so if we send a tx with nonce 0, it should reject
+      const fakeNonceChain = {
+        accounts: {
+          getNonceAndBalance: async () => {
+            return { nonce: Quantity.from(1), balance: Quantity.from(1e15) };
+          }
+        },
+        common,
+        blocks: {
+          latest: { header: { baseFeePerGas: Quantity.from(875000000) } }
         }
-      },
-      common,
-      blocks: {
-        latest: { header: { baseFeePerGas: Quantity.from(875000000) } }
-      }
-    } as any;
-    const txPool = new TransactionPool(options.miner, fakeNonceChain, origins);
-    const executableTx = TransactionFactory.fromRpc(executableRpc, common);
-    await assert.rejects(
-      txPool.prepareTransaction(executableTx, secretKey),
-      {
-        message: `the tx doesn't have the correct nonce. account has nonce of: 1 tx has nonce of: ${executableTx.nonce.toBigInt()}`
-      },
-      "transaction with nonce lower than account nonce should have been rejected"
-    );
+      } as any;
+      const txPool = new TransactionPool(
+        options.miner,
+        fakeNonceChain,
+        origins
+      );
+      const executableTx = TransactionFactory.fromRpc(executableRpc, common);
+      await assert.rejects(
+        txPool.prepareTransaction(executableTx, secretKey),
+        {
+          message: `the tx doesn't have the correct nonce. account has nonce of: 1 tx has nonce of: ${executableTx.nonce.toBigInt()}`
+        },
+        "transaction with nonce lower than account nonce should have been rejected"
+      );
+    });
+
+    it("rejects executable replacement transactions whose gas price isn't sufficiently high", async () => {
+      const txPool = new TransactionPool(options.miner, blockchain, origins);
+      const executableTx = TransactionFactory.fromRpc(executableRpc, common);
+      const isExecutable = await txPool.prepareTransaction(
+        executableTx,
+        secretKey
+      );
+      assert(isExecutable); // our first transaction is executable
+      const { pending } = txPool.executables;
+      // our executable transaction should be found in the pending queue
+      const found = findIn(executableTx.hash.toBuffer(), pending);
+      assert.strictEqual(
+        found.serialized.toString(),
+        executableTx.serialized.toString()
+      );
+
+      const replacementRpc = JSON.parse(JSON.stringify(executableRpc));
+      replacementRpc.maxPriorityFeePerGas = "0xffff";
+      const replacementTx1 = TransactionFactory.fromRpc(replacementRpc, common);
+      // even if the tip is high enough, the max fee isn't enough to replace, so it'll throw
+      await assert.rejects(
+        txPool.prepareTransaction(replacementTx1, secretKey),
+        {
+          code: -32003,
+          message: "transaction underpriced"
+        },
+        "replacement transaction with insufficient gas price to replace should have been rejected"
+      );
+
+      replacementRpc.maxPriorityFeePerGas = executableRpc.maxPriorityFeePerGas;
+      replacementRpc.maxFeePerGas = "0xffffffffff";
+      const replacementTx2 = TransactionFactory.fromRpc(replacementRpc, common);
+      // even if the maxFee is high enough, the tip isn't enough to replace, so it'll throw
+      await assert.rejects(
+        txPool.prepareTransaction(replacementTx2, secretKey),
+        {
+          code: -32003,
+          message: "transaction underpriced"
+        },
+        "replacement transaction with insufficient gas price to replace should have been rejected"
+      );
+
+      const legacyReplacementRpc: Transaction = {
+        from: from,
+        type: "0x0",
+        gasPrice: "0xffffffff",
+        gasLimit: "0xffff",
+        nonce: "0x0"
+      };
+      const replacementTx3 = TransactionFactory.fromRpc(
+        legacyReplacementRpc,
+        common
+      );
+      // the gasPrice is higher than the tip but lower than the maxFee, which isn't enough, so it'll throw
+      await assert.rejects(
+        txPool.prepareTransaction(replacementTx3, secretKey),
+        {
+          code: -32003,
+          message: "transaction underpriced"
+        },
+        "replacement transaction with insufficient gas price to replace should have been rejected"
+      );
+    });
+
+    it("rejects future nonce replacement transactions whose gas price isn't sufficiently high", async () => {
+      const txPool = new TransactionPool(options.miner, blockchain, origins);
+      const futureNonceTx = TransactionFactory.fromRpc(futureNonceRpc, common);
+      const isExecutable = await txPool.prepareTransaction(
+        futureNonceTx,
+        secretKey
+      );
+      assert(!isExecutable); // our transaction is not executable
+      // our non executable transaction should be found in the origins queue
+      const found = findIn(futureNonceTx.hash.toBuffer(), origins);
+      assert.strictEqual(
+        found.serialized.toString(),
+        futureNonceTx.serialized.toString()
+      );
+      // now, if we resend the same transaction, since the gas price isn't higher,
+      // it should be rejected
+      await assert.rejects(
+        txPool.prepareTransaction(futureNonceTx, secretKey),
+        {
+          code: -32003,
+          message: "transaction underpriced"
+        },
+        "replacement transaction with insufficient gas price to replace should have been rejected"
+      );
+    });
+
+    it("rejects transactions whose potential cost is more than the account's balance", async () => {
+      const expensiveRpc: EIP1559FeeMarketRpcTransaction = {
+        from,
+        type: "0x2",
+        value: "0xfffffffffffffffffff",
+        maxFeePerGas: "0xffffff",
+        maxPriorityFeePerGas: "0xff",
+        gasLimit: "0xffff"
+      };
+      const txPool = new TransactionPool(options.miner, blockchain, origins);
+      const expensiveTx = TransactionFactory.fromRpc(expensiveRpc, common);
+      await assert.rejects(
+        txPool.prepareTransaction(expensiveTx, secretKey),
+        {
+          code: -32003,
+          message: "insufficient funds for gas * price + value"
+        },
+        "transaction whose potential cost is more than the account's balance should have been rejected"
+      );
+    });
   });
 
-  it("rejects executable replacement transactions whose gas price isn't sufficiently high", async () => {
-    const txPool = new TransactionPool(options.miner, blockchain, origins);
-    const executableTx = TransactionFactory.fromRpc(executableRpc, common);
-    const isExecutable = await txPool.prepareTransaction(
-      executableTx,
-      secretKey
-    );
-    assert(isExecutable); // our first transaction is executable
-    const { pending } = txPool.executables;
-    // our executable transaction should be found in the pending queue
-    const found = findIn(executableTx.hash.toBuffer(), pending);
-    assert.strictEqual(
-      found.serialized.toString(),
-      executableTx.serialized.toString()
-    );
+  describe("regular operation", async () => {
+    beforeEach(beforeEachSetup);
+    it("adds immediately executable transactions to the pending queue", async () => {
+      const txPool = new TransactionPool(options.miner, blockchain, origins);
+      const executableTx = TransactionFactory.fromRpc(executableRpc, common);
+      const isExecutable = await txPool.prepareTransaction(
+        executableTx,
+        secretKey
+      );
+      assert(isExecutable); // our first transaction is executable
+      const { pending } = txPool.executables;
+      // our executable transaction should be found in the pending queue
+      const found = findIn(executableTx.hash.toBuffer(), pending);
+      assert.strictEqual(
+        found.serialized.toString(),
+        executableTx.serialized.toString()
+      );
+    });
 
-    const replacementRpc = JSON.parse(JSON.stringify(executableRpc));
-    replacementRpc.maxPriorityFeePerGas = "0xffff";
-    const replacementTx1 = TransactionFactory.fromRpc(replacementRpc, common);
-    // even if the tip is high enough, the max fee isn't enough to replace, so it'll throw
-    await assert.rejects(
-      txPool.prepareTransaction(replacementTx1, secretKey),
-      {
-        code: -32003,
-        message: "transaction underpriced"
-      },
-      "replacement transaction with insufficient gas price to replace should have been rejected"
-    );
+    it("adds future nonce transactions to the future queue", async () => {
+      const txPool = new TransactionPool(options.miner, blockchain, origins);
+      const futureNonceTx = TransactionFactory.fromRpc(futureNonceRpc, common);
+      const isExecutable = await txPool.prepareTransaction(
+        futureNonceTx,
+        secretKey
+      );
+      assert(!isExecutable); // our transaction is not executable
+      // our non executable transaction should be found in the origins queue
+      const found = findIn(futureNonceTx.hash.toBuffer(), origins);
+      assert.strictEqual(
+        found.serialized.toString(),
+        futureNonceTx.serialized.toString()
+      );
+    });
 
-    replacementRpc.maxPriorityFeePerGas = executableRpc.maxPriorityFeePerGas;
-    replacementRpc.maxFeePerGas = "0xffffffffff";
-    const replacementTx2 = TransactionFactory.fromRpc(replacementRpc, common);
-    // even if the maxFee is high enough, the tip isn't enough to replace, so it'll throw
-    await assert.rejects(
-      txPool.prepareTransaction(replacementTx2, secretKey),
-      {
-        code: -32003,
-        message: "transaction underpriced"
-      },
-      "replacement transaction with insufficient gas price to replace should have been rejected"
-    );
+    it("replaces immediately executable transactions in the pending queue", async () => {
+      const txPool = new TransactionPool(options.miner, blockchain, origins);
+      const executableTx = TransactionFactory.fromRpc(executableRpc, common);
+      const isExecutable = await txPool.prepareTransaction(
+        executableTx,
+        secretKey
+      );
+      assert(isExecutable); // our first transaction is executable
+      const { pending } = txPool.executables;
+      // our executable transaction should be found in the pending queue
+      const found = findIn(executableTx.hash.toBuffer(), pending);
+      assert.strictEqual(
+        found.serialized.toString(),
+        executableTx.serialized.toString()
+      );
 
-    const legacyReplacementRpc: Transaction = {
-      from: from,
-      type: "0x0",
-      gasPrice: "0xffffffff",
-      gasLimit: "0xffff",
-      nonce: "0x0"
-    };
-    const replacementTx3 = TransactionFactory.fromRpc(
-      legacyReplacementRpc,
-      common
-    );
-    // the gasPrice is higher than the tip but lower than the maxFee, which isn't enough, so it'll throw
-    await assert.rejects(
-      txPool.prepareTransaction(replacementTx3, secretKey),
-      {
-        code: -32003,
-        message: "transaction underpriced"
-      },
-      "replacement transaction with insufficient gas price to replace should have been rejected"
-    );
-  });
+      // raise our replacement transaction's prices by exactly the price bump amount
+      const originalMaxFee = Quantity.toBigInt(executableRpc.maxFeePerGas);
+      const originalTip = Quantity.from(
+        executableRpc.maxPriorityFeePerGas
+      ).toBigInt();
+      const maxFeePremium =
+        originalMaxFee + (originalMaxFee * priceBump) / 100n;
+      const tipPremium = originalTip + (originalTip * priceBump) / 100n;
+      // our replacement transaction needs to have a sufficiently higher gasPrice
+      const replacementRpc: Transaction = {
+        from: from,
+        type: "0x2",
+        maxFeePerGas: Quantity.toString(maxFeePremium),
+        maxPriorityFeePerGas: Quantity.toString(tipPremium),
+        gasLimit: "0xffff",
+        nonce: "0x0"
+      };
+      const replacementTx = TransactionFactory.fromRpc(replacementRpc, common);
+      const replacementIsExecutable = await txPool.prepareTransaction(
+        replacementTx,
+        secretKey
+      );
+      assert(replacementIsExecutable); // our replacement transaction is executable
+      // our replacement transaction should be found in the pending queue
+      const replacementFound = findIn(replacementTx.hash.toBuffer(), pending);
+      assert.strictEqual(
+        replacementFound.serialized.toString(),
+        replacementTx.serialized.toString()
+      );
 
-  it("rejects future nonce replacement transactions whose gas price isn't sufficiently high", async () => {
-    const txPool = new TransactionPool(options.miner, blockchain, origins);
-    const futureNonceTx = TransactionFactory.fromRpc(futureNonceRpc, common);
-    const isExecutable = await txPool.prepareTransaction(
-      futureNonceTx,
-      secretKey
-    );
-    assert(!isExecutable); // our transaction is not executable
-    // our non executable transaction should be found in the origins queue
-    const found = findIn(futureNonceTx.hash.toBuffer(), origins);
-    assert.strictEqual(
-      found.serialized.toString(),
-      futureNonceTx.serialized.toString()
-    );
-    // now, if we resend the same transaction, since the gas price isn't higher,
-    // it should be rejected
-    await assert.rejects(
-      txPool.prepareTransaction(futureNonceTx, secretKey),
-      {
-        code: -32003,
-        message: "transaction underpriced"
-      },
-      "replacement transaction with insufficient gas price to replace should have been rejected"
-    );
-  });
+      // our replaced transaction should not be found anywhere in the pool
+      const originalFound = txPool.find(executableTx.hash.toBuffer());
+      assert.strictEqual(originalFound, null);
+    });
 
-  it("rejects transactions whose potential cost is more than the account's balance", async () => {
-    const expensiveRpc: EIP1559FeeMarketRpcTransaction = {
-      from,
-      type: "0x2",
-      value: "0xfffffffffffffffffff",
-      maxFeePerGas: "0xffffff",
-      maxPriorityFeePerGas: "0xff",
-      gasLimit: "0xffff"
-    };
-    const txPool = new TransactionPool(options.miner, blockchain, origins);
-    const expensiveTx = TransactionFactory.fromRpc(expensiveRpc, common);
-    await assert.rejects(
-      txPool.prepareTransaction(expensiveTx, secretKey),
-      {
-        code: -32003,
-        message: "insufficient funds for gas * price + value"
-      },
-      "transaction whose potential cost is more than the account's balance should have been rejected"
-    );
-  });
+    it("replaces future nonce transactions in the future queue", async () => {
+      const txPool = new TransactionPool(options.miner, blockchain, origins);
+      const futureNonceTx = TransactionFactory.fromRpc(futureNonceRpc, common);
+      const isExecutable = await txPool.prepareTransaction(
+        futureNonceTx,
+        secretKey
+      );
+      assert(!isExecutable); // our transaction is not executable
+      // our non executable transaction should be found in the origins queue
+      const found = findIn(futureNonceTx.hash.toBuffer(), origins);
+      assert.strictEqual(
+        found.serialized.toString(),
+        futureNonceTx.serialized.toString()
+      );
 
-  it("adds immediately executable transactions to the pending queue", async () => {
-    const txPool = new TransactionPool(options.miner, blockchain, origins);
-    const executableTx = TransactionFactory.fromRpc(executableRpc, common);
-    const isExecutable = await txPool.prepareTransaction(
-      executableTx,
-      secretKey
-    );
-    assert(isExecutable); // our first transaction is executable
-    const { pending } = txPool.executables;
-    // our executable transaction should be found in the pending queue
-    const found = findIn(executableTx.hash.toBuffer(), pending);
-    assert.strictEqual(
-      found.serialized.toString(),
-      executableTx.serialized.toString()
-    );
-  });
+      // our replacement transaction needs to have a sufficiently higher gasPrice
+      const replacementRpc: Transaction = {
+        from: from,
+        type: "0x2",
+        maxFeePerGas: "0xffffffffff",
+        maxPriorityFeePerGas: "0xffff",
+        gasLimit: "0xffff",
+        nonce: "0x2"
+      };
+      const replacementTx = TransactionFactory.fromRpc(replacementRpc, common);
+      const replacementIsExecutable = await txPool.prepareTransaction(
+        replacementTx,
+        secretKey
+      );
+      assert(!replacementIsExecutable); // our replacement transaction is also not executable
+      // our replacement transaction should be found in the origins queue
+      const replacementFound = findIn(replacementTx.hash.toBuffer(), origins);
+      assert.strictEqual(
+        replacementFound.serialized.toString(),
+        replacementTx.serialized.toString()
+      );
 
-  it("adds future nonce transactions to the future queue", async () => {
-    const txPool = new TransactionPool(options.miner, blockchain, origins);
-    const futureNonceTx = TransactionFactory.fromRpc(futureNonceRpc, common);
-    const isExecutable = await txPool.prepareTransaction(
-      futureNonceTx,
-      secretKey
-    );
-    assert(!isExecutable); // our transaction is not executable
-    // our non executable transaction should be found in the origins queue
-    const found = findIn(futureNonceTx.hash.toBuffer(), origins);
-    assert.strictEqual(
-      found.serialized.toString(),
-      futureNonceTx.serialized.toString()
-    );
-  });
+      // our replaced transaction should not be found anywhere in the pool
+      const originalFound = txPool.find(futureNonceTx.hash.toBuffer());
+      assert.strictEqual(originalFound, null);
+    });
 
-  it("replaces immediately executable transactions in the pending queue", async () => {
-    const txPool = new TransactionPool(options.miner, blockchain, origins);
-    const executableTx = TransactionFactory.fromRpc(executableRpc, common);
-    const isExecutable = await txPool.prepareTransaction(
-      executableTx,
-      secretKey
-    );
-    assert(isExecutable); // our first transaction is executable
-    const { pending } = txPool.executables;
-    // our executable transaction should be found in the pending queue
-    const found = findIn(executableTx.hash.toBuffer(), pending);
-    assert.strictEqual(
-      found.serialized.toString(),
-      executableTx.serialized.toString()
-    );
+    it("executes future transactions when the nonce gap is filled", async () => {
+      const txPool = new TransactionPool(options.miner, blockchain, origins);
+      const futureNonceTx = TransactionFactory.fromRpc(futureNonceRpc, common);
+      const futureIsExecutable = await txPool.prepareTransaction(
+        futureNonceTx,
+        secretKey
+      );
+      assert(!futureIsExecutable); // our transaction is not executable
+      // our non executable transaction should be found in the origins queue
+      const foundInOrigins = findIn(futureNonceTx.hash.toBuffer(), origins);
+      assert.strictEqual(
+        foundInOrigins.serialized.toString(),
+        futureNonceTx.serialized.toString()
+      );
 
-    // raise our replacement transaction's prices by exactly the price bump amount
-    const originalMaxFee = Quantity.toBigInt(executableRpc.maxFeePerGas);
-    const originalTip = Quantity.from(
-      executableRpc.maxPriorityFeePerGas
-    ).toBigInt();
-    const maxFeePremium = originalMaxFee + (originalMaxFee * priceBump) / 100n;
-    const tipPremium = originalTip + (originalTip * priceBump) / 100n;
-    // our replacement transaction needs to have a sufficiently higher gasPrice
-    const replacementRpc: Transaction = {
-      from: from,
-      type: "0x2",
-      maxFeePerGas: Quantity.toString(maxFeePremium),
-      maxPriorityFeePerGas: Quantity.toString(tipPremium),
-      gasLimit: "0xffff",
-      nonce: "0x0"
-    };
-    const replacementTx = TransactionFactory.fromRpc(replacementRpc, common);
-    const replacementIsExecutable = await txPool.prepareTransaction(
-      replacementTx,
-      secretKey
-    );
-    assert(replacementIsExecutable); // our replacement transaction is executable
-    // our replacement transaction should be found in the pending queue
-    const replacementFound = findIn(replacementTx.hash.toBuffer(), pending);
-    assert.strictEqual(
-      replacementFound.serialized.toString(),
-      replacementTx.serialized.toString()
-    );
+      // since the "future nonce" is 0x2, we need a 0x0 and a 0x1 nonce transaction
+      // from this origin. queue up the 0x0 one now
+      const executableTx = TransactionFactory.fromRpc(executableRpc, common);
+      const isExecutable = await txPool.prepareTransaction(
+        executableTx,
+        secretKey
+      );
+      assert(isExecutable); // our first transaction is executable
+      const { pending } = txPool.executables;
+      // our executable transaction should be found in the pending queue
+      const found = findIn(executableTx.hash.toBuffer(), pending);
+      assert.strictEqual(
+        found.serialized.toString(),
+        executableTx.serialized.toString()
+      );
 
-    // our replaced transaction should not be found anywhere in the pool
-    const originalFound = txPool.find(executableTx.hash.toBuffer());
-    assert.strictEqual(originalFound, null);
-  });
+      // now we'll send in transaction that will fill the gap between the queued
+      // tx and the account's nonce
+      // note, we're sending a transaction that doesn't have a nonce just for
+      // code coverage, to hit the lines where there 1. is an executable tx already
+      // and 2. a no-nonce tx is sent so the next highest nonce needs to be used
+      const tx = TransactionFactory.fromRpc(rpcTx, common);
+      const txIsExecutable = await txPool.prepareTransaction(tx, secretKey);
+      assert(txIsExecutable); // our next transaction is executable
+      // our executable transaction should be found in the pending queue
+      const txFound = findIn(tx.hash.toBuffer(), pending);
+      assert.strictEqual(
+        txFound.serialized.toString(),
+        tx.serialized.toString()
+      );
 
-  it("replaces future nonce transactions in the future queue", async () => {
-    const txPool = new TransactionPool(options.miner, blockchain, origins);
-    const futureNonceTx = TransactionFactory.fromRpc(futureNonceRpc, common);
-    const isExecutable = await txPool.prepareTransaction(
-      futureNonceTx,
-      secretKey
-    );
-    assert(!isExecutable); // our transaction is not executable
-    // our non executable transaction should be found in the origins queue
-    const found = findIn(futureNonceTx.hash.toBuffer(), origins);
-    assert.strictEqual(
-      found.serialized.toString(),
-      futureNonceTx.serialized.toString()
-    );
+      // now, the tx pool should have automatically marked our previously "future"
+      // tx as executable and moved it out of the origins queue.
+      const futureInPending = findIn(futureNonceTx.hash.toBuffer(), pending);
+      assert.strictEqual(
+        futureInPending.serialized.toString(),
+        futureNonceTx.serialized.toString()
+      );
+      const futureInOrigin = findIn(futureNonceTx.hash.toBuffer(), origins);
+      assert.strictEqual(futureInOrigin, undefined);
+    });
 
-    // our replacement transaction needs to have a sufficiently higher gasPrice
-    const replacementRpc: Transaction = {
-      from: from,
-      type: "0x2",
-      maxFeePerGas: "0xffffffffff",
-      maxPriorityFeePerGas: "0xffff",
-      gasLimit: "0xffff",
-      nonce: "0x2"
-    };
-    const replacementTx = TransactionFactory.fromRpc(replacementRpc, common);
-    const replacementIsExecutable = await txPool.prepareTransaction(
-      replacementTx,
-      secretKey
-    );
-    assert(!replacementIsExecutable); // our replacement transaction is also not executable
-    // our replacement transaction should be found in the origins queue
-    const replacementFound = findIn(replacementTx.hash.toBuffer(), origins);
-    assert.strictEqual(
-      replacementFound.serialized.toString(),
-      replacementTx.serialized.toString()
-    );
+    it("can be cleared/emptied", async () => {
+      const txPool = new TransactionPool(options.miner, blockchain, origins);
+      const transaction = TransactionFactory.fromRpc(rpcTx, common);
 
-    // our replaced transaction should not be found anywhere in the pool
-    const originalFound = txPool.find(futureNonceTx.hash.toBuffer());
-    assert.strictEqual(originalFound, null);
-  });
+      await txPool.prepareTransaction(transaction, secretKey);
+      const { pending } = txPool.executables;
+      // our executable transaction should be found in the pending queue
+      const found = findIn(transaction.hash.toBuffer(), pending);
+      assert.strictEqual(
+        found.serialized.toString(),
+        transaction.serialized.toString()
+      );
 
-  it("executes future transactions when the nonce gap is filled", async () => {
-    const txPool = new TransactionPool(options.miner, blockchain, origins);
-    const futureNonceTx = TransactionFactory.fromRpc(futureNonceRpc, common);
-    const futureIsExecutable = await txPool.prepareTransaction(
-      futureNonceTx,
-      secretKey
-    );
-    assert(!futureIsExecutable); // our transaction is not executable
-    // our non executable transaction should be found in the origins queue
-    const foundInOrigins = findIn(futureNonceTx.hash.toBuffer(), origins);
-    assert.strictEqual(
-      foundInOrigins.serialized.toString(),
-      futureNonceTx.serialized.toString()
-    );
+      const futureNonceTx = TransactionFactory.fromRpc(futureNonceRpc, common);
+      const futureIsExecutable = await txPool.prepareTransaction(
+        futureNonceTx,
+        secretKey
+      );
+      assert(!futureIsExecutable); // our transaction is not executable
+      // our non executable transaction should be found in the origins queue
+      const foundInOrigins = findIn(futureNonceTx.hash.toBuffer(), origins);
+      assert.strictEqual(
+        foundInOrigins.serialized.toString(),
+        futureNonceTx.serialized.toString()
+      );
 
-    // since the "future nonce" is 0x2, we need a 0x0 and a 0x1 nonce transaction
-    // from this origin. queue up the 0x0 one now
-    const executableTx = TransactionFactory.fromRpc(executableRpc, common);
-    const isExecutable = await txPool.prepareTransaction(
-      executableTx,
-      secretKey
-    );
-    assert(isExecutable); // our first transaction is executable
-    const { pending } = txPool.executables;
-    // our executable transaction should be found in the pending queue
-    const found = findIn(executableTx.hash.toBuffer(), pending);
-    assert.strictEqual(
-      found.serialized.toString(),
-      executableTx.serialized.toString()
-    );
+      txPool.clear();
+      // both queues should be empty
+      assert.strictEqual(pending.values.length, 0);
+      assert.strictEqual(origins.values.length, 0);
+    });
 
-    // now we'll send in transaction that will fill the gap between the queued
-    // tx and the account's nonce
-    // note, we're sending a transaction that doesn't have a nonce just for
-    // code coverage, to hit the lines where there 1. is an executable tx already
-    // and 2. a no-nonce tx is sent so the next highest nonce needs to be used
-    const tx = TransactionFactory.fromRpc(rpcTx, common);
-    const txIsExecutable = await txPool.prepareTransaction(tx, secretKey);
-    assert(txIsExecutable); // our next transaction is executable
-    // our executable transaction should be found in the pending queue
-    const txFound = findIn(tx.hash.toBuffer(), pending);
-    assert.strictEqual(txFound.serialized.toString(), tx.serialized.toString());
+    it("emits an event when a transaction is ready to be mined", async () => {
+      const txPool = new TransactionPool(options.miner, blockchain, origins);
+      const transaction = TransactionFactory.fromRpc(rpcTx, common);
 
-    // now, the tx pool should have automatically marked our previously "future"
-    // tx as executable and moved it out of the origins queue.
-    const futureInPending = findIn(futureNonceTx.hash.toBuffer(), pending);
-    assert.strictEqual(
-      futureInPending.serialized.toString(),
-      futureNonceTx.serialized.toString()
-    );
-    const futureInOrigin = findIn(futureNonceTx.hash.toBuffer(), origins);
-    assert.strictEqual(futureInOrigin, undefined);
-  });
+      await txPool.prepareTransaction(transaction, secretKey);
+      const drainPromise = txPool.once("drain");
+      txPool.drain();
+      await drainPromise;
 
-  it("sets the transactions nonce appropriately if omitted from the transaction", async () => {
-    const txPool = new TransactionPool(options.miner, blockchain, origins);
-    const transaction = TransactionFactory.fromRpc(rpcTx, common);
-
-    // our transaction doesn't have a nonce up front.
-    assert(transaction.nonce.isNull());
-    await txPool.prepareTransaction(transaction, secretKey);
-    // after it's prepared by the txPool, an appropriate nonce for the account is set
-    assert.strictEqual(transaction.nonce.valueOf(), Quantity.from(0).valueOf());
-  });
-
-  it("can be cleared/emptied", async () => {
-    const txPool = new TransactionPool(options.miner, blockchain, origins);
-    const transaction = TransactionFactory.fromRpc(rpcTx, common);
-
-    await txPool.prepareTransaction(transaction, secretKey);
-    const { pending } = txPool.executables;
-    // our executable transaction should be found in the pending queue
-    const found = findIn(transaction.hash.toBuffer(), pending);
-    assert.strictEqual(
-      found.serialized.toString(),
-      transaction.serialized.toString()
-    );
-
-    const futureNonceTx = TransactionFactory.fromRpc(futureNonceRpc, common);
-    const futureIsExecutable = await txPool.prepareTransaction(
-      futureNonceTx,
-      secretKey
-    );
-    assert(!futureIsExecutable); // our transaction is not executable
-    // our non executable transaction should be found in the origins queue
-    const foundInOrigins = findIn(futureNonceTx.hash.toBuffer(), origins);
-    assert.strictEqual(
-      foundInOrigins.serialized.toString(),
-      futureNonceTx.serialized.toString()
-    );
-
-    txPool.clear();
-    // both queues should be empty
-    assert.strictEqual(pending.values.length, 0);
-    assert.strictEqual(origins.values.length, 0);
-  });
-
-  it("emits an event when a transaction is ready to be mined", async () => {
-    const txPool = new TransactionPool(options.miner, blockchain, origins);
-    const transaction = TransactionFactory.fromRpc(rpcTx, common);
-
-    await txPool.prepareTransaction(transaction, secretKey);
-    const drainPromise = txPool.once("drain");
-    txPool.drain();
-    await drainPromise;
-
-    const { pending } = txPool.executables;
-    // our executable transaction should be found in the pending queue after the drain event
-    const found = findIn(transaction.hash.toBuffer(), pending);
-    assert.strictEqual(
-      found.serialized.toString(),
-      transaction.serialized.toString()
-    );
+      const { pending } = txPool.executables;
+      // our executable transaction should be found in the pending queue after the drain event
+      const found = findIn(transaction.hash.toBuffer(), pending);
+      assert.strictEqual(
+        found.serialized.toString(),
+        transaction.serialized.toString()
+      );
+    });
   });
 
   it("generates a nonce based off of the account's latest executed transaction", async () => {


### PR DESCRIPTION
#2489 documents a race condition in the transaction pool when nonces are automatically being assigned by Ganache. This ended up running pretty deep in the causes of the race condition.

### Check `inProgress` queue for highest nonce
Before this change, we would look at the pending pool first to assign a highest nonce. This is good. The pending transactions are up next to be run, so if we fetched the account's nonce from the chain instead, we'd be assigning this transaction a nonce that is about to be out of date.

However, we wouldn't check the `inProgress` pool. When a transaction is _run_ in the miner, it is removed from the `pending` pool and added to the `inProgress` pool. However, at this point, the block hasn't been saved so the account's nonce hasn't been updated yet. The `pending` pool won't contain transactions from this origin, and the account nonce is out of date.

To resolve this, I've added the `#getLatestInProgressFromOrigin` function, which will search the `inProgress` queue for transactions from this origin and get the one with the highest nonce. This lead to changing the shape of the `inProgress` pool a bit - previously it was a `Set<TypedTransaction>`, which we'd have to loop over to get all transactions from this origin. Now it is `Map<string, Set<TypedTransaction>>` so that we can reduce the number of transactions to look through - now we only check the transactions from this origin.

As a note, we don't care about the `inProgress` pool if there _are_ transactions in the `pending` pool. The `pending` pool will have the account's highest nonces, followed by the `inProgress` pool, and finally the account. So that's the priority we put on finding the nonce.

### Use Semaphore to queue same-origin transactions
If transactions come into the pool quickly enough, it's possible that multiple transactions are looking to have a nonce generated before any of them have been added to the pool. All of these transactions will have the same pool conditions - the same (or no) transactions in the `pending` and `inProgress` pools, so they will all be assigned the same nonce. This will cause all but the first to be mined to throw with an incorrect nonce error.

To solve this, we now use a semaphore to queue transactions from the same origin. Unique-origins transactions can still be prepared in parallel, but same-origin transactions are prepared in series.

### Cache account balance with `inProgress` transactions
Regardless of the above enhancement, we'd still have to make a slow trip to the database to get the account's balance. This is to verify that the sender has sufficient funds to pay for the transaction. This async call was causing a lot of race conditions, so I did my best to minimize them.

Now, when a transaction is run in the miner, we fetch the account balance (which is still in memory from running the transaction) and store it with the transaction in the `inProgress` pool. This lead to further modifying the shape of the `inProgress` pool - from `Map<string, Set<TypedTransaction>>` to `Map<string, Set<{transaction: TypedTransaction, originBalance: Quantity}>>`

Fixes #2489 and Fixes #3794