### PR TITLE
ci: fix docker publish

### DIFF
--- a/.github/actions/docker-publish/action.yml
+++ b/.github/actions/docker-publish/action.yml
@@ -66,7 +66,7 @@ runs:
         context: .
         file: ./src/packages/ganache/Dockerfile
         push: true
-        tags: ${{ format('trufflesuite/ganache:{0}, trufflesuite/ganache:v{1}', inputs.TAG, inputs.VERSION) }}
+        tags: trufflesuite/ganache:${{ inputs.TAG }}, trufflesuite/ganache:v${{ inputs.VERSION }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: linux/arm64/v8,linux/amd64
         build-args: |

--- a/.github/actions/docker-publish/action.yml
+++ b/.github/actions/docker-publish/action.yml
@@ -66,7 +66,7 @@ runs:
         context: .
         file: ./src/packages/ganache/Dockerfile
         push: true
-        tags: trufflesuite/ganache:${{ inputs.TAG }}, trufflesuite/ganache:v${{ inputs.VERSION }}
+        tags: ${{ format('trufflesuite/ganache:{0}, trufflesuite/ganache:v{1}', inputs.TAG, inputs.VERSION) }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: linux/arm64/v8,linux/amd64
         build-args: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,15 +42,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run installation
-        run: npm ci
-
-      - name: Test
-        run: npm test
-        env:
-          FORCE_COLOR: 1
-          INFURA_KEY: ${{ secrets.TEST_INFURA_KEY }}
-
       - name: Set TAG for master to latest
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
@@ -99,6 +90,15 @@ jobs:
         # if we are "latest" and we do NOT have features, set the release to "patch"
         if: ${{ env.TAG == 'latest' && env.FEATURE_COUNT == '0' }}
         run: echo "RELEASE_KIND=patch" >> $GITHUB_ENV
+
+      - name: Run installation
+        run: npm ci
+
+      - name: Test
+        run: npm test
+        env:
+          FORCE_COLOR: 1
+          INFURA_KEY: ${{ secrets.TEST_INFURA_KEY }}
 
       - name: Update package versions for latest release (master)
         if: ${{ env.TAG == 'latest' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
     # pr.yml
     runs-on: ubuntu-20.04
     outputs:
-      TAG: ${{ steps.setTagOutput.TAG }}
-      VERSION: ${{ steps.setVersionOutput.VERSION }}
+      TAG: ${{ steps.set_tag_output.outputs.TAG }}
+      VERSION: ${{ steps.set_version_output.outputs.VERSION }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -52,7 +52,8 @@ jobs:
         run: |
           echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
-      - id: setTagOutput
+      - name: Set TAG as job output variable
+        id: set_tag_output
         run: echo "::set-output name=TAG::${TAG}"
 
       - name: Count features
@@ -125,7 +126,8 @@ jobs:
         run: |
           echo "VERSION=$(node -e 'console.log(require("./src/packages/ganache/package.json").version)')" >> $GITHUB_ENV
 
-      - id: setVersionOutput
+      - name: Set VERSION as job output variable
+        id: set_version_output
         run: echo "::set-output name=VERSION::${VERSION}"
 
       - name: Commit all staged changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
     # this should match the os version used by the "check bundle size" step in
     # pr.yml
     runs-on: ubuntu-20.04
+    outputs:
+      TAG: ${{ steps.setTagOutput.TAG }}
+      VERSION: ${{ steps.setVersionOutput.VERSION }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -57,6 +60,9 @@ jobs:
         if: ${{ github.ref != 'refs/heads/master' }}
         run: |
           echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - id: setTagOutput
+        run: echo "::set-output name=TAG::${TAG}"
 
       - name: Count features
         if: ${{ env.TAG == 'latest'}}
@@ -119,6 +125,9 @@ jobs:
         run: |
           echo "VERSION=$(node -e 'console.log(require("./src/packages/ganache/package.json").version)')" >> $GITHUB_ENV
 
+      - id: setVersionOutput
+        run: echo "::set-output name=VERSION::${VERSION}"
+
       - name: Commit all staged changes
         run: |
           git commit -m "chore(release): publish v${VERSION}" -m "ganache@${VERSION}"
@@ -171,8 +180,8 @@ jobs:
         # containing an `action.yml` file
         uses: ./.github/actions/docker-publish
         with:
-          VERSION: ${{ env.VERSION }}
-          TAG: ${{ env.TAG }}
+          VERSION: ${{ needs.release.outputs.VERSION }}
+          TAG: ${{ needs.release.outputs.TAG }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           INFURA_KEY: ${{ secrets.INFURA_KEY }}


### PR DESCRIPTION
This code was tested as an alpha release. The run can be seen here: https://github.com/trufflesuite/ganache/runs/8215680896?check_suite_focus=true

The problem with the original PR (#3547) that this fixes was that the environment variables are not persisted from job to job. This fix saves those environment variables that are needed in the subsequent docker publish job.