### PR TITLE
chore: add pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## PR description
+
+<!-- Enter PR description here. Don't forget to link any issues that are resolved by this PR. -->
+
+## Testing instructions
+
+<!-- If there are any relevant instructions for testing this PR, add them here. -->
+
+## Documentation
+
+<!-- Consider the documentation needs of this PR, and select the appropriate option. -->
+
+- [ ] I've added the `doc-change-required` label to this PR so that documentation can be added by the docs team in another PR.
+- [ ] I've included documentation changes in this PR:
+  - [ ] I've updated the `README.md`.
+  - [ ] I've updated the `CONTRIBUTING.md`.
+  - [ ] I've added/updated an RPC method in `src/chains/ethereum/ethereum/RPC-METHODS.md`.
+  - [ ] I've added/updated a JS-DOC example of a new RPC method in `src/chains/ethereum/ethereum/src/api.ts`.
+- [ ] This PR does not require documentation changes.
+- [ ] I don't know what this PR needs in regards to documentation. <!-- There's no shame in asking for help :-) -->
+
+## Release Notes
+
+<!-- In an effort to automate the generation of release notes, each PR has a "release-ready" explanation of the change. Everything after this comment will be added to our initial set of auto-generated notes (don't worry, we'll proof read them first before shipping). If you are an external contributor, feel free to skip this section; we'll come by to add in some release notes later. If you want to give it a go, check out our previous release notes for some examples of our style: https://github.com/trufflesuite/ganache/releases -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,27 @@
-## PR description
+<!-- If you are an external contributor, thank you so much for your pull request! We are so grateful for community involvement on the Ganache repo. Filling out the below information can be helpful for the team, but the only truly important one is the "PR Description" section.-->
+
+## PR Description
 
 <!-- Enter PR description here. Don't forget to link any issues that are resolved by this PR. -->
 
-## Testing instructions
+## Testing Instructions
 
-<!-- If there are any relevant instructions for testing this PR, add them here. -->
+<!-- Optional - If there are any relevant instructions for testing this PR, add them here. -->
 
 ## Documentation
 
-<!-- Consider the documentation needs of this PR, and select the appropriate option. -->
+<!-- Optional -->
 
-- [ ] I've added the `doc-change-required` label to this PR so that documentation can be added by the docs team in another PR.
+Consider the documentation needs of this PR, and select the appropriate option.
+
+- [ ] I don't know what this PR needs in regards to documentation, or I don't really want to think about it. <!-- There's no shame in asking for help :-) -->
+- [ ] This PR warrants documentation updates, but they are not included in the PR. <!--this lets the internal team know that the `doc-change-required` label should be added to this PR so that documentation can be added by the docs team in another PR. If you're an external contributor, no action is needed other than checking this box. -->
 - [ ] I've included documentation changes in this PR:
   - [ ] I've updated the `README.md`.
   - [ ] I've updated the `CONTRIBUTING.md`.
   - [ ] I've added/updated an RPC method in `src/chains/ethereum/ethereum/RPC-METHODS.md`.
   - [ ] I've added/updated a JS-DOC example of a new RPC method in `src/chains/ethereum/ethereum/src/api.ts`.
 - [ ] This PR does not require documentation changes.
-- [ ] I don't know what this PR needs in regards to documentation. <!-- There's no shame in asking for help :-) -->
 
 ## Release Notes
 


### PR DESCRIPTION
## PR description

<!-- Enter PR description here. Don't forget to link any issues that are resolved by this PR. -->
This PR introduces a PR template that will be used to guide contributors on a format for creating PRs in the Ganache repo. Fixes #3758 

We can bike shed this to our heart's content, but I figured I'd get something out to start the conversation. By the way, this PR description uses the template. 

## Testing instructions

<!-- If there are any relevant instructions for testing this PR, add them here. -->
N/A

## Documentation

<!-- Consider the documentation needs of this PR, and select the appropriate option. -->

- [ ] I've added the `doc-change-required` label to this PR so that documentation can be added by the docs team in another PR.
- [ ] I've included documentation changes in this PR:
  - [ ] I've updated the `README.md`.
  - [ ] I've updated the `CONTRIBUTING.md`.
  - [ ] I've added/updated an RPC method in `src/chains/ethereum/ethereum/RPC-METHODS.md`.
  - [ ] I've added/updated a JS-DOC example of a new RPC method in `src/chains/ethereum/ethereum/src/api.ts`.
- [X] This PR does not require documentation changes.
- [x] I don't know what this PR needs in regards to documentation. <!-- There's no shame in asking for help :-) -->

## Release Notes

<!-- In an effort to automate the generation of release notes, each PR has a "release-ready" explanation of the change. Everything after this comment will be added to our initial set of auto-generated notes (don't worry, we'll proof read them first before shipping). If you are an external contributor, feel free to skip this section; we'll come by to add in some release notes later. If you want to give it a go, check out our previous release notes for some examples of our style: https://github.com/trufflesuite/ganache/releases -->

This change introduces a PR template that will be used to guide contributors on a format for creating PRs in the Ganache repo.
