### PR TITLE
test: improve coverage of RPC-JSON Data byteLength argument

### DIFF
--- a/src/packages/utils/tests/json-rpc-data.test.ts
+++ b/src/packages/utils/tests/json-rpc-data.test.ts
@@ -16,20 +16,38 @@ const testData = [
 
 describe("json-rpc-data", () => {
   describe("constructor", () => {
-    it("should create a Data", () => {
+    it("should create a Data instance", () => {
       const input = Buffer.alloc(0);
       const data = new Data(input);
 
       assert(data instanceof Data);
     });
+
+    it("should create a Data instance with the specified `byteLength`", () => {
+      const byteLength = 10;
+      const input = "0x1234";
+      const data = new Data(input, byteLength);
+
+      // we can't directly access the instances length
+      assert.strictEqual(data.toBuffer().length, byteLength);
+    });
   });
 
   describe("from()", () => {
-    it("should create a Data", () => {
+    it("should create a Data instance", () => {
       const input = Buffer.alloc(0);
       const data = Data.from(input);
 
       assert(data instanceof Data);
+    });
+
+    it("should create a Data instance with the specified `byteLength`", () => {
+      const byteLength = 10;
+      const input = "0x1234";
+      const data = Data.from(input, byteLength);
+
+      // we can't directly access the instances length
+      assert.strictEqual(data.toBuffer().length, byteLength);
     });
   });
 

--- a/src/packages/utils/tests/json-rpc-data.test.ts
+++ b/src/packages/utils/tests/json-rpc-data.test.ts
@@ -80,6 +80,14 @@ describe("json-rpc-data", () => {
       const result = new Data(Buffer.from([0x01])).toString(10);
       assert.strictEqual(result, "0x00000000000000000001");
     });
+
+    it("should prefer the specified byteLength, over the value provided to the constructor", () => {
+      const byteLength = 10;
+      const data = new Data("0x01", 2);
+
+      const result = data.toString(byteLength);
+      assert.strictEqual(result, "0x00000000000000000001");
+    });
   });
 
   describe("toBuffer()", () => {
@@ -107,6 +115,18 @@ describe("json-rpc-data", () => {
       const expected = Buffer.from([
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
       ]);
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("should prefer the specified byteLength, over the value provided to the constructor", () => {
+      const byteLength = 10;
+      const data = new Data("0x01", 2);
+
+      const result = data.toBuffer(byteLength);
+      const expected = Buffer.from([
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+      ]);
+
       assert.deepStrictEqual(result, expected);
     });
 


### PR DESCRIPTION
This change adds basic tests ensuring the `byteLength` argument passed to the RPC-JSON Data constructor and factory method are respected internally, and that they are overridden by the argument passed to `toString()` and `toBuffer()`.