### PR TITLE
ci: update docker release action

### DIFF
--- a/.github/actions/docker-publish/action.yml
+++ b/.github/actions/docker-publish/action.yml
@@ -34,13 +34,13 @@ runs:
       shell: bash
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      uses: docker/login-action@f75d088332b07a08afadf6ac53c74509b9453f12
       with:
         username: ${{ inputs.DOCKER_USERNAME }}
         password: ${{ inputs.DOCKER_ACCESS_TOKEN }}
 
     - name: Log in to the Container registry
-      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      uses: docker/login-action@f75d088332b07a08afadf6ac53c74509b9453f12
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -48,20 +48,20 @@ runs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      uses: docker/metadata-action@314ddf6d4a82333bf1bc7630399df41bf68eba09
       with:
         images: |
           trufflesuite/ganache
           ghcr.io/${{ github.repository}}
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@0522dcd2bf084920c411162fde334a308be75015
+      uses: docker/setup-qemu-action@38836d31bd1e0f8f29b8c7ad0412da32020f15b3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@91cb32d715c128e5f0ede915cd7e196ab7799b83
+      uses: docker/setup-buildx-action@39a1a82492fd1ad19af19d61b5f748e4cb6cd1af
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      uses: docker/build-push-action@175d02bffea74695e96b351069ac938b338802f9
       with:
         context: .
         file: ./src/packages/ganache/Dockerfile

--- a/.github/actions/docker-publish/action.yml
+++ b/.github/actions/docker-publish/action.yml
@@ -65,7 +65,7 @@ runs:
       with:
         context: .
         file: ./src/packages/ganache/Dockerfile
-        push: false
+        push: true
         tags: ${{ format('trufflesuite/ganache:{0}, trufflesuite/ganache:v{1}', inputs.TAG, inputs.VERSION) }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: linux/arm64/v8,linux/amd64

--- a/.github/actions/docker-publish/action.yml
+++ b/.github/actions/docker-publish/action.yml
@@ -65,7 +65,7 @@ runs:
       with:
         context: .
         file: ./src/packages/ganache/Dockerfile
-        push: true
+        push: false
         tags: ${{ format('trufflesuite/ganache:{0}, trufflesuite/ganache:v{1}', inputs.TAG, inputs.VERSION) }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: linux/arm64/v8,linux/amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ needs.release.outputs.TAG }}
       - name: Run Ganache's docker publish action
         # we are running our local action, so point directly to a folder
         # containing an `action.yml` file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: latest
       - name: Run Ganache's docker publish action
         # we are running our local action, so point directly to a folder
         # containing an `action.yml` file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # by specifying the tag of this version as the ref to checkout, we're
-          # making sure the version we just release to npm is being released to
+          # making sure the version we just released to npm is being released to
           # Docker.
           ref: v${{ needs.release.outputs.VERSION }}
       - name: Run Ganache's docker publish action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # by specifying the tag of this version as the ref to checkout, we're
+          # making sure the version we just release to npm is being released to
+          # Docker.
           ref: v${{ needs.release.outputs.VERSION }}
       - name: Run Ganache's docker publish action
         # we are running our local action, so point directly to a folder

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ needs.release.outputs.TAG }}
+          ref: v${{ needs.release.outputs.VERSION }}
       - name: Run Ganache's docker publish action
         # we are running our local action, so point directly to a folder
         # containing an `action.yml` file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,174 @@
-name: Test-Docker
+name: Release
 
 # allow only one "Release" workflow to run at a time
 concurrency: production
 
 on:
   push:
-    branches: [update-docker-release-action]
+    branches: [alpha, beta, rc, master]
 
 jobs:
+  release:
+    # this should match the os version used by the "check bundle size" step in
+    # pr.yml
+    runs-on: ubuntu-20.04
+    outputs:
+      TAG: ${{ steps.set_tag_output.outputs.TAG }}
+      VERSION: ${{ steps.set_version_output.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # we need all commit history so we can merge master into develop
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          # use node 14 until we can evaluate using npm 7+ and lock file version 2
+          # this should match the node version used by the "check bundle size"
+          # step in pr.yml
+          node-version: 14
+
+      - name: Import Robot GPG key
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.TRUFBOT_GPG_SECRET_KEY }}
+          passphrase: ${{ secrets.TRUFBOT_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Set git origin url
+        run: |
+          git remote set-url origin https://robot:${GITHUB_TOKEN}@github.com/$GITHUB_REPOSITORY
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set TAG for master to latest
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: |
+          echo "TAG=latest" >> $GITHUB_ENV
+
+      - name: Set TAG for non-master to the branch name
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: |
+          echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Set TAG as job output variable
+        id: set_tag_output
+        run: echo "::set-output name=TAG::${TAG}"
+
+      - name: Count features
+        if: ${{ env.TAG == 'latest'}}
+        # get all commits in develop that aren't in master, find any that start with feat: or feat(*):, then count them
+        # 1. `git tag --sort=-version:refname --no-contains HEAD`
+        #    - get a list of all tags that do NOT contain out current HEAD commit
+        #    - sort by version name
+        #    - in reverse order
+        # 2. `grep -P "^v(0|[1-9]\d*)?\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"`
+        #    - filter the list for semver matching tags only, e.g. "v*.*.*" (ignores pre-releases!)
+        #    - ignores pre-releases
+        #    - ignores improper tags like v01.02.03 (no leading 0s)
+        # 3. `head -1`
+        #    - get the last tag in the list
+        # 4. `git log ^$LATEST_TAG HEAD --pretty=format:%s`
+        #    - get all from the `LATEST_TAG` (exclusive) to `HEAD`
+        # 5. `grep -o -P '^feat(\(.*?\))?:'`
+        #    - output only the matching part (in case a newline can get in here... probably not possible?)
+        #    - filter for only commit subjects that match conventional commits for features, i.e., `feat:` or `feat(<subject>):`
+        # 6. `wc -l`
+        #    - count how many matches we have
+        # 7.  `>> $GITHUB_ENV`
+        #    - assign the above `FEATURE_COUNT` to the `wc` result (e.g., "FEATURE_COUNT=1") and append it to `$GITHUB_ENV`
+        run: |
+          LATEST_TAG=$(git tag --sort=-version:refname --no-contains HEAD | grep -P '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$' | head -1) &&
+          echo FEATURE_COUNT="$(git log ^"${LATEST_TAG}" HEAD --pretty=format:%s | grep -o -P '^feat(\(.*?\))?:' | wc -l)" >> "${GITHUB_ENV}"
+
+      - name: Determine Release Kind (minor)
+        # if we are "latest" and we have features, set the release to "minor"
+        if: ${{ env.TAG == 'latest' && env.FEATURE_COUNT != '0' }}
+        run: echo "RELEASE_KIND=minor" >> $GITHUB_ENV
+
+      - name: Determine Release Kind (patch)
+        # if we are "latest" and we do NOT have features, set the release to "patch"
+        if: ${{ env.TAG == 'latest' && env.FEATURE_COUNT == '0' }}
+        run: echo "RELEASE_KIND=patch" >> $GITHUB_ENV
+
+      - name: Run installation
+        run: npm ci
+
+      - name: Test
+        run: npm test
+        env:
+          FORCE_COLOR: 1
+          INFURA_KEY: ${{ secrets.TEST_INFURA_KEY }}
+
+      - name: Update package versions for latest release (master)
+        if: ${{ env.TAG == 'latest' }}
+        run: $(npm bin)/lerna version "$RELEASE_KIND" --no-git-tag-version --no-push --yes --exact
+
+      - name: Update package versions for pre-releases
+        if: ${{ env.TAG != 'latest' }}
+        run: $(npm bin)/lerna version prerelease --no-git-tag-version --no-push --yes --exact --preid "$TAG"
+
+      - name: Add updated versions to git
+        run: git add .
+
+      - name: Run build
+        run: npm run build
+        env:
+          INFURA_KEY: ${{ secrets.INFURA_KEY }}
+
+      - name: Update documentation
+        run: |
+          npm run docs.build
+          git add docs/**
+
+      - name: Set VERSION
+        run: |
+          echo "VERSION=$(node -e 'console.log(require("./src/packages/ganache/package.json").version)')" >> $GITHUB_ENV
+
+      - name: Set VERSION as job output variable
+        id: set_version_output
+        run: echo "::set-output name=VERSION::${VERSION}"
+
+      - name: Commit all staged changes
+        run: |
+          git commit -m "chore(release): publish v${VERSION}" -m "ganache@${VERSION}"
+
+      - name: Tag the amended release commit
+        run: |
+          git tag -a "ganache@${VERSION}" -m "ganache@${VERSION}"
+          git tag -a "v${VERSION}" -m "v${VERSION}"
+
+      - name: Push changes to git
+        run: |
+          git push origin ${GITHUB_REF##*/}
+          git push origin --tags
+
+      - name: Set up auth for npm publish
+        run: npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # - name: Smoke test release
+      #   TODO: set up verdaccio to mock npm https://verdaccio.org/
+
+      # this needs `--no-verify-access` until https://github.com/lerna/lerna/issues/2788 is fixed
+      - name: Release to npm
+        run: |
+          $(npm bin)/lerna publish from-package --yes --dist-tag ${TAG} --pre-dist-tag ${TAG} --no-verify-access
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge changes back into develop for latest release (master)
+        if: ${{ env.TAG == 'latest' }}
+        run: |
+          git checkout develop
+          git merge origin/master
+          git push origin develop
+
   publish-docker:
+    needs: release
     runs-on: ubuntu-20.04
     steps:
       # because the docker publish action is an action we made, we have to
@@ -22,8 +182,8 @@ jobs:
         # containing an `action.yml` file
         uses: ./.github/actions/docker-publish
         with:
-          VERSION: 7.6.0
-          TAG: latest
+          VERSION: ${{ needs.release.outputs.VERSION }}
+          TAG: ${{ needs.release.outputs.TAG }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           INFURA_KEY: ${{ secrets.INFURA_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,174 +1,14 @@
-name: Release
+name: Test-Docker
 
 # allow only one "Release" workflow to run at a time
 concurrency: production
 
 on:
   push:
-    branches: [alpha, beta, rc, master]
+    branches: [update-docker-release-action]
 
 jobs:
-  release:
-    # this should match the os version used by the "check bundle size" step in
-    # pr.yml
-    runs-on: ubuntu-20.04
-    outputs:
-      TAG: ${{ steps.set_tag_output.outputs.TAG }}
-      VERSION: ${{ steps.set_version_output.outputs.VERSION }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # we need all commit history so we can merge master into develop
-          fetch-depth: 0
-      - uses: actions/setup-node@v3
-        with:
-          # use node 14 until we can evaluate using npm 7+ and lock file version 2
-          # this should match the node version used by the "check bundle size"
-          # step in pr.yml
-          node-version: 14
-
-      - name: Import Robot GPG key
-        uses: crazy-max/ghaction-import-gpg@v4
-        with:
-          gpg_private_key: ${{ secrets.TRUFBOT_GPG_SECRET_KEY }}
-          passphrase: ${{ secrets.TRUFBOT_GPG_PASSPHRASE }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-
-      - name: Set git origin url
-        run: |
-          git remote set-url origin https://robot:${GITHUB_TOKEN}@github.com/$GITHUB_REPOSITORY
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set TAG for master to latest
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: |
-          echo "TAG=latest" >> $GITHUB_ENV
-
-      - name: Set TAG for non-master to the branch name
-        if: ${{ github.ref != 'refs/heads/master' }}
-        run: |
-          echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
-
-      - name: Set TAG as job output variable
-        id: set_tag_output
-        run: echo "::set-output name=TAG::${TAG}"
-
-      - name: Count features
-        if: ${{ env.TAG == 'latest'}}
-        # get all commits in develop that aren't in master, find any that start with feat: or feat(*):, then count them
-        # 1. `git tag --sort=-version:refname --no-contains HEAD`
-        #    - get a list of all tags that do NOT contain out current HEAD commit
-        #    - sort by version name
-        #    - in reverse order
-        # 2. `grep -P "^v(0|[1-9]\d*)?\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"`
-        #    - filter the list for semver matching tags only, e.g. "v*.*.*" (ignores pre-releases!)
-        #    - ignores pre-releases
-        #    - ignores improper tags like v01.02.03 (no leading 0s)
-        # 3. `head -1`
-        #    - get the last tag in the list
-        # 4. `git log ^$LATEST_TAG HEAD --pretty=format:%s`
-        #    - get all from the `LATEST_TAG` (exclusive) to `HEAD`
-        # 5. `grep -o -P '^feat(\(.*?\))?:'`
-        #    - output only the matching part (in case a newline can get in here... probably not possible?)
-        #    - filter for only commit subjects that match conventional commits for features, i.e., `feat:` or `feat(<subject>):`
-        # 6. `wc -l`
-        #    - count how many matches we have
-        # 7.  `>> $GITHUB_ENV`
-        #    - assign the above `FEATURE_COUNT` to the `wc` result (e.g., "FEATURE_COUNT=1") and append it to `$GITHUB_ENV`
-        run: |
-          LATEST_TAG=$(git tag --sort=-version:refname --no-contains HEAD | grep -P '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$' | head -1) &&
-          echo FEATURE_COUNT="$(git log ^"${LATEST_TAG}" HEAD --pretty=format:%s | grep -o -P '^feat(\(.*?\))?:' | wc -l)" >> "${GITHUB_ENV}"
-
-      - name: Determine Release Kind (minor)
-        # if we are "latest" and we have features, set the release to "minor"
-        if: ${{ env.TAG == 'latest' && env.FEATURE_COUNT != '0' }}
-        run: echo "RELEASE_KIND=minor" >> $GITHUB_ENV
-
-      - name: Determine Release Kind (patch)
-        # if we are "latest" and we do NOT have features, set the release to "patch"
-        if: ${{ env.TAG == 'latest' && env.FEATURE_COUNT == '0' }}
-        run: echo "RELEASE_KIND=patch" >> $GITHUB_ENV
-
-      - name: Run installation
-        run: npm ci
-
-      - name: Test
-        run: npm test
-        env:
-          FORCE_COLOR: 1
-          INFURA_KEY: ${{ secrets.TEST_INFURA_KEY }}
-
-      - name: Update package versions for latest release (master)
-        if: ${{ env.TAG == 'latest' }}
-        run: $(npm bin)/lerna version "$RELEASE_KIND" --no-git-tag-version --no-push --yes --exact
-
-      - name: Update package versions for pre-releases
-        if: ${{ env.TAG != 'latest' }}
-        run: $(npm bin)/lerna version prerelease --no-git-tag-version --no-push --yes --exact --preid "$TAG"
-
-      - name: Add updated versions to git
-        run: git add .
-
-      - name: Run build
-        run: npm run build
-        env:
-          INFURA_KEY: ${{ secrets.INFURA_KEY }}
-
-      - name: Update documentation
-        run: |
-          npm run docs.build
-          git add docs/**
-
-      - name: Set VERSION
-        run: |
-          echo "VERSION=$(node -e 'console.log(require("./src/packages/ganache/package.json").version)')" >> $GITHUB_ENV
-
-      - name: Set VERSION as job output variable
-        id: set_version_output
-        run: echo "::set-output name=VERSION::${VERSION}"
-
-      - name: Commit all staged changes
-        run: |
-          git commit -m "chore(release): publish v${VERSION}" -m "ganache@${VERSION}"
-
-      - name: Tag the amended release commit
-        run: |
-          git tag -a "ganache@${VERSION}" -m "ganache@${VERSION}"
-          git tag -a "v${VERSION}" -m "v${VERSION}"
-
-      - name: Push changes to git
-        run: |
-          git push origin ${GITHUB_REF##*/}
-          git push origin --tags
-
-      - name: Set up auth for npm publish
-        run: npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      # - name: Smoke test release
-      #   TODO: set up verdaccio to mock npm https://verdaccio.org/
-
-      # this needs `--no-verify-access` until https://github.com/lerna/lerna/issues/2788 is fixed
-      - name: Release to npm
-        run: |
-          $(npm bin)/lerna publish from-package --yes --dist-tag ${TAG} --pre-dist-tag ${TAG} --no-verify-access
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Merge changes back into develop for latest release (master)
-        if: ${{ env.TAG == 'latest' }}
-        run: |
-          git checkout develop
-          git merge origin/master
-          git push origin develop
-
   publish-docker:
-    needs: release
     runs-on: ubuntu-20.04
     steps:
       # because the docker publish action is an action we made, we have to
@@ -177,14 +17,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ needs.release.outputs.TAG }}
       - name: Run Ganache's docker publish action
         # we are running our local action, so point directly to a folder
         # containing an `action.yml` file
         uses: ./.github/actions/docker-publish
         with:
-          VERSION: ${{ needs.release.outputs.VERSION }}
-          TAG: ${{ needs.release.outputs.TAG }}
+          VERSION: 7.6.0
+          TAG: latest
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           INFURA_KEY: ${{ secrets.INFURA_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: latest
+          ref: v7.6.0
       - name: Run Ganache's docker publish action
         # we are running our local action, so point directly to a folder
         # containing an `action.yml` file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,174 @@
-name: Test-Docker
+name: Release
 
 # allow only one "Release" workflow to run at a time
 concurrency: production
 
 on:
   push:
-    branches: [update-docker-release-action]
+    branches: [alpha, beta, rc, master]
 
 jobs:
+  release:
+    # this should match the os version used by the "check bundle size" step in
+    # pr.yml
+    runs-on: ubuntu-20.04
+    outputs:
+      TAG: ${{ steps.set_tag_output.outputs.TAG }}
+      VERSION: ${{ steps.set_version_output.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # we need all commit history so we can merge master into develop
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          # use node 14 until we can evaluate using npm 7+ and lock file version 2
+          # this should match the node version used by the "check bundle size"
+          # step in pr.yml
+          node-version: 14
+
+      - name: Import Robot GPG key
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.TRUFBOT_GPG_SECRET_KEY }}
+          passphrase: ${{ secrets.TRUFBOT_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Set git origin url
+        run: |
+          git remote set-url origin https://robot:${GITHUB_TOKEN}@github.com/$GITHUB_REPOSITORY
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set TAG for master to latest
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: |
+          echo "TAG=latest" >> $GITHUB_ENV
+
+      - name: Set TAG for non-master to the branch name
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: |
+          echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Set TAG as job output variable
+        id: set_tag_output
+        run: echo "::set-output name=TAG::${TAG}"
+
+      - name: Count features
+        if: ${{ env.TAG == 'latest'}}
+        # get all commits in develop that aren't in master, find any that start with feat: or feat(*):, then count them
+        # 1. `git tag --sort=-version:refname --no-contains HEAD`
+        #    - get a list of all tags that do NOT contain out current HEAD commit
+        #    - sort by version name
+        #    - in reverse order
+        # 2. `grep -P "^v(0|[1-9]\d*)?\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"`
+        #    - filter the list for semver matching tags only, e.g. "v*.*.*" (ignores pre-releases!)
+        #    - ignores pre-releases
+        #    - ignores improper tags like v01.02.03 (no leading 0s)
+        # 3. `head -1`
+        #    - get the last tag in the list
+        # 4. `git log ^$LATEST_TAG HEAD --pretty=format:%s`
+        #    - get all from the `LATEST_TAG` (exclusive) to `HEAD`
+        # 5. `grep -o -P '^feat(\(.*?\))?:'`
+        #    - output only the matching part (in case a newline can get in here... probably not possible?)
+        #    - filter for only commit subjects that match conventional commits for features, i.e., `feat:` or `feat(<subject>):`
+        # 6. `wc -l`
+        #    - count how many matches we have
+        # 7.  `>> $GITHUB_ENV`
+        #    - assign the above `FEATURE_COUNT` to the `wc` result (e.g., "FEATURE_COUNT=1") and append it to `$GITHUB_ENV`
+        run: |
+          LATEST_TAG=$(git tag --sort=-version:refname --no-contains HEAD | grep -P '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$' | head -1) &&
+          echo FEATURE_COUNT="$(git log ^"${LATEST_TAG}" HEAD --pretty=format:%s | grep -o -P '^feat(\(.*?\))?:' | wc -l)" >> "${GITHUB_ENV}"
+
+      - name: Determine Release Kind (minor)
+        # if we are "latest" and we have features, set the release to "minor"
+        if: ${{ env.TAG == 'latest' && env.FEATURE_COUNT != '0' }}
+        run: echo "RELEASE_KIND=minor" >> $GITHUB_ENV
+
+      - name: Determine Release Kind (patch)
+        # if we are "latest" and we do NOT have features, set the release to "patch"
+        if: ${{ env.TAG == 'latest' && env.FEATURE_COUNT == '0' }}
+        run: echo "RELEASE_KIND=patch" >> $GITHUB_ENV
+
+      - name: Run installation
+        run: npm ci
+
+      - name: Test
+        run: npm test
+        env:
+          FORCE_COLOR: 1
+          INFURA_KEY: ${{ secrets.TEST_INFURA_KEY }}
+
+      - name: Update package versions for latest release (master)
+        if: ${{ env.TAG == 'latest' }}
+        run: $(npm bin)/lerna version "$RELEASE_KIND" --no-git-tag-version --no-push --yes --exact
+
+      - name: Update package versions for pre-releases
+        if: ${{ env.TAG != 'latest' }}
+        run: $(npm bin)/lerna version prerelease --no-git-tag-version --no-push --yes --exact --preid "$TAG"
+
+      - name: Add updated versions to git
+        run: git add .
+
+      - name: Run build
+        run: npm run build
+        env:
+          INFURA_KEY: ${{ secrets.INFURA_KEY }}
+
+      - name: Update documentation
+        run: |
+          npm run docs.build
+          git add docs/**
+
+      - name: Set VERSION
+        run: |
+          echo "VERSION=$(node -e 'console.log(require("./src/packages/ganache/package.json").version)')" >> $GITHUB_ENV
+
+      - name: Set VERSION as job output variable
+        id: set_version_output
+        run: echo "::set-output name=VERSION::${VERSION}"
+
+      - name: Commit all staged changes
+        run: |
+          git commit -m "chore(release): publish v${VERSION}" -m "ganache@${VERSION}"
+
+      - name: Tag the amended release commit
+        run: |
+          git tag -a "ganache@${VERSION}" -m "ganache@${VERSION}"
+          git tag -a "v${VERSION}" -m "v${VERSION}"
+
+      - name: Push changes to git
+        run: |
+          git push origin ${GITHUB_REF##*/}
+          git push origin --tags
+
+      - name: Set up auth for npm publish
+        run: npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # - name: Smoke test release
+      #   TODO: set up verdaccio to mock npm https://verdaccio.org/
+
+      # this needs `--no-verify-access` until https://github.com/lerna/lerna/issues/2788 is fixed
+      - name: Release to npm
+        run: |
+          $(npm bin)/lerna publish from-package --yes --dist-tag ${TAG} --pre-dist-tag ${TAG} --no-verify-access
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge changes back into develop for latest release (master)
+        if: ${{ env.TAG == 'latest' }}
+        run: |
+          git checkout develop
+          git merge origin/master
+          git push origin develop
+
   publish-docker:
+    needs: release
     runs-on: ubuntu-20.04
     steps:
       # because the docker publish action is an action we made, we have to
@@ -17,14 +177,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: v7.6.0
+          ref: ${{ needs.release.outputs.TAG }}
       - name: Run Ganache's docker publish action
         # we are running our local action, so point directly to a folder
         # containing an `action.yml` file
         uses: ./.github/actions/docker-publish
         with:
-          VERSION: 7.6.0
-          TAG: latest
+          VERSION: ${{ needs.release.outputs.VERSION }}
+          TAG: ${{ needs.release.outputs.TAG }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           INFURA_KEY: ${{ secrets.INFURA_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,174 +1,14 @@
-name: Release
+name: Test-Docker
 
 # allow only one "Release" workflow to run at a time
 concurrency: production
 
 on:
   push:
-    branches: [alpha, beta, rc, master]
+    branches: [update-docker-release-action]
 
 jobs:
-  release:
-    # this should match the os version used by the "check bundle size" step in
-    # pr.yml
-    runs-on: ubuntu-20.04
-    outputs:
-      TAG: ${{ steps.set_tag_output.outputs.TAG }}
-      VERSION: ${{ steps.set_version_output.outputs.VERSION }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # we need all commit history so we can merge master into develop
-          fetch-depth: 0
-      - uses: actions/setup-node@v3
-        with:
-          # use node 14 until we can evaluate using npm 7+ and lock file version 2
-          # this should match the node version used by the "check bundle size"
-          # step in pr.yml
-          node-version: 14
-
-      - name: Import Robot GPG key
-        uses: crazy-max/ghaction-import-gpg@v4
-        with:
-          gpg_private_key: ${{ secrets.TRUFBOT_GPG_SECRET_KEY }}
-          passphrase: ${{ secrets.TRUFBOT_GPG_PASSPHRASE }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-
-      - name: Set git origin url
-        run: |
-          git remote set-url origin https://robot:${GITHUB_TOKEN}@github.com/$GITHUB_REPOSITORY
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set TAG for master to latest
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: |
-          echo "TAG=latest" >> $GITHUB_ENV
-
-      - name: Set TAG for non-master to the branch name
-        if: ${{ github.ref != 'refs/heads/master' }}
-        run: |
-          echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
-
-      - name: Set TAG as job output variable
-        id: set_tag_output
-        run: echo "::set-output name=TAG::${TAG}"
-
-      - name: Count features
-        if: ${{ env.TAG == 'latest'}}
-        # get all commits in develop that aren't in master, find any that start with feat: or feat(*):, then count them
-        # 1. `git tag --sort=-version:refname --no-contains HEAD`
-        #    - get a list of all tags that do NOT contain out current HEAD commit
-        #    - sort by version name
-        #    - in reverse order
-        # 2. `grep -P "^v(0|[1-9]\d*)?\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"`
-        #    - filter the list for semver matching tags only, e.g. "v*.*.*" (ignores pre-releases!)
-        #    - ignores pre-releases
-        #    - ignores improper tags like v01.02.03 (no leading 0s)
-        # 3. `head -1`
-        #    - get the last tag in the list
-        # 4. `git log ^$LATEST_TAG HEAD --pretty=format:%s`
-        #    - get all from the `LATEST_TAG` (exclusive) to `HEAD`
-        # 5. `grep -o -P '^feat(\(.*?\))?:'`
-        #    - output only the matching part (in case a newline can get in here... probably not possible?)
-        #    - filter for only commit subjects that match conventional commits for features, i.e., `feat:` or `feat(<subject>):`
-        # 6. `wc -l`
-        #    - count how many matches we have
-        # 7.  `>> $GITHUB_ENV`
-        #    - assign the above `FEATURE_COUNT` to the `wc` result (e.g., "FEATURE_COUNT=1") and append it to `$GITHUB_ENV`
-        run: |
-          LATEST_TAG=$(git tag --sort=-version:refname --no-contains HEAD | grep -P '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$' | head -1) &&
-          echo FEATURE_COUNT="$(git log ^"${LATEST_TAG}" HEAD --pretty=format:%s | grep -o -P '^feat(\(.*?\))?:' | wc -l)" >> "${GITHUB_ENV}"
-
-      - name: Determine Release Kind (minor)
-        # if we are "latest" and we have features, set the release to "minor"
-        if: ${{ env.TAG == 'latest' && env.FEATURE_COUNT != '0' }}
-        run: echo "RELEASE_KIND=minor" >> $GITHUB_ENV
-
-      - name: Determine Release Kind (patch)
-        # if we are "latest" and we do NOT have features, set the release to "patch"
-        if: ${{ env.TAG == 'latest' && env.FEATURE_COUNT == '0' }}
-        run: echo "RELEASE_KIND=patch" >> $GITHUB_ENV
-
-      - name: Run installation
-        run: npm ci
-
-      - name: Test
-        run: npm test
-        env:
-          FORCE_COLOR: 1
-          INFURA_KEY: ${{ secrets.TEST_INFURA_KEY }}
-
-      - name: Update package versions for latest release (master)
-        if: ${{ env.TAG == 'latest' }}
-        run: $(npm bin)/lerna version "$RELEASE_KIND" --no-git-tag-version --no-push --yes --exact
-
-      - name: Update package versions for pre-releases
-        if: ${{ env.TAG != 'latest' }}
-        run: $(npm bin)/lerna version prerelease --no-git-tag-version --no-push --yes --exact --preid "$TAG"
-
-      - name: Add updated versions to git
-        run: git add .
-
-      - name: Run build
-        run: npm run build
-        env:
-          INFURA_KEY: ${{ secrets.INFURA_KEY }}
-
-      - name: Update documentation
-        run: |
-          npm run docs.build
-          git add docs/**
-
-      - name: Set VERSION
-        run: |
-          echo "VERSION=$(node -e 'console.log(require("./src/packages/ganache/package.json").version)')" >> $GITHUB_ENV
-
-      - name: Set VERSION as job output variable
-        id: set_version_output
-        run: echo "::set-output name=VERSION::${VERSION}"
-
-      - name: Commit all staged changes
-        run: |
-          git commit -m "chore(release): publish v${VERSION}" -m "ganache@${VERSION}"
-
-      - name: Tag the amended release commit
-        run: |
-          git tag -a "ganache@${VERSION}" -m "ganache@${VERSION}"
-          git tag -a "v${VERSION}" -m "v${VERSION}"
-
-      - name: Push changes to git
-        run: |
-          git push origin ${GITHUB_REF##*/}
-          git push origin --tags
-
-      - name: Set up auth for npm publish
-        run: npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      # - name: Smoke test release
-      #   TODO: set up verdaccio to mock npm https://verdaccio.org/
-
-      # this needs `--no-verify-access` until https://github.com/lerna/lerna/issues/2788 is fixed
-      - name: Release to npm
-        run: |
-          $(npm bin)/lerna publish from-package --yes --dist-tag ${TAG} --pre-dist-tag ${TAG} --no-verify-access
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Merge changes back into develop for latest release (master)
-        if: ${{ env.TAG == 'latest' }}
-        run: |
-          git checkout develop
-          git merge origin/master
-          git push origin develop
-
   publish-docker:
-    needs: release
     runs-on: ubuntu-20.04
     steps:
       # because the docker publish action is an action we made, we have to
@@ -182,8 +22,8 @@ jobs:
         # containing an `action.yml` file
         uses: ./.github/actions/docker-publish
         with:
-          VERSION: ${{ needs.release.outputs.VERSION }}
-          TAG: ${{ needs.release.outputs.TAG }}
+          VERSION: 7.6.0
+          TAG: latest
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           INFURA_KEY: ${{ secrets.INFURA_KEY }}


### PR DESCRIPTION
Some of the GitHub Actions commands used by our Docker Publish Action are deprecated. This PR updates the Actions to versions that have since been updated to stop using these deprecated commands.