### PR TITLE
fix: return exactly 32 bytes from `eth_getStorageAt`

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -1781,7 +1781,7 @@ export default class EthereumApi implements Api {
     const addressStateRoot = decode<EthereumRawAccount>(addressData)[2];
     trie.setContext(addressStateRoot, addressBuf, blockNum);
     const value = await trie.get(paddedPosBuff);
-    return Data.from(decode(value));
+    return Data.from(decode(value), 32);
   }
 
   /**

--- a/src/chains/ethereum/ethereum/tests/api/eth/getStorageAt.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getStorageAt.test.ts
@@ -53,7 +53,10 @@ describe("api", () => {
           contractAddress,
           "0x1"
         ]);
-        assert.strictEqual(result2, "0x01");
+        assert.strictEqual(
+          result2,
+          "0x0000000000000000000000000000000000000000000000000000000000000001"
+        );
       });
 
       it("returns the value at the 32-byte hex position", async () => {
@@ -66,7 +69,10 @@ describe("api", () => {
           contractAddress,
           "0x" + THIRTY_TWO_BYES.slice(-1) + "1"
         ]);
-        assert.strictEqual(result2, "0x01");
+        assert.strictEqual(
+          result2,
+          "0x0000000000000000000000000000000000000000000000000000000000000001"
+        );
       });
 
       it("returns the value even when hex positions exceeds 32-bytes", async () => {
@@ -81,7 +87,10 @@ describe("api", () => {
           contractAddress,
           thirtyThreeBytePosition2
         ]);
-        assert.strictEqual(result2, "0x01");
+        assert.strictEqual(
+          result2,
+          "0x0000000000000000000000000000000000000000000000000000000000000001"
+        );
       });
 
       it("rejects when the block doesn't exist", async () => {

--- a/src/chains/ethereum/ethereum/tests/api/eth/getStorageAt.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/getStorageAt.test.ts
@@ -3,7 +3,6 @@ import assert from "assert";
 import { EthereumProvider } from "../../../src/provider";
 import compile, { CompileOutput } from "../../helpers/compile";
 import { join } from "path";
-const THIRTY_TWO_BYES = "0".repeat(64);
 
 describe("api", () => {
   describe("eth", () => {
@@ -62,12 +61,12 @@ describe("api", () => {
       it("returns the value at the 32-byte hex position", async () => {
         const result = await provider.send("eth_getStorageAt", [
           contractAddress,
-          "0x" + THIRTY_TWO_BYES
+          "0x0000000000000000000000000000000000000000000000000000000000000000"
         ]);
         assert.strictEqual(BigInt(result), 123n);
         const result2 = await provider.send("eth_getStorageAt", [
           contractAddress,
-          "0x" + THIRTY_TWO_BYES.slice(-1) + "1"
+          "0x0000000000000000000000000000000000000000000000000000000000000001"
         ]);
         assert.strictEqual(
           result2,
@@ -76,13 +75,15 @@ describe("api", () => {
       });
 
       it("returns the value even when hex positions exceeds 32-bytes", async () => {
-        const thirtyThreeBytePosition = "0x1" + THIRTY_TWO_BYES;
+        const thirtyThreeBytePosition =
+          "0x10000000000000000000000000000000000000000000000000000000000000000";
         const result = await provider.send("eth_getStorageAt", [
           contractAddress,
           thirtyThreeBytePosition
         ]);
         assert.strictEqual(BigInt(result), 123n);
-        const thirtyThreeBytePosition2 = "0x" + THIRTY_TWO_BYES + "1";
+        const thirtyThreeBytePosition2 =
+          "0x00000000000000000000000000000000000000000000000000000000000000001";
         const result2 = await provider.send("eth_getStorageAt", [
           contractAddress,
           thirtyThreeBytePosition2

--- a/src/chains/ethereum/ethereum/tests/api/evm/evm.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/evm/evm.test.ts
@@ -283,7 +283,7 @@ describe("api", () => {
         const [account] = await provider.send("eth_accounts");
         const slot =
           "0x0000000000000000000000000000000000000000000000000000000000000005";
-        const newStorage = Data.from("0xbaddad42");
+        const newStorage = Data.from("0xbaddad42", 32);
         const initialStorage = await provider.send("eth_getStorageAt", [
           account,
           slot

--- a/src/chains/ethereum/ethereum/tests/temp-tests.test.ts
+++ b/src/chains/ethereum/ethereum/tests/temp-tests.test.ts
@@ -136,7 +136,10 @@ describe("Random tests that are temporary!", () => {
       "0x0",
       receipt.blockNumber
     ]);
-    assert.strictEqual(storage, "0x05");
+    assert.strictEqual(
+      storage,
+      "0x0000000000000000000000000000000000000000000000000000000000000005"
+    );
 
     const raw25 =
       "0000000000000000000000000000000000000000000000000000000000000019";
@@ -159,7 +162,10 @@ describe("Random tests that are temporary!", () => {
       "0x0",
       txReceipt.blockNumber
     ]);
-    assert.strictEqual(storage2, "0x19");
+    assert.strictEqual(
+      storage2,
+      "0x0000000000000000000000000000000000000000000000000000000000000019"
+    );
   });
 
   it("transfers value", async () => {


### PR DESCRIPTION
`eth_getStorageAt` was returning compact representations of data, e.g., `"0x5"` instead of `"0x0000000000000000000000000000000000000000000000000000000000000005"`. We now always return the padded whole 32 byte word.

Fixes #3526