### PR TITLE
docs: add trufflesuite.com to README

### DIFF
--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -585,8 +585,9 @@ See [CONTRIBUTING.md](https://github.com/trufflesuite/ganache/blob/develop/CONTR
 
 ## Related
 
-- [Truffle](https://www.github.com/trufflesuite/truffle)
-- [Drizzle](https://www.github.com/trufflesuite/drizzle)
+- [Truffle GitHub](https://www.github.com/trufflesuite/truffle)
+- [Drizzle GitHub](https://www.github.com/trufflesuite/drizzle)
+- [Truffle Suite Website](https://www.trufflesuite.com/)
 
 <br/>
 


### PR DESCRIPTION
We just thought it'd be useful to have a link to our website on our README :link: 