### PR TITLE
fix: set the `earliest` block tag on startup when forking

### DIFF
--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -332,7 +332,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
             ({ block }) => block
           );
           // when we are forking, blocks.earliest is already set to what was
-          // retrieve from the fork
+          // retrieved from the fork
           if (!blocks.earliest) {
             blocks.earliest = blocks.latest;
           }

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -328,8 +328,10 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
             options.miner.blockGasLimit,
             initialAccounts
           );
-          blocks.earliest = blocks.latest =
-            await this.#blockBeingSavedPromise.then(({ block }) => block);
+          blocks.latest = await this.#blockBeingSavedPromise.then(({ block }) => block);
+          if (!blocks.earliest) {
+            blocks.earliest = blocks.latest;
+          }
         }
       }
 

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -331,6 +331,8 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
           blocks.latest = await this.#blockBeingSavedPromise.then(
             ({ block }) => block
           );
+          // when we are forking, blocks.earliest is already set to what was
+          // retrieve from the fork
           if (!blocks.earliest) {
             blocks.earliest = blocks.latest;
           }

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -328,7 +328,9 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
             options.miner.blockGasLimit,
             initialAccounts
           );
-          blocks.latest = await this.#blockBeingSavedPromise.then(({ block }) => block);
+          blocks.latest = await this.#blockBeingSavedPromise.then(
+            ({ block }) => block
+          );
           if (!blocks.earliest) {
             blocks.earliest = blocks.latest;
           }

--- a/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
@@ -15,6 +15,7 @@ import {
   TypedDatabaseTransaction
 } from "@ganache/ethereum-transaction";
 import { GanacheLevelUp } from "../database";
+import { Ethereum } from "../api-types";
 
 const LATEST_INDEX_KEY = BUFFER_ZERO;
 
@@ -277,7 +278,7 @@ export default class BlockManager extends Manager<Block> {
   async getEarliest() {
     const fallback = this.#blockchain.fallback;
     if (fallback) {
-      const json = await fallback.request<any>(
+      const json = await fallback.request<Ethereum.Block<true, "public">>(
         "eth_getBlockByNumber",
         [Tag.earliest, true],
         // TODO: re-enable cache once this is fixed

--- a/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
@@ -292,9 +292,12 @@ export default class BlockManager extends Manager<Block> {
         );
         return new Block(BlockManager.rawFromJSON(json, common), common);
       }
-    }
-    for await (const data of this.base.createValueStream({ limit: 1 })) {
-      return new Block(data as Buffer, this.#common);
+    } else {
+      // if we're forking, there shouldn't be an earliest block saved to the db,
+      // it's always retrieved from the fork
+      for await (const data of this.base.createValueStream({ limit: 1 })) {
+        return new Block(data as Buffer, this.#common);
+      }
     }
   }
 

--- a/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
@@ -280,6 +280,8 @@ export default class BlockManager extends Manager<Block> {
       const json = await fallback.request<any>(
         "eth_getBlockByNumber",
         [Tag.earliest, true],
+        // TODO: re-enable cache once this is fixed
+        // https://github.com/trufflesuite/ganache/issues/3773
         { disableCache: true }
       );
       if (json) {

--- a/src/chains/ethereum/ethereum/tests/forking/block.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/block.test.ts
@@ -3,7 +3,7 @@ import getProvider from "../helpers/getProvider";
 import { EthereumProvider } from "../../src/provider";
 import request from "superagent";
 
-describe("forking", function () {
+describe("forking", function() {
   this.timeout(10000);
 
   describe("blocks", () => {
@@ -11,7 +11,7 @@ describe("forking", function () {
     const blockNumHex = `0x${blockNumber.toString(16)}`;
     const URL = "https://mainnet.infura.io/v3/" + process.env.INFURA_KEY;
     let provider: EthereumProvider;
-    before(async function () {
+    before(async function() {
       if (!process.env.INFURA_KEY) {
         this.skip();
       }
@@ -38,6 +38,22 @@ describe("forking", function () {
       ]);
       assert.deepStrictEqual(parseInt(block.number), blockNumber + 1);
       assert.deepStrictEqual(block.parentHash, remoteBlock.hash);
+    });
+
+    it("after initialization our earliest block should be the fork earliest block, parentHash should match", async () => {
+      const res = await request.post(URL).send({
+        jsonrpc: "2.0",
+        id: "1",
+        method: "eth_getBlockByNumber",
+        params: ["earliest", true]
+      });
+      const remoteBlock = JSON.parse(res.text).result;
+      const block = await provider.send("eth_getBlockByNumber", [
+        "earliest",
+        true
+      ]);
+      assert.deepStrictEqual(parseInt(block.number), parseInt(remoteBlock.number));
+      assert.deepStrictEqual(block.hash, remoteBlock.hash);
     });
 
     //todo: reinstate this test after https://github.com/trufflesuite/ganache/issues/3616 is fixed

--- a/src/chains/ethereum/ethereum/tests/forking/block.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/block.test.ts
@@ -3,7 +3,7 @@ import getProvider from "../helpers/getProvider";
 import { EthereumProvider } from "../../src/provider";
 import request from "superagent";
 
-describe("forking", function() {
+describe("forking", function () {
   this.timeout(10000);
 
   describe("blocks", () => {

--- a/src/chains/ethereum/ethereum/tests/forking/block.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/block.test.ts
@@ -11,7 +11,7 @@ describe("forking", function() {
     const blockNumHex = `0x${blockNumber.toString(16)}`;
     const URL = "https://mainnet.infura.io/v3/" + process.env.INFURA_KEY;
     let provider: EthereumProvider;
-    before(async function() {
+    before(async function () {
       if (!process.env.INFURA_KEY) {
         this.skip();
       }


### PR DESCRIPTION
This change updates Ganache's startup procedure when forking to retrieve the `earliest` block from the remote and cache this block as the `earliest` block in Ganache's block manager. This fixes a bug where calling `eth_getBlockByNumber` with the `"earliest"` block tag parameter yielded no result.