### PR TITLE
test: replace `assert.equal` with `assert.strictEqual` in tests

### DIFF
--- a/src/chains/ethereum/address/tests/index.test.ts
+++ b/src/chains/ethereum/address/tests/index.test.ts
@@ -7,7 +7,7 @@ describe("@ganache/ethereum-address", () => {
       const address = new Address("0x1");
       const stringifiedAddress = address.toString();
 
-      assert.equal(
+      assert.strictEqual(
         stringifiedAddress,
         "0x0000000000000000000000000000000000000001"
       );
@@ -17,14 +17,14 @@ describe("@ganache/ethereum-address", () => {
       const address = new Address("0x1");
       const stringifiedAddress = address.toString(1);
 
-      assert.equal(stringifiedAddress, "0x01");
+      assert.strictEqual(stringifiedAddress, "0x01");
     });
 
     it("should stringify a 20 byte address string", () => {
       const address = new Address("0x2104859394604359378433865360947116707876");
       const stringifiedAddress = address.toString();
 
-      assert.equal(
+      assert.strictEqual(
         stringifiedAddress,
         "0x2104859394604359378433865360947116707876"
       );
@@ -33,7 +33,7 @@ describe("@ganache/ethereum-address", () => {
     it("should pad an address to 20 bytes when called as static function", () => {
       const stringifiedAddress = Address.toString("0x1");
 
-      assert.equal(
+      assert.strictEqual(
         stringifiedAddress,
         "0x0000000000000000000000000000000000000001"
       );
@@ -54,7 +54,7 @@ describe("@ganache/ethereum-address", () => {
       const address = new Address("0x2104859394604359378433865360947116707876");
       const stringifiedAddress = address.toString(1);
 
-      assert.equal(stringifiedAddress, "0x21");
+      assert.strictEqual(stringifiedAddress, "0x21");
     });
 
     it("should convert a 20 byte address to a buffer", () => {

--- a/src/chains/ethereum/ethereum/tests/blockchain.test.ts
+++ b/src/chains/ethereum/ethereum/tests/blockchain.test.ts
@@ -82,11 +82,14 @@ describe("blockchain", async () => {
           try {
             const blockNumber = block.header.number.toString();
             const expectedBlockNumber = startingBlockNumber + i + 1;
-            assert.equal(blockNumber, `0x${expectedBlockNumber.toString(16)}`);
-            assert.equal(transactions.length, 1);
+            assert.strictEqual(
+              blockNumber,
+              `0x${expectedBlockNumber.toString(16)}`
+            );
+            assert.strictEqual(transactions.length, 1);
 
             const transaction = transactions[0];
-            assert.equal(
+            assert.strictEqual(
               transaction.hash.toString(),
               transactionHashes[i].toString()
             );

--- a/src/chains/ethereum/options/tests/index.test.ts
+++ b/src/chains/ethereum/options/tests/index.test.ts
@@ -38,7 +38,7 @@ describe("EthereumOptionsConfig", () => {
       const options = EthereumOptionsConfig.normalize({
         wallet: { totalAccounts: 7 }
       });
-      assert.equal(options.wallet.totalAccounts, 7);
+      assert.strictEqual(options.wallet.totalAccounts, 7);
     });
     it("throws an error when an option conflict is found", () => {
       assert.throws(() => {
@@ -55,7 +55,7 @@ describe("EthereumOptionsConfig", () => {
       it("accepts some legacy input formats", () => {
         const seed = "from their voids, cry to the dolphined sea";
         const options = EthereumOptionsConfig.normalize({ seed } as Object);
-        assert.equal(options.wallet.seed, seed);
+        assert.strictEqual(options.wallet.seed, seed);
       });
       it("errors if there is a conflict with legacy inputs", () => {
         const seed = "I ate three cookies";

--- a/src/packages/utils/tests/json-rpc-data.test.ts
+++ b/src/packages/utils/tests/json-rpc-data.test.ts
@@ -47,7 +47,7 @@ describe("json-rpc-data", () => {
         "hex"
       )}`, () => {
         const result = new Data(<Buffer>input).toString();
-        assert.equal(result, expected);
+        assert.strictEqual(result, expected);
       });
     });
 
@@ -55,12 +55,12 @@ describe("json-rpc-data", () => {
       const result = new Data(
         Buffer.from([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef])
       ).toString(1);
-      assert.equal(result, "0x01");
+      assert.strictEqual(result, "0x01");
     });
 
     it("should pad to a longer byteLength", () => {
       const result = new Data(Buffer.from([0x01])).toString(10);
-      assert.equal(result, "0x00000000000000000001");
+      assert.strictEqual(result, "0x00000000000000000001");
     });
   });
 
@@ -113,7 +113,7 @@ describe("json-rpc-data", () => {
     it("should return false for any non-empty buffer", () => {
       [Buffer.allocUnsafe(1), Buffer.allocUnsafe(2)].forEach(input => {
         const data = new Data(input);
-        assert.equal(data.isNull(), false);
+        assert.strictEqual(data.isNull(), false);
       });
     });
   });

--- a/src/packages/utils/tests/json-rpc-quantity.test.ts
+++ b/src/packages/utils/tests/json-rpc-quantity.test.ts
@@ -14,7 +14,12 @@ const testData = [
     0x0123456789abcdef,
     Buffer.from([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef])
   ],
-  [Buffer.from([0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), "0x10000000000000", 0x10000000000000, Buffer.from([ 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])]
+  [
+    Buffer.from([0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+    "0x10000000000000",
+    0x10000000000000,
+    Buffer.from([0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+  ]
 ];
 
 const nullLikeInputs = [null, undefined, Buffer.alloc(0)];
@@ -70,14 +75,14 @@ describe("json-rpc-quantity", () => {
     it("should return 0x0 for a non-empty buffer of 0x00 bytes", () => {
       const result = new Quantity(Buffer.alloc(10), true).toString();
 
-      assert.equal(result, "0x0");
+      assert.strictEqual(result, "0x0");
     });
 
     it(`should return "0x0" for null-like inputs`, () => {
       nullLikeInputs.forEach(input => {
         const result = new Quantity(input, false).toString();
 
-        assert.equal(result, "0x0");
+        assert.strictEqual(result, "0x0");
       });
     });
 
@@ -88,7 +93,7 @@ describe("json-rpc-quantity", () => {
         [true, false].forEach(nullable => {
           const result = new Quantity(input, nullable).toString();
 
-          assert.equal(result, expected);
+          assert.strictEqual(result, expected);
         });
       });
     });
@@ -106,14 +111,14 @@ describe("json-rpc-quantity", () => {
     it("should return null for empty input", () => {
       const result = new Quantity(Buffer.alloc(0), true).toNumber();
 
-      assert.equal(result, null);
+      assert.strictEqual(result, null);
     });
 
     it("should return 0 for null-like inputs", () => {
       nullLikeInputs.forEach(input => {
         const result = new Quantity(input, false).toNumber();
 
-        assert.equal(result, 0);
+        assert.strictEqual(result, 0);
       });
     });
 
@@ -124,7 +129,7 @@ describe("json-rpc-quantity", () => {
         [true, false].forEach(nullable => {
           const result = new Quantity(input, nullable).toNumber();
 
-          assert.equal(result, expected);
+          assert.strictEqual(result, expected);
         });
       });
     });
@@ -182,7 +187,7 @@ describe("json-rpc-quantity", () => {
         [Buffer.alloc(1), Buffer.alloc(2)].forEach(input => {
           const quantity = new Quantity(input, nullable);
 
-          assert.equal(quantity.isNull(), false);
+          assert.strictEqual(quantity.isNull(), false);
         });
       });
     });


### PR DESCRIPTION
Fixes #3504 