### PR TITLE
docs: fix typo in fork.username cli description

### DIFF
--- a/src/chains/ethereum/options/src/fork-options.ts
+++ b/src/chains/ethereum/options/src/fork-options.ts
@@ -393,7 +393,7 @@ Use the shorthand command \`ganache --fork\` to automatically fork from Mainnet 
   },
   username: {
     normalize,
-    cliDescription: `* Username to use for Basic Authentication. Does not require setting \`fork.password\`.
+    cliDescription: `Username to use for Basic Authentication. Does not require setting \`fork.password\`.
     
 When combined with \`fork.password\`, is shorthand for \`fork: { headers: { "Authorization": "Basic {ENCODED-BASIC-HEADER}" } }\`
 


### PR DESCRIPTION
Just fixing a typo in the CLI's `--help` description for the `--fork.username` option.