### PR TITLE
feat: package ganache as a snap

### DIFF
--- a/src/packages/ganache/npm-shrinkwrap.json
+++ b/src/packages/ganache/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
 	"name": "ganache",
-	"version": "7.3.0",
+	"version": "7.4.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/packages/ganache/snapcraft.yaml
+++ b/src/packages/ganache/snapcraft.yaml
@@ -1,0 +1,17 @@
+name: ganach3
+version: "1.0.0"
+summary: Ganache
+description: Something more verbose later.
+confinement: strict
+base: core20
+
+apps:
+  ganacho:
+    command: bin/ganache
+    plugs: [network]
+
+parts:
+  ganacho:
+    plugin: npm
+    npm-node-version: 14.16.1
+    source: .


### PR DESCRIPTION
Adds a `snapcraft.yaml` to the `src/packages/ganache` directory that contains the configuration for building snaps.