### PR TITLE
fix: handle `eth_gasEstimate` reverts correctly to prevent potential process crash

### DIFF
--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -960,7 +960,7 @@ export default class EthereumApi implements Api {
         generateVM,
         runArgs,
         (err: Error, result: EstimateGasResult) => {
-          if (err) reject(err);
+          if (err) return void reject(err);
           resolve(Quantity.from(result.gasEstimate));
         }
       );

--- a/src/chains/ethereum/ethereum/tests/api/eth/estimateGas.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/estimateGas.test.ts
@@ -1,0 +1,45 @@
+import assert from "assert";
+import getProvider from "../../helpers/getProvider";
+
+describe("api", () => {
+  describe("eth", () => {
+    describe("estimateGas", () => {
+      it("shouldn't raise an unhandled rejection when the transaction fails", async () => {
+        // see https://github.com/trufflesuite/ganache/pull/4056
+        const provider = await getProvider();
+        const [from] = await provider.request({
+          method: "eth_accounts",
+          params: []
+        });
+
+        const transaction = {
+          from,
+          // invalid bytecode
+          input: "0x1234"
+        };
+
+        let didRaiseUnhandledRejection = false;
+        const unhandledRejectionHandler = () =>
+          (didRaiseUnhandledRejection = true);
+        process.once("unhandledRejection", unhandledRejectionHandler);
+
+        try {
+          const estimatingGas = provider.request({
+            method: "eth_estimateGas",
+            params: [transaction]
+          });
+
+          await assert.rejects(estimatingGas);
+          await new Promise(resolve => setImmediate(resolve));
+
+          assert(
+            didRaiseUnhandledRejection === false,
+            "Shouldn't have raised an unhandledRejection"
+          );
+        } finally {
+          process.off("unhandledRejection", unhandledRejectionHandler);
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
When updating to support the Merge hardfork code that handled `eth_gasEstimate` was refactored. A code block that previously "short circuited" the function no longer did, causing a JavaScript Promise to be fullfilled with a _handled_ rejection, but then also an _unhandled_ rejection.

We've fixed the short circuit code and added a test to prevent this from regressing in the future.