### PR TITLE
ci: add config for semantic-prs app

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,5 +1,5 @@
 # validates that the PR title has a semantic commit message; ignores commits
 titleOnly: true
-# a custom URL for the "Details" link (which appears next to the success/failure
+# custom URL for the "Details" link (which appears next to the success/failure
 # message from the app) to be specified
 targetUrl: https://github.com/trufflesuite/ganache/blob/develop/CONTRIBUTING.md#pull-requests

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -2,4 +2,4 @@
 titleOnly: true
 # custom URL for the "Details" link (which appears next to the success/failure
 # message from the app) to be specified
-targetUrl: https://github.com/trufflesuite/ganache/blob/develop/CONTRIBUTING.md#pull-requests
+targetUrl: "https://github.com/trufflesuite/ganache/blob/develop/CONTRIBUTING.md#pull-requests"

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,5 @@
+# validates that the PR title has a semantic commit message; ignores commits
+titleOnly: true
+# a custom URL for the "Details" link (which appears next to the success/failure
+# message from the app) to be specified
+targetUrl: https://github.com/trufflesuite/ganache/blob/develop/CONTRIBUTING.md#pull-requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ find useful.
 
 We _always_ "Squash and Merge" Pull Requests into a single commit message when merging into the `develop` branch.
 
-The "Squash and Merge" commit message _must_ be in the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format:
+The PR title and "Squash and Merge" commit message _must_ be in the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format. The [semantic-prs](https://github.com/Ezard/semantic-prs#readme) Github app is enabled for the repo and configured to require a PR title in the conventional commit format. When you "Squash and Merge", the commit message will automatically pull from the PR title, so just don't change this and there shouldn't be any issues. The conventional commit format is as follows:
 
 ```
 <type>[optional scope]: <description> (#PR Number)


### PR DESCRIPTION
This change adds a `semantic.yml` file to configure how the Semantic-PRs app interacts with Ganache. This app will now require that all pull requests have a title with a [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).