### PR TITLE
fix: add `"EADDRINUSE"` as `code` to server `Error`

### DIFF
--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -245,7 +245,7 @@ export class Server<
             `listen EADDRINUSE: address already in use ${
               host || DEFAULT_HOST
             }:${portNumber}.`
-          ) as any;
+          ) as NodeJS.ErrnoException;
           // emulate part of node's EADDRINUSE error:
           err.code = "EADDRINUSE";
           throw err;

--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -245,7 +245,9 @@ export class Server<
             `listen EADDRINUSE: address already in use ${
               host || DEFAULT_HOST
             }:${portNumber}.`
-          );
+          ) as any;
+          // emulate part of node's EADDRINUSE error:
+          err.code = "EADDRINUSE";
           throw err;
         }
       })

--- a/src/packages/core/tests/server.test.ts
+++ b/src/packages/core/tests/server.test.ts
@@ -493,10 +493,10 @@ describe("server", () => {
       server.listen(port);
 
       try {
-        await assert.rejects(
-          setup(),
-          `Error: listen EADDRINUSE: address already in use 127.0.0.1:${port}.`
-        );
+        await assert.rejects(setup(), {
+          message: `Error: listen EADDRINUSE: address already in use 127.0.0.1:${port}.`,
+          code: "EADDRINUSE"
+        });
       } finally {
         await Promise.all([
           teardown(),
@@ -517,7 +517,8 @@ describe("server", () => {
         const s = Ganache.server();
         const listen = promisify(s.listen.bind(s));
         await assert.rejects(listen(port), {
-          message: `listen EADDRINUSE: address already in use 127.0.0.1:${port}.`
+          message: `listen EADDRINUSE: address already in use 127.0.0.1:${port}.`,
+          code: "EADDRINUSE"
         });
       } finally {
         await Promise.all([

--- a/src/packages/core/tests/server.test.ts
+++ b/src/packages/core/tests/server.test.ts
@@ -494,7 +494,7 @@ describe("server", () => {
 
       try {
         await assert.rejects(setup(), {
-          message: `Error: listen EADDRINUSE: address already in use 127.0.0.1:${port}.`,
+          message: `listen EADDRINUSE: address already in use 127.0.0.1:${port}.`,
           code: "EADDRINUSE"
         });
       } finally {


### PR DESCRIPTION
This PR sets the `code` property related to the error `"listen EADDRINUSE: address already in use { address }"` to "EADDRINUSE", making detecting this kind of "address in use" error programmatically much easier and straightforward. This property existed in Ganache v6 and earlier and was removed in v7.0.0 in error.

Previously:

```json
{
  "message": "listen EADDRINUSE: address already in use 127.0.0.1:5001"
}
```

Now:

```json
{
  "code": "EADDRINUSE",
  "message": "listen EADDRINUSE: address already in use 127.0.0.1:5001"
}
```

Fixes #4020