### PR TITLE
fix: assume unknown tx type is `TransactionType.Legacy`

### DIFF
--- a/src/chains/ethereum/transaction/src/transaction-factory.ts
+++ b/src/chains/ethereum/transaction/src/transaction-factory.ts
@@ -38,8 +38,6 @@ function assertValidTransactionSValue(common: Common, tx: TypedTransaction) {
   }
 }
 
-const UNTYPED_TX_START_BYTE = 0xc0; // all txs with first byte >= 0xc0 are untyped
-
 export enum TransactionType {
   Legacy = 0x0,
   EIP2930AccessList = 0x1,
@@ -265,14 +263,8 @@ export class TransactionFactory {
       type === TransactionType.EIP2930AccessList
     ) {
       return type;
-    } else if (
-      type >= UNTYPED_TX_START_BYTE ||
-      type === TransactionType.Legacy ||
-      type === undefined
-    ) {
-      return TransactionType.Legacy;
     } else {
-      throw new Error(`Invalid transaction type: ${type}`);
+      return TransactionType.Legacy;
     }
   }
 

--- a/src/chains/ethereum/transaction/tests/index.test.ts
+++ b/src/chains/ethereum/transaction/tests/index.test.ts
@@ -61,12 +61,8 @@ describe("@ganache/ethereum-transaction", async () => {
     type: "0x0",
     gasPrice: "0xffff"
   };
-  const unknownTypeTx: Transaction = {
-    from: from,
-    to: to,
-    type: "0x55",
-    gasPrice: "0xffff"
-  };
+  
+  const UNTYPED_TX_START_BYTE = 0xc0; // all txs with first byte >= 0xc0 are untyped
 
   const rawLegacyStrTx =
     "0xf8618082ffff80945a17650be84f28ed583e93e6ed0c99b1d1fc1b348080820a95a0d9c2d3cb65d7079f528d28d782fe752ed698381481f7b91790e067ea335c1dc0a0731131778ae061aa29567cc6b36fe3528092b687fb68c3f529493fca200c711d";
@@ -151,6 +147,36 @@ describe("@ganache/ethereum-transaction", async () => {
         assert.strictEqual(txFromRpc.type.toString(), "0x0");
       });
       it("assumes legacy transaction if type unknown", () => {
+        const unknownTypeTx: Transaction = {
+          from: from,
+          to: to,
+          type: "0x55",
+          gasPrice: "0xffff"
+        };
+        txFromRpc = <LegacyTransaction>(
+          TransactionFactory.fromRpc(unknownTypeTx, common)
+        );
+        assert.strictEqual(txFromRpc.type.toString(), "0x0");
+      });
+      it(`assumes legacy transaction if type ${UNTYPED_TX_START_BYTE}`, () => {
+        const unknownTypeTx = {
+          from: from,
+          to: to,
+          type: "0x" + UNTYPED_TX_START_BYTE.toString(16),
+          gasPrice: "0xffff"
+        };
+        txFromRpc = <LegacyTransaction>(
+          TransactionFactory.fromRpc(unknownTypeTx, common)
+        );
+        assert.strictEqual(txFromRpc.type.toString(), "0x0");
+      });
+      it(`assumes legacy transaction if type > ${UNTYPED_TX_START_BYTE}`, () => {
+        const unknownTypeTx = {
+          from: from,
+          to: to,
+          type: "0x" + (UNTYPED_TX_START_BYTE + 1).toString(16),
+          gasPrice: "0xffff"
+        };
         txFromRpc = <LegacyTransaction>(
           TransactionFactory.fromRpc(unknownTypeTx, common)
         );

--- a/src/chains/ethereum/transaction/tests/index.test.ts
+++ b/src/chains/ethereum/transaction/tests/index.test.ts
@@ -61,6 +61,12 @@ describe("@ganache/ethereum-transaction", async () => {
     type: "0x0",
     gasPrice: "0xffff"
   };
+  const unknownTypeTx: Transaction = {
+    from: from,
+    to: to,
+    type: "0x55",
+    gasPrice: "0xffff"
+  };
 
   const rawLegacyStrTx =
     "0xf8618082ffff80945a17650be84f28ed583e93e6ed0c99b1d1fc1b348080820a95a0d9c2d3cb65d7079f528d28d782fe752ed698381481f7b91790e067ea335c1dc0a0731131778ae061aa29567cc6b36fe3528092b687fb68c3f529493fca200c711d";
@@ -141,6 +147,12 @@ describe("@ganache/ethereum-transaction", async () => {
       it("infers legacy transaction if type omitted", () => {
         txFromRpc = <LegacyTransaction>(
           TransactionFactory.fromRpc(untypedTx, common)
+        );
+        assert.strictEqual(txFromRpc.type.toString(), "0x0");
+      });
+      it("assumes legacy transaction if type unknown", () => {
+        txFromRpc = <LegacyTransaction>(
+          TransactionFactory.fromRpc(unknownTypeTx, common)
         );
         assert.strictEqual(txFromRpc.type.toString(), "0x0");
       });
@@ -557,17 +569,6 @@ describe("@ganache/ethereum-transaction", async () => {
   });
 
   describe("Error and helper cases", () => {
-    it("does not allow unsupported tx types from rpc data", async () => {
-      const rpc: Transaction = {
-        from: from,
-        to: to,
-        type: "0x55",
-        gasPrice: "0xffff"
-      };
-      assert.throws(() => {
-        TransactionFactory.fromRpc(rpc, common);
-      });
-    });
     it("does not allow unsupported tx types from raw buffer data", async () => {
       const db = [
         Buffer.from("0x55"),
@@ -588,12 +589,6 @@ describe("@ganache/ethereum-transaction", async () => {
           db as TypedDatabaseTransaction,
           common
         );
-      });
-    });
-    it("does not allow unsupported tx types from raw string data", async () => {
-      const str: string = "0x55";
-      assert.throws(() => {
-        TransactionFactory.fromString(str, common);
       });
     });
     it("gets tx type from raw data", async () => {


### PR DESCRIPTION
Fixes #3489
Fixes #3458