### PR TITLE
fix: use zero address when unable to calculate 'from'

### DIFF
--- a/lib/utils/transaction.js
+++ b/lib/utils/transaction.js
@@ -235,10 +235,17 @@ module.exports = class Transaction extends EthereumJsTransaction {
    * into an identical Transaction via `Transaction.decode(encodedTx)`.
    */
   encode() {
+    var from;
+    try {
+      from = to.rpcDataHexString(this.from);
+    }
+    catch {
+      from = "0x0000000000000000000000000000000000000000";
+    }
     const resultJSON = {
       hash: to.nullableRpcDataHexString(this.hash()),
       nonce: to.nullableRpcQuantityHexString(this.nonce) || "0x",
-      from: to.rpcDataHexString(this.from),
+      from: from,
       to: to.nullableRpcDataHexString(this.to),
       value: to.nullableRpcQuantityHexString(this.value),
       gas: to.nullableRpcQuantityHexString(this.gasLimit),
@@ -309,13 +316,20 @@ module.exports = class Transaction extends EthereumJsTransaction {
       }
     }
 
+    var from;
+    try {
+      from = to.rpcDataHexString(this.from);
+    }
+    catch {
+      from = "0x0000000000000000000000000000000000000000";
+    }
     const resultJSON = {
       hash: to.nullableRpcDataHexString(hash),
       nonce: to.rpcQuantityHexString(this.nonce),
       blockHash: to.nullableRpcDataHexString(block.hash()),
       blockNumber: to.nullableRpcQuantityHexString(block.header.number),
       transactionIndex: to.nullableRpcQuantityHexString(transactionIndex),
-      from: to.rpcDataHexString(this.from),
+      from: from,
       to: to.nullableRpcDataHexString(this.to),
       value: to.rpcQuantityHexString(this.value),
       gas: to.rpcQuantityHexString(this.gasLimit),


### PR DESCRIPTION
I'm trying to fork a evm-compatible chain with ganache-ui, but my chain contains custom signatures and when block that is used as a fork point has transaction with custom signature ganache application crashes on Transactions screen.
The problem comes from Transaction.from getter function which throws if signature is invalid and causes ui to crash.
This PR simply uses zero address as 'from' field instead of throwing an exception.