### PR TITLE
chore: add sepolia as a network option

### DIFF
--- a/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
@@ -1223,9 +1223,9 @@ describe("forking", function () {
         block: "0x595434"
       },
       sepolia: {
-        address: "0x9d525E28Fe5830eE92d7Aa799c4D21590567B595",
-        balance: "0x81744abdb769a3b6dc08b",
-        block: "0x595434"
+        address: "0xd7d76c58b3a519e9fA6Cc4D22dC017259BC49F1E",
+        balance: "0x52b7d2dcc80cd2e4000000",
+        block: "0x1AD62D"
       }
     };
     let localProvider: EthereumProvider;

--- a/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
@@ -1221,6 +1221,11 @@ describe("forking", function () {
         address: "0x9d525E28Fe5830eE92d7Aa799c4D21590567B595",
         balance: "0x81744abdb769a3b6dc08b",
         block: "0x595434"
+      },
+      sepolia: {
+        address: "0x9d525E28Fe5830eE92d7Aa799c4D21590567B595",
+        balance: "0x81744abdb769a3b6dc08b",
+        block: "0x595434"
       }
     };
     let localProvider: EthereumProvider;

--- a/src/chains/ethereum/options/src/fork-options.ts
+++ b/src/chains/ethereum/options/src/fork-options.ts
@@ -17,14 +17,16 @@ type KnownNetworks =
   | "kovan"
   | "rinkeby"
   | "goerli"
-  | "görli";
+  | "görli"
+  | "sepolia";
 export const KNOWN_NETWORKS = [
   "mainnet",
   "ropsten",
   "kovan",
   "rinkeby",
   "goerli",
-  "görli"
+  "görli",
+  "sepolia"
 ] as UnionToTuple<KnownNetworks>;
 
 export type ForkConfig = {

--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -381,8 +381,8 @@ Fork:
 
                                         Use the shorthand command ganache --fork to automatically fork from
                                         Mainnet at the latest block.
-                                        [choices: "mainnet", "ropsten", "kovan", "rinkeby", "goerli", "görli"]
-
+                                        [choices: "mainnet", "ropsten", "kovan", "rinkeby", "goerli", "görli"
+                                                                                                    "sepolia"]
   --fork.blockNumber                    Block number the provider should fork from.
                                                                                 [default: Latest block number]
 

--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -381,7 +381,7 @@ Fork:
 
                                         Use the shorthand command ganache --fork to automatically fork from
                                         Mainnet at the latest block.
-                                        [choices: "mainnet", "ropsten", "kovan", "rinkeby", "goerli", "görli"
+                                        [choices: "mainnet", "ropsten", "kovan", "rinkeby", "goerli", "görli",
                                                                                                     "sepolia"]
   --fork.blockNumber                    Block number the provider should fork from.
                                                                                 [default: Latest block number]


### PR DESCRIPTION
No code changes here. Just adding sepolia as a network option.