### PR TITLE
perf: use keccak from `@ganache/utils` where possible

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -19,13 +19,13 @@ import {
 } from "@ganache/ethereum-transaction";
 import {
   toRpcSig,
-  ecsign,
   hashPersonalMessage,
   KECCAK256_NULL
 } from "@ethereumjs/util";
 import { signTypedData_v4 } from "eth-sig-util";
 import {
   Data,
+  ecsign,
   Heap,
   Quantity,
   PromiEvent,

--- a/src/chains/ethereum/ethereum/src/helpers/trie.ts
+++ b/src/chains/ethereum/ethereum/src/helpers/trie.ts
@@ -1,8 +1,12 @@
-import { Quantity } from "@ganache/utils";
+import { keccak, Quantity } from "@ganache/utils";
 import { DB, Trie } from "@ethereumjs/trie";
 import Blockchain from "../blockchain";
 import { LevelDB } from "../leveldb";
 import { UpgradedLevelDown } from "../leveldown-to-level";
+
+const keyHashingFunction = (msg: Uint8Array) => {
+  return keccak(Buffer.from(msg.buffer, msg.byteOffset, msg.length));
+};
 
 export class GanacheTrie extends Trie {
   public readonly blockchain: Blockchain;
@@ -12,7 +16,13 @@ export class GanacheTrie extends Trie {
     root: Buffer,
     blockchain: Blockchain
   ) {
-    super({ db, root, useRootPersistence: true, useKeyHashing: true });
+    super({
+      db,
+      root,
+      useRootPersistence: true,
+      useKeyHashing: true,
+      useKeyHashingFunction: keyHashingFunction
+    });
     this.blockchain = blockchain;
   }
 

--- a/src/chains/ethereum/transaction/package.json
+++ b/src/chains/ethereum/transaction/package.json
@@ -55,7 +55,6 @@
     "@ganache/secp256k1": "0.4.1",
     "@ethereumjs/tx": "4.0.0",
     "@ganache/utils": "0.5.2",
-    "@ethereumjs/util": "8.0.0",
     "node-gyp-build": "4.5.0"
   },
   "devDependencies": {

--- a/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
@@ -4,7 +4,8 @@ import {
   keccak,
   BUFFER_32_ZERO,
   BUFFER_ZERO,
-  JsonRpcErrorCode
+  JsonRpcErrorCode,
+  ecsign
 } from "@ganache/utils";
 import { Address } from "@ganache/ethereum-address";
 import type { Common } from "@ethereumjs/common";
@@ -27,21 +28,6 @@ import secp256k1 from "@ganache/secp256k1";
 import { CodedError } from "@ganache/ethereum-utils";
 
 const bigIntMin = (...args: bigint[]) => args.reduce((m, e) => (e < m ? e : m));
-
-function ecsign(msgHash: Uint8Array, privateKey: Uint8Array) {
-  const object = { signature: new Uint8Array(64), recid: null };
-  const status = secp256k1.ecdsaSign(object, msgHash, privateKey);
-  if (status === 0) {
-    const buffer = object.signature.buffer;
-    const r = Buffer.from(buffer, 0, 32);
-    const s = Buffer.from(buffer, 32, 32);
-    return { r, s, v: object.recid };
-  } else {
-    throw new Error(
-      "The nonce generation function failed, or the private key was invalid"
-    );
-  }
-}
 
 const CAPABILITIES = [2718, 2930, 1559];
 

--- a/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip2930-access-list-transaction.ts
@@ -4,7 +4,8 @@ import {
   keccak,
   BUFFER_ZERO,
   BUFFER_32_ZERO,
-  JsonRpcErrorCode
+  JsonRpcErrorCode,
+  ecsign
 } from "@ganache/utils";
 import { Address } from "@ganache/ethereum-address";
 import type { Common } from "@ethereumjs/common";
@@ -23,23 +24,7 @@ import {
   Capability,
   EIP2930AccessListTransactionJSON
 } from "./transaction-types";
-import secp256k1 from "@ganache/secp256k1";
 import { CodedError } from "@ganache/ethereum-utils";
-
-function ecsign(msgHash: Uint8Array, privateKey: Uint8Array) {
-  const object = { signature: new Uint8Array(64), recid: null };
-  const status = secp256k1.ecdsaSign(object, msgHash, privateKey);
-  if (status === 0) {
-    const buffer = object.signature.buffer;
-    const r = Buffer.from(buffer, 0, 32);
-    const s = Buffer.from(buffer, 32, 32);
-    return { r, s, v: object.recid };
-  } else {
-    throw new Error(
-      "The nonce generation function failed, or the private key was invalid"
-    );
-  }
-}
 
 const CAPABILITIES = [2718, 2930];
 

--- a/src/chains/ethereum/transaction/src/legacy-transaction.ts
+++ b/src/chains/ethereum/transaction/src/legacy-transaction.ts
@@ -4,7 +4,8 @@ import {
   keccak,
   BUFFER_EMPTY,
   BUFFER_32_ZERO,
-  ecsignLegacy
+  ecsignLegacy,
+  ECSignResult
 } from "@ganache/utils";
 import { Address } from "@ganache/ethereum-address";
 import type { Common } from "@ethereumjs/common";
@@ -169,7 +170,7 @@ export class LegacyTransaction extends RuntimeTransaction {
     let raw: LegacyDatabasePayload;
     let data: EncodedPart;
     let dataLength: number;
-    let sig: { v: bigint; r: Buffer; s: Buffer };
+    let sig: ECSignResult;
     if (eip155IsActive) {
       chainId = Quantity.toBuffer(this.common.chainId());
       raw = this.toEthRawTransaction(chainId, BUFFER_EMPTY, BUFFER_EMPTY);

--- a/src/packages/utils/package.json
+++ b/src/packages/utils/package.json
@@ -47,6 +47,7 @@
     "tooling"
   ],
   "dependencies": {
+    "@ganache/secp256k1": "0.4.1",
     "emittery": "0.10.0",
     "keccak": "3.0.2",
     "seedrandom": "3.0.5"

--- a/src/packages/utils/src/utils/index.ts
+++ b/src/packages/utils/src/utils/index.ts
@@ -11,3 +11,4 @@ export * from "./buffer-to-key";
 export * from "./keccak";
 export * from "./find-insert-position";
 export * from "./random-number-generator";
+export * from "./signature";

--- a/src/packages/utils/src/utils/signature.ts
+++ b/src/packages/utils/src/utils/signature.ts
@@ -5,7 +5,12 @@ type ECDSASignOutput = {
   recid: number;
 };
 
-export function ecsign(msgHash: Uint8Array, privateKey: Uint8Array) {
+export type ECSignResult = { v: bigint; r: Buffer; s: Buffer };
+
+export function ecsign(
+  msgHash: Uint8Array,
+  privateKey: Uint8Array
+): ECSignResult {
   const output: ECDSASignOutput = {
     signature: new Uint8Array(64),
     recid: null
@@ -28,7 +33,7 @@ export function ecsignLegacy(
   msgHash: Uint8Array,
   privateKey: Uint8Array,
   chainId?: bigint
-) {
+): ECSignResult {
   const { v, r, s } = ecsign(msgHash, privateKey);
 
   const legacyV =

--- a/src/packages/utils/src/utils/signature.ts
+++ b/src/packages/utils/src/utils/signature.ts
@@ -1,0 +1,37 @@
+import secp256k1 from "@ganache/secp256k1";
+
+type ECDSASignOutput = {
+  signature: Uint8Array;
+  recid: number;
+};
+
+export function ecsign(msgHash: Uint8Array, privateKey: Uint8Array) {
+  const output: ECDSASignOutput = {
+    signature: new Uint8Array(64),
+    recid: null
+  };
+  const status = secp256k1.ecdsaSign(output, msgHash, privateKey);
+  if (status !== 0) {
+    throw new Error(
+      "The nonce generation function failed, or the private key was invalid"
+    );
+  }
+  const { signature, recid } = output;
+  const buffer = signature.buffer;
+  const r = Buffer.from(buffer, 0, 32);
+  const s = Buffer.from(buffer, 32, 32);
+  const v = BigInt(recid);
+  return { r, s, v };
+}
+
+export function ecsignLegacy(
+  msgHash: Uint8Array,
+  privateKey: Uint8Array,
+  chainId?: bigint
+) {
+  const { v, r, s } = ecsign(msgHash, privateKey);
+
+  const legacyV =
+    chainId === undefined ? v + 27n : v + 35n + BigInt(chainId) * 2n;
+  return { r, s, v: legacyV };
+}

--- a/src/packages/utils/tsconfig.json
+++ b/src/packages/utils/tsconfig.json
@@ -8,5 +8,11 @@
   "include": [
     "index.ts",
     "src/**/*"
+  ],
+  "references": [
+    {
+      "name": "@ganache/secp256k1",
+      "path": "../secp256k1"
+    }
   ]
 }


### PR DESCRIPTION
The latest releases of `@ethereumjs/util` and `@ethereumjs/trie` swap out their previous keccak function to use the less performant [ethereum-cryptography](https://github.com/ethereum/js-ethereum-cryptography) package instead. This change uses the keccak exported from `@ganache/utils` instead, where possible. 