### PR TITLE
fix: `evm_setTime` doesn't work correctly with `miner.timestampIncrement`

### DIFF
--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -597,7 +597,8 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
   ) => {
     const nextBlock = this.#readyNextBlock(this.blocks.latest, timestamp);
 
-    // if block time is incremental, adjustments should only apply once, otherwise they accumulate with each block.
+    // if block time is incremental, adjustments should only apply once, 
+    // otherwise they accumulate with each block.
     if (this.#options.miner.timestampIncrement !== "clock") {
       this.#timeAdjustment = 0;
     }

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -597,7 +597,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
   ) => {
     const nextBlock = this.#readyNextBlock(this.blocks.latest, timestamp);
 
-    // if block time is incremental, adjustments should only apply once otherwise they accumulate with each block.
+    // if block time is incremental, adjustments should only apply once, otherwise they accumulate with each block.
     if (this.#options.miner.timestampIncrement !== "clock") {
       this.#timeAdjustment = 0;
     }

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -596,6 +596,11 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
     onlyOneBlock: boolean = false
   ) => {
     const nextBlock = this.#readyNextBlock(this.blocks.latest, timestamp);
+
+    // if block time is incremental, adjustments should only apply once otherwise they accumulate with each block.
+    if (this.#options.miner.timestampIncrement !== "clock") {
+      this.#timeAdjustment = 0;
+    }
     const transactions = await this.#miner.mine(
       nextBlock,
       maxTransactions,

--- a/src/chains/ethereum/ethereum/tests/provider.test.ts
+++ b/src/chains/ethereum/ethereum/tests/provider.test.ts
@@ -141,10 +141,10 @@ describe("provider", () => {
       await provider.disconnect();
     });
 
-    it("uses the adjustment only once when `timestampIncrement` is used", async () => {
+    it("applies the adjustment only once when `timestampIncrement` is used", async () => {
       const time = new Date("2019-01-01T00:00:00.000Z");
       const timestampIncrement = 5; // seconds
-      const fastForward = 100; // seconds
+      const fastForwardSeconds = 100;
       const provider = await getProvider({
         chain: { time },
         miner: { timestampIncrement }
@@ -152,12 +152,11 @@ describe("provider", () => {
 
       await provider.request({
         method: "evm_increaseTime",
-        // fastForward into the future, evm_increaseTime param is in seconds
-        params: [`0x${fastForward.toString(16)}`]
+        params: [`0x${fastForwardSeconds.toString(16)}`]
       });
 
       const mineAndAssertTimestamp = async (
-        expectedTimestamp: number,
+        expectedTimestampSeconds: number,
         message?: string
       ) => {
         await provider.request({
@@ -170,7 +169,7 @@ describe("provider", () => {
         });
         assert.strictEqual(
           timestamp,
-          `0x${expectedTimestamp.toString(16)}`,
+          `0x${expectedTimestampSeconds.toString(16)}`,
           message
         );
       };
@@ -178,15 +177,15 @@ describe("provider", () => {
       let startTimeSeconds = Math.floor(+time / 1000);
 
       await mineAndAssertTimestamp(
-        startTimeSeconds + fastForward + timestampIncrement,
+        startTimeSeconds + fastForwardSeconds + timestampIncrement,
         "unexpected timestamp for the first block mined"
       );
       await mineAndAssertTimestamp(
-        startTimeSeconds + fastForward + timestampIncrement * 2,
+        startTimeSeconds + fastForwardSeconds + timestampIncrement * 2,
         "unexpected timestamp for the second block mined"
       );
       await mineAndAssertTimestamp(
-        startTimeSeconds + fastForward + timestampIncrement * 3
+        startTimeSeconds + fastForwardSeconds + timestampIncrement * 3
       ),
         "unexpected timestamp for the third block mined";
     });


### PR DESCRIPTION
When using `miner.timestampIncrement`, calling `evm_setTime` can result in unexpected values, and potentially with an error being thrown.

This is because the `timeAdjustment` is applied to the previous blocktime, so this offset is applied for every block that is mined.

With the following example, the initial block is mined correctly, as is the first block after setting the time, but subsequent blocks will have a descending block time, until the value becomes negative.

```javascript
const p = await getProvider({
  miner: {timestampIncrement: 1},
  chain: {time : 10000}
});

const mineAndShowBlock = async () => {
  await p.send("evm_mine");
  const {number, timestamp} = await p.send("eth_getBlockByNumber", ["latest"]);

  console.log({number, timestamp: Quantity.toNumber(timestamp)});  
}
await mineAndShowBlock();

await p.send("evm_setTime", [5000]);

while(true) {
  await mineAndShowBlock();
}
```

```
{ number: '0x1', timestamp: 11 }
{ number: '0x2', timestamp: 6 }
{ number: '0x3', timestamp: 1 }

Error: Cannot wrap a negative value as a json-rpc type
```

Fixes: #3330 