### PR TITLE
ci: update actions/workflows to use Node 16

### DIFF
--- a/.github/actions/docker-publish/action.yml
+++ b/.github/actions/docker-publish/action.yml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Use npm 14
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 14
 

--- a/.github/workflows/cancel-pr.yml
+++ b/.github/workflows/cancel-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 3
     steps:
-      - uses: styfle/cancel-workflow-action@0.7.0
+      - uses: styfle/cancel-workflow-action@0.11.0
         with:
           workflow_id: 5127767
           access_token: ${{ github.token }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.7.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,12 +24,12 @@ jobs:
         uses: styfle/cancel-workflow-action@0.7.0
         with:
           access_token: ${{ github.token }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Add msbuild to PATH
         # we need msbuild tools for the `bcrypto` module
         if: startsWith(matrix.os, 'windows-')
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.1
 
       - run: npm ci
       - run: npm run tsc

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Add msbuild to PATH
         # we need msbuild tools for the `bigint-buffer` module
         if: startsWith(matrix.os, 'windows-')
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.1
 
       - name: install node tools
         # we don't need to install the windows-build-tools package, as we

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - run: npm ci
@@ -46,11 +46,11 @@ jobs:
     if: github.ref == 'refs/heads/develop'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
       TAG: ${{ steps.set_tag_output.outputs.TAG }}
       VERSION: ${{ steps.set_version_output.outputs.VERSION }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # we need all commit history so we can merge master into develop
           fetch-depth: 0
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           # use node 14 until we can evaluate using npm 7+ and lock file version 2
           # this should match the node version used by the "check bundle size"
@@ -174,7 +174,7 @@ jobs:
       # because the docker publish action is an action we made, we have to
       # check out the repo
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Ganache's docker publish action


### PR DESCRIPTION
See warnings for:
- [pr.yml warnings](https://github.com/trufflesuite/ganache/actions/runs/3314484697)
- [cancel-pr.yml](https://github.com/trufflesuite/ganache/actions/runs/3314484684)
- [push.yml](https://github.com/trufflesuite/ganache/actions/runs/3313423385)

## updated actions
| action  | current version  | updated version |
| ------------- | ------------- | ------------- |
| [actions/setup-node](https://github.com/actions/setup-node)  | v1 | v3 |
| [actions/checkout](https://github.com/actions/checkout)  | v2 | v3 |
| [styfle/cancel-workflow-action](https://github.com/styfle/cancel-workflow-action)  | 0.7.0 | 0.11.0 |
| [microsoft/setup-msbuild](https://github.com/microsoft/setup-msbuild)  | 1.0.2 | 1.1 |

Edit: update PR overview