### PR TITLE
fix: set default hardfork to london

### DIFF
--- a/src/chains/ethereum/block/tests/index.test.ts
+++ b/src/chains/ethereum/block/tests/index.test.ts
@@ -50,7 +50,7 @@ describe("@ganache/ethereum-block", async () => {
           comment: "Local test network",
           bootstrapNodes: []
         },
-        "grayGlacier"
+        "london"
       );
       blockchain = new Blockchain(options, fromAddress);
       await blockchain.initialize(wallet.initialAccounts);

--- a/src/chains/ethereum/ethereum/tests/api/eth/sendTransaction.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/sendTransaction.test.ts
@@ -82,7 +82,7 @@ describe("api", () => {
                   value: `0x${(balance - approximateGasCost).toString(16)}`
                 }),
                 new RegExp(
-                  `VM Exception while processing transaction: sender doesn't have enough funds to send tx\\. The upfront cost is: \\d+ and the sender's account \\(${from}\\) only has: \\d+ \\(vm hf=grayGlacier -> block -> tx\\)`
+                  `VM Exception while processing transaction: sender doesn't have enough funds to send tx\\. The upfront cost is: \\d+ and the sender's account \\(${from}\\) only has: \\d+ \\(vm hf=london -> block -> tx\\)`
                 )
               );
             } finally {

--- a/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
+++ b/src/chains/ethereum/ethereum/tests/miner/miner.test.ts
@@ -29,7 +29,7 @@ describe("miner", async () => {
           comment: "Local test network",
           bootstrapNodes: []
         },
-        "grayGlacier"
+        "london"
       );
       const optionsJson = {
         wallet: {

--- a/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
+++ b/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
@@ -76,7 +76,7 @@ describe("transaction pool", async () => {
         comment: "Local test network",
         bootstrapNodes: []
       },
-      "grayGlacier"
+      "london"
     );
     // we're spoofing a minimal fake blockchain for the tx pool that just
     // returns an account's nonce

--- a/src/chains/ethereum/options/src/chain-options.ts
+++ b/src/chains/ethereum/options/src/chain-options.ts
@@ -110,7 +110,7 @@ export type ChainConfig = {
 
     /**
      * Set the hardfork rules for the EVM.
-     * @defaultValue "grayGlacier"
+     * @defaultValue "london"
      */
     readonly hardfork: {
       type: Hardfork;
@@ -196,7 +196,7 @@ export const ChainOptions: Definitions<ChainConfig> = {
   hardfork: {
     normalize,
     cliDescription: "Set the hardfork rules for the EVM.",
-    default: () => "grayGlacier",
+    default: () => "london",
     legacyName: "hardfork",
     cliAliases: ["k", "hardfork"],
     cliType: "string",

--- a/src/chains/ethereum/transaction/tests/index.test.ts
+++ b/src/chains/ethereum/transaction/tests/index.test.ts
@@ -29,7 +29,7 @@ describe("@ganache/ethereum-transaction", async () => {
       comment: "Local test network",
       bootstrapNodes: []
     },
-    "grayGlacier"
+    "london"
   );
   // #region configure accounts and private keys in wallet
   const privKey = `0x${"46".repeat(32)}`;
@@ -61,7 +61,7 @@ describe("@ganache/ethereum-transaction", async () => {
     type: "0x0",
     gasPrice: "0xffff"
   };
-  
+
   const UNTYPED_TX_START_BYTE = 0xc0; // all txs with first byte >= 0xc0 are untyped
 
   const rawLegacyStrTx =

--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -259,7 +259,7 @@ Chain:
   -k, --chain.hardfork                  Set the hardfork rules for the EVM.
                                         deprecated aliases: --hardfork
           [string] [choices: "constantinople", "byzantium", "petersburg", "istanbul", "muirGlacier", "berlin",
-                                                london", "arrowGlacier", "grayGlacier"] [default: grayGlacier]
+                                                london", "arrowGlacier", "grayGlacier"] [default: london
 
   --chain.vmErrorsOnRPCResponse         Whether to report runtime errors from EVM code as RPC errors.
                                                                                     [boolean] [default: false]


### PR DESCRIPTION
In #3534, we updated Ganache to use Gray Glacier as the default hardfork. This broke forking testnets using Ganache because the test nets do not support Gray Glacier. This PR keeps support for Gray Glacier, but reverts the default hardfork to London so that forking testnets will work out of the box.