### PR TITLE
fix: add leveldown back to bundle for Windows installation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,5 +70,6 @@ jobs:
         # this should match the os and version used in the release.yml
         if: startsWith(matrix.os, 'ubuntu-20.04') && startsWith(matrix.node, '14.')
         uses: actions/upload-artifact@v3
+        with:
           name: Candidate
-            path: ./src/packages/ganache/ganache-*.tgz
+          path: ./src/packages/ganache/ganache-*.tgz

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,3 +66,9 @@ jobs:
           # use a fake infura key for the bundle size check so this test will
           # run successfully on external contributor Pull Requests
           INFURA_KEY: "badc0de0deadc0debadc0de0deadc0de"
+      - name: Upload artifact
+        # this should match the os and version used in the release.yml
+        if: startsWith(matrix.os, 'ubuntu-20.04') && startsWith(matrix.node, '14.')
+        uses: actions/upload-artifact@v3
+          name: Candidate
+            path: ./src/packages/ganache/ganache-*.tgz

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,6 +56,7 @@ jobs:
         # 5. exit with non-zero exit code if the test fails.
         run: |
           npm run build &&
+          npm run prepublishOnly &&
           cd ./src/packages/ganache &&
           npm pack &&
           size="$(zcat ganache-*.tgz | wc -c)" &&

--- a/src/packages/ganache/package.json
+++ b/src/packages/ganache/package.json
@@ -112,9 +112,6 @@
     "@trufflesuite/bigint-buffer",
     "keccak",
     "leveldown",
-    "secp256k1",
-    "@types/bn.js",
-    "@types/lru-cache",
-    "@types/seedrandom"
+    "secp256k1"
   ]
 }

--- a/src/packages/ganache/package.json
+++ b/src/packages/ganache/package.json
@@ -114,6 +114,7 @@
     "async-eventemitter",
     "emittery",
     "keccak",
+    "leveldown",
     "secp256k1",
     "@types/bn.js",
     "@types/lru-cache",

--- a/src/packages/ganache/package.json
+++ b/src/packages/ganache/package.json
@@ -110,9 +110,6 @@
   },
   "bundledDependencies": [
     "@trufflesuite/bigint-buffer",
-    "abstract-leveldown",
-    "async-eventemitter",
-    "emittery",
     "keccak",
     "leveldown",
     "secp256k1",


### PR DESCRIPTION
For reasons not yet understood, the `leveldown` package must be bundled or installations on Windows without windows-build-tools installed fails. This puts the `leveldown` package back into the `ganache` package's `bundledDependencies`.

This PR also introduces changes to our CI process to build a release candidate tarball during test runs.

Fixes #3661