### PR TITLE
ci: remove node 12 from CI tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12.0.0, 12.x, 14.x, 16.x, 18.x]
+        node: [14.x, 16.x, 18.x]
         os: [windows-2019, ubuntu-18.04, ubuntu-20.04, macos-11]
         exclude:
           # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14.x, 16.x, 18.x]
+        node: [14.0.0, 14.x, 16.x, 18.x]
         os: [windows-2019, ubuntu-18.04, ubuntu-20.04, macos-11]
         exclude:
           # Node v18 does not run on ubuntu-18.04: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442

--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -1,6 +1,6 @@
 # Ganache Upgrade Guide
 
-## ganache-core v2.x.x and ganache-cli v6.x.x to ganache v7.x.x
+## ganache-core v2.x.x and ganache-cli v6.x.x to ganache v7.0.0-v7.6.0
 
 ### Installing
 
@@ -447,3 +447,7 @@ be addressing this shortcoming in a future EIP and release by extending eth_call
 with an option to run the transaction at a certain _index_ in the specified
 block (you likely won't ever see this option enabled on public nodes, like
 Infura, as it can be a very CPU-intensive process).
+
+## ganache v7.0.0-v7.6.0 to ganache v7.7.0+
+
+As of Ganache v7.7.0, Node 12 is no longer supported. You'll need to update to Node 14.0.0 or later to use Ganache v7.7.0 or later.

--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -132,11 +132,13 @@ If you want to use the new default mode but still be able to get the reason for
 a transaction failure, you need to resend your transaction with an `eth_call`.
 This will return the revert reason in nearly all cases[^2].
 
-#### Dropped support for Node v8 and v10
+#### v7.0.0-7.6.0, Dropped support for Node v8 and v10
 
-We no longer support Node v8 - v11. You'll need to update to Node v12.0.0 or
-later. NOTE: Support for Node.js v12.x.x will be dropped shortly after the
-Node.js Foundation stops supporting it in April 2022.
+As of v7.0.0 we no longer support Node v8-v10. You'll need to update to Node v12.0.0 or later.
+
+#### v7.7.0+, Dropped support for Node v12
+
+We no longer support Node v12. You'll need to update to Node v14.0.0 or later. NOTE: Support for Node.js v14.x.x will be dropped shortly after the Node.js Foundation stops supporting it in April 2023.
 
 #### DockerHub repo has been moved to trufflesuite/ganache
 
@@ -447,7 +449,3 @@ be addressing this shortcoming in a future EIP and release by extending eth_call
 with an option to run the transaction at a certain _index_ in the specified
 block (you likely won't ever see this option enabled on public nodes, like
 Infura, as it can be a very CPU-intensive process).
-
-## ganache v7.0.0-v7.6.0 to ganache v7.7.0+
-
-As of Ganache v7.7.0, Node 12 is no longer supported. You'll need to update to Node 14.0.0 or later to use Ganache v7.7.0 or later.

--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -1,6 +1,6 @@
 # Ganache Upgrade Guide
 
-## ganache-core v2.x.x and ganache-cli v6.x.x to ganache v7.0.0-v7.6.0
+## ganache-core v2.x.x and ganache-cli v6.x.x to ganache v7.x.x
 
 ### Installing
 


### PR DESCRIPTION
You know when you spend a really long time on a big PR and finally think you've got every little detail settled, then the whole team reviews the PR and finds a few other little things that you fix, then they all approve the PR, so you all think you've got every little detail settled, then you finally merge the PR and you immediately realize that you forgot to remove a now unsupported version of node from your CI tests that only run once the PR has been merged into develop, so now you have to make another PR to remove the now unsupported node version from your CI tests? Yeah I hate when that happens.