### PR TITLE
refactor: remove support for deprecated test networks

### DIFF
--- a/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
@@ -1202,11 +1202,6 @@ describe("forking", function () {
         balance: "0x6cdf802b72c2a000",
         block: "0xae42fd"
       },
-      kovan: {
-        address: "0x596e8221A30bFe6e7eFF67Fee664A01C73BA3C56",
-        balance: "0x19b2bed356f3da980e2e3",
-        block: "0x1a36e09"
-      },
       rinkeby: {
         address: "0x6dC0c0be4c8B2dFE750156dc7d59FaABFb5B923D",
         balance: "0x11cde6445010582e1ae",

--- a/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
@@ -1197,16 +1197,6 @@ describe("forking", function () {
         balance: "0x6d3c9dd798891c3455045",
         block: "0xcfd6e0"
       },
-      ropsten: {
-        address: "0x00000000219ab540356cbb839cbe05303d7705fa",
-        balance: "0x6cdf802b72c2a000",
-        block: "0xae42fd"
-      },
-      rinkeby: {
-        address: "0x6dC0c0be4c8B2dFE750156dc7d59FaABFb5B923D",
-        balance: "0x11cde6445010582e1ae",
-        block: "0x92c444"
-      },
       goerli: {
         address: "0x9d525E28Fe5830eE92d7Aa799c4D21590567B595",
         balance: "0x81744abdb769a3b6dc08b",

--- a/src/chains/ethereum/options/src/fork-options.ts
+++ b/src/chains/ethereum/options/src/fork-options.ts
@@ -11,17 +11,9 @@ const MAX_BLOCK_NUMBER = Math.floor(Number.MAX_SAFE_INTEGER / 2);
 type HeaderRecord = { name: string; value: string };
 type ForkUrl = URL & { _blockNumber?: number | typeof Tag.latest };
 
-type KnownNetworks =
-  | "mainnet"
-  | "ropsten"
-  | "rinkeby"
-  | "goerli"
-  | "görli"
-  | "sepolia";
+type KnownNetworks = "mainnet" | "goerli" | "görli" | "sepolia";
 export const KNOWN_NETWORKS = [
   "mainnet",
-  "ropsten",
-  "rinkeby",
   "goerli",
   "görli",
   "sepolia"

--- a/src/chains/ethereum/options/src/fork-options.ts
+++ b/src/chains/ethereum/options/src/fork-options.ts
@@ -14,7 +14,6 @@ type ForkUrl = URL & { _blockNumber?: number | typeof Tag.latest };
 type KnownNetworks =
   | "mainnet"
   | "ropsten"
-  | "kovan"
   | "rinkeby"
   | "goerli"
   | "görli"
@@ -22,7 +21,6 @@ type KnownNetworks =
 export const KNOWN_NETWORKS = [
   "mainnet",
   "ropsten",
-  "kovan",
   "rinkeby",
   "goerli",
   "görli",

--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -381,8 +381,7 @@ Fork:
 
                                         Use the shorthand command ganache --fork to automatically fork from
                                         Mainnet at the latest block.
-                                        [choices: "mainnet", "ropsten", "rinkeby", "goerli", "görli",
-                                                                                                    "sepolia"]
+                                                            [choices: "mainnet", "goerli", "görli", "sepolia"]
   --fork.blockNumber                    Block number the provider should fork from.
                                                                                 [default: Latest block number]
 

--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -381,8 +381,7 @@ Fork:
 
                                         Use the shorthand command ganache --fork to automatically fork from
                                         Mainnet at the latest block.
-                                        [choices: "mainnet", "ropsten", "kovan", "rinkeby", "goerli", "görli",
-                                                                                                    "sepolia"]
+                                        [choices: "mainnet", "ropsten", "rinkeby", "goerli", "görli", "sepolia"]
   --fork.blockNumber                    Block number the provider should fork from.
                                                                                 [default: Latest block number]
 

--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -381,7 +381,8 @@ Fork:
 
                                         Use the shorthand command ganache --fork to automatically fork from
                                         Mainnet at the latest block.
-                                        [choices: "mainnet", "ropsten", "rinkeby", "goerli", "görli", "sepolia"]
+                                        [choices: "mainnet", "ropsten", "rinkeby", "goerli", "görli",
+                                                                                                    "sepolia"]
   --fork.blockNumber                    Block number the provider should fork from.
                                                                                 [default: Latest block number]
 


### PR DESCRIPTION
Removes native support for deprecated testnets: [Kovan](https://ethereum.org/en/developers/docs/networks/#kovan), [Ropsten](https://ethereum.org/en/developers/docs/networks/#ropsten), and [Rinkeby](https://ethereum.org/en/developers/docs/networks/#rinkeby).

Fixes #3706