### PR TITLE
fix: make empty string mnemonic use default path

### DIFF
--- a/src/chains/ethereum/options/src/miner-options.ts
+++ b/src/chains/ethereum/options/src/miner-options.ts
@@ -221,6 +221,10 @@ const toNumberOrString = (str: string) => {
   }
 };
 
+const normalizeQuantity = (rawInput: number | bigint | string | Buffer) => {
+  return Quantity.from(rawInput);
+};
+
 export const MinerOptions: Definitions<MinerConfig> = {
   blockTime: {
     normalize: rawInput => {
@@ -246,7 +250,7 @@ export const MinerOptions: Definitions<MinerConfig> = {
     cliType: "string"
   },
   defaultGasPrice: {
-    normalize: Quantity.from,
+    normalize: normalizeQuantity,
     cliDescription:
       "Sets the default gas price in WEI for transactions if not otherwise specified.",
     default: () => Quantity.from(2_000_000_000),
@@ -256,7 +260,7 @@ export const MinerOptions: Definitions<MinerConfig> = {
     cliCoerce: toBigIntOrString
   },
   blockGasLimit: {
-    normalize: Quantity.from,
+    normalize: normalizeQuantity,
     cliDescription: "Sets the block gas limit in WEI.",
     default: () => Quantity.from(30_000_000),
     legacyName: "gasLimit",
@@ -274,7 +278,7 @@ export const MinerOptions: Definitions<MinerConfig> = {
     cliCoerce: estimateOrToBigIntOrString
   },
   difficulty: {
-    normalize: Quantity.from,
+    normalize: normalizeQuantity,
     cliDescription:
       "Sets the block difficulty. Value is always 0 after the merge hardfork.",
     default: () => Quantity.One,
@@ -282,7 +286,7 @@ export const MinerOptions: Definitions<MinerConfig> = {
     cliCoerce: toBigIntOrString
   },
   callGasLimit: {
-    normalize: Quantity.from,
+    normalize: normalizeQuantity,
     cliDescription:
       "Sets the transaction gas limit in WEI for `eth_call` and `eth_estimateGas` calls.",
     default: () => Quantity.from(50_000_000),

--- a/src/chains/ethereum/options/src/wallet-options.ts
+++ b/src/chains/ethereum/options/src/wallet-options.ts
@@ -263,7 +263,17 @@ export const WalletOptions: Definitions<WalletConfig> = {
     conflicts: ["mnemonic", "deterministic"]
   },
   mnemonic: {
-    normalize,
+    // if the mnemonic is empty, we want to throw an error because it is likely
+    // unexpected behavior
+    normalize: (mnemonic, config) => {
+      // if the mnemonic is `""` use `default` mnemonic generation.
+      if (mnemonic === "") {
+        // NOTE: the `flavor` param here isn't used by `default` but is
+        // required by the `default` function signature, so we pass in ""
+        return WalletOptions.mnemonic.default(config, "");
+      }
+      return mnemonic;
+    },
     cliDescription:
       "Use a specific HD wallet mnemonic to generate initial addresses.",
     // The order of the options matter here! `wallet.seed`

--- a/src/chains/ethereum/options/tests/index.test.ts
+++ b/src/chains/ethereum/options/tests/index.test.ts
@@ -50,6 +50,18 @@ describe("EthereumOptionsConfig", () => {
         } as Object);
       });
     });
+    it("uses default mnemonic path when 'mnemonic' is an empty string", () => {
+      const config = {
+        wallet: { mnemonic: "" }
+      };
+      const options1 = EthereumOptionsConfig.normalize(config);
+      const options2 = EthereumOptionsConfig.normalize(config);
+      // we should effectively ignore the empty string:
+      assert.notStrictEqual(options1.wallet.mnemonic, "");
+      assert.notStrictEqual(options2.wallet.mnemonic, "");
+      // and we should generate a different mnemonic each time:
+      assert.notStrictEqual(options1.wallet.mnemonic, options2.wallet.mnemonic);
+    });
 
     describe("legacy input formats", () => {
       it("accepts some legacy input formats", () => {

--- a/src/packages/options/src/create.ts
+++ b/src/packages/options/src/create.ts
@@ -53,7 +53,10 @@ function fill(defaults: any, options: any, target: any, namespace: any) {
       const propDefinition = def[key];
       let value = namespaceOptions[key];
       if (value !== undefined) {
-        const normalized = propDefinition.normalize(namespaceOptions[key]);
+        const normalized = propDefinition.normalize(
+          namespaceOptions[key],
+          config
+        );
         if (normalized !== undefined) {
           checkForConflicts(
             key,
@@ -68,7 +71,7 @@ function fill(defaults: any, options: any, target: any, namespace: any) {
         const legacyName = propDefinition.legacyName || key;
         value = options[legacyName];
         if (value !== undefined) {
-          const normalized = propDefinition.normalize(value);
+          const normalized = propDefinition.normalize(value, config);
           if (normalized !== undefined) {
             checkForConflicts(
               key,
@@ -92,7 +95,7 @@ function fill(defaults: any, options: any, target: any, namespace: any) {
       const legacyName = propDefinition.legacyName || key;
       const value = options[legacyName];
       if (value !== undefined) {
-        const normalized = propDefinition.normalize(value);
+        const normalized = propDefinition.normalize(value, config);
         if (normalized !== undefined) {
           checkForConflicts(
             key,

--- a/src/packages/options/src/definition.ts
+++ b/src/packages/options/src/definition.ts
@@ -19,7 +19,10 @@ import { UnionToIntersection } from "./types";
 type Normalize<
   C extends Base.Config,
   N extends OptionName<C> = OptionName<C>
-> = (rawInput: OptionRawType<C, N>) => OptionType<C, N>;
+> = (
+  rawInput: OptionRawType<C, N>,
+  config: InternalConfig<C>
+) => OptionType<C, N>;
 
 export type ExternalConfig<C extends Base.Config> = Partial<
   ExclusiveGroupUnionAndUnconstrainedPlus<C, "rawType">


### PR DESCRIPTION
For reviewers:

I don't know if this is the best approach. Maybe we should throw instead?