### PR TITLE
fix: make port `0` bind to any available port

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Check bundle size
         # this should match the os and version used in the release.yml
-        if: startsWith(matrix.os, 'ubuntu-22.04') && startsWith(matrix.node, '14.')
+        if: startsWith(matrix.os, 'ubuntu-22.04') && startsWith(matrix.node, '14.') && matrix.node != '14.0.0'
         # 1. build ganache
         # 2. pack it into a tarball
         # 3. measure the _unpacked_ tarball's size
@@ -65,7 +65,7 @@ jobs:
           INFURA_KEY: "badc0de0deadc0debadc0de0deadc0de"
       - name: Upload artifact
         # this should match the os and version used in the release.yml
-        if: startsWith(matrix.os, 'ubuntu-22.04') && startsWith(matrix.node, '14.')
+        if: startsWith(matrix.os, 'ubuntu-22.04') && startsWith(matrix.node, '14.') && matrix.node != '14.0.0'
         uses: actions/upload-artifact@v3
         with:
           name: Candidate

--- a/src/chains/ethereum/ethereum/package-lock.json
+++ b/src/chains/ethereum/ethereum/package-lock.json
@@ -2441,9 +2441,9 @@
 			"dev": true
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.10.0-unofficial.1",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.1.tgz",
-			"integrity": "sha512-35K4XHmqWHLD9k0UsveCJG3NJ0zqdYG3cfRE8Z0984aNwNN+uf5nSNLcrUSs5szJExbknmSwJyHPOLtD+AiEeg==",
+			"version": "20.10.0-unofficial.2",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.2.tgz",
+			"integrity": "sha512-oQQlnS3oNeGsgS4K3KCSSavJgSb0W9D5ktZs4FacX9VbM7b+NlhjH96d6/G4fMrz+bc5MXRyco419on0X0dvRA==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",

--- a/src/chains/ethereum/ethereum/package.json
+++ b/src/chains/ethereum/ethereum/package.json
@@ -87,7 +87,7 @@
     "ws": "8.2.3"
   },
   "devDependencies": {
-    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.1",
+    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.2",
     "@types/encoding-down": "5.0.0",
     "@types/fs-extra": "9.0.2",
     "@types/keccak": "3.0.1",

--- a/src/chains/filecoin/filecoin/package-lock.json
+++ b/src/chains/filecoin/filecoin/package-lock.json
@@ -861,9 +861,9 @@
 			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.10.0-unofficial.1",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.1.tgz",
-			"integrity": "sha512-35K4XHmqWHLD9k0UsveCJG3NJ0zqdYG3cfRE8Z0984aNwNN+uf5nSNLcrUSs5szJExbknmSwJyHPOLtD+AiEeg==",
+			"version": "20.10.0-unofficial.2",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.2.tgz",
+			"integrity": "sha512-oQQlnS3oNeGsgS4K3KCSSavJgSb0W9D5ktZs4FacX9VbM7b+NlhjH96d6/G4fMrz+bc5MXRyco419on0X0dvRA==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",
@@ -1903,15 +1903,6 @@
 			"optional": true,
 			"requires": {
 				"node-gyp-build": "^4.3.0"
-			},
-			"dependencies": {
-				"node-gyp-build": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-					"integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
-					"dev": true,
-					"optional": true
-				}
 			}
 		},
 		"bufio": {
@@ -10498,15 +10489,6 @@
 			"optional": true,
 			"requires": {
 				"node-gyp-build": "^4.3.0"
-			},
-			"dependencies": {
-				"node-gyp-build": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-					"integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
-					"dev": true,
-					"optional": true
-				}
 			}
 		},
 		"utf8-byte-length": {

--- a/src/chains/filecoin/filecoin/package.json
+++ b/src/chains/filecoin/filecoin/package.json
@@ -59,7 +59,7 @@
     "@filecoin-shipyard/lotus-client-schema": "2.0.0",
     "@ganache/filecoin-options": "0.7.0",
     "@ganache/utils": "0.7.0",
-    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.1",
+    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.2",
     "@types/abstract-leveldown": "7.2.0",
     "@types/bn.js": "5.1.0",
     "@types/deep-equal": "1.0.1",

--- a/src/chains/tezos/tezos/package-lock.json
+++ b/src/chains/tezos/tezos/package-lock.json
@@ -51,9 +51,9 @@
 			"dev": true
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.10.0-unofficial.1",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.1.tgz",
-			"integrity": "sha512-35K4XHmqWHLD9k0UsveCJG3NJ0zqdYG3cfRE8Z0984aNwNN+uf5nSNLcrUSs5szJExbknmSwJyHPOLtD+AiEeg==",
+			"version": "20.10.0-unofficial.2",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.2.tgz",
+			"integrity": "sha512-oQQlnS3oNeGsgS4K3KCSSavJgSb0W9D5ktZs4FacX9VbM7b+NlhjH96d6/G4fMrz+bc5MXRyco419on0X0dvRA==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",
@@ -1831,9 +1831,9 @@
 			"dev": true
 		},
 		"node-gyp-build": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-			"integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+			"integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
 			"dev": true,
 			"optional": true
 		},

--- a/src/chains/tezos/tezos/package.json
+++ b/src/chains/tezos/tezos/package.json
@@ -47,7 +47,7 @@
     "emittery": "0.10.0"
   },
   "devDependencies": {
-    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.1",
+    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.2",
     "@types/mocha": "9.0.0",
     "cheerio": "1.0.0-rc.3",
     "cross-env": "7.0.3",

--- a/src/packages/cli/src/args.ts
+++ b/src/packages/cli/src/args.ts
@@ -218,7 +218,7 @@ export default function (
           })
           .check(argv => {
             const { "server.port": port, "server.host": host } = argv;
-            if (port < 1 || port > 65535) {
+            if (port < 0 || port > 65535) {
               throw new Error(`Invalid port number '${port}'`);
             }
 

--- a/src/packages/cli/src/cli.ts
+++ b/src/packages/cli/src/cli.ts
@@ -158,7 +158,7 @@ if (argv.action === "start") {
     // instance), so we need to notify that we are ready.
     const isDetachedInstance = process.send !== undefined;
     if (isDetachedInstance) {
-      notifyDetachedInstanceReady();
+      notifyDetachedInstanceReady(port);
     }
   });
 } else if (argv.action === "stop") {

--- a/src/packages/cli/src/cli.ts
+++ b/src/packages/cli/src/cli.ts
@@ -138,17 +138,18 @@ if (argv.action === "start") {
       return;
     }
     started = true;
+    const { address: host, port } = server.address();
     switch (flavor) {
       case FilecoinFlavorName: {
-        await initializeFilecoin(
-          server.provider as FilecoinProvider,
-          cliSettings
-        );
+        await initializeFilecoin(server.provider as FilecoinProvider, {
+          host,
+          port
+        });
         break;
       }
       case EthereumFlavorName:
       default: {
-        initializeEthereum(server.provider as EthereumProvider, cliSettings);
+        initializeEthereum(server.provider as EthereumProvider, { host, port });
         break;
       }
     }

--- a/src/packages/cli/src/detach.ts
+++ b/src/packages/cli/src/detach.ts
@@ -114,7 +114,7 @@ export async function startDetachedInstance(
 
   // Wait for the child process to send the "ready" message, which indicates
   // that the Ganache server has started and is ready to receive RPC requests.
-  // It signals by sending the port number to which it was bound to back to us;
+  // It signals by sending the port number to which it was bound back to us;
   // this is needed because Ganache may bind to a random port if the user
   // specified port 0.
   const actualPort = await new Promise<number>((resolve, reject) => {

--- a/src/packages/cli/src/detach.ts
+++ b/src/packages/cli/src/detach.ts
@@ -117,7 +117,7 @@ export async function startDetachedInstance(
   // It signals by sending the port number to which it was bound back to us;
   // this is needed because Ganache may bind to a random port if the user
   // specified port 0.
-  const actualPort = await new Promise<number>((resolve, reject) => {
+  const port = await new Promise<number>((resolve, reject) => {
     child.on("message", port => {
       resolve(port as number);
     });
@@ -148,7 +148,7 @@ export async function startDetachedInstance(
   child.disconnect();
 
   const flavor = instanceInfo.flavor;
-  const { host, port } = instanceInfo.server;
+  const { host } = instanceInfo.server;
   const cmd =
     process.platform === "win32"
       ? path.basename(process.execPath)
@@ -161,7 +161,7 @@ export async function startDetachedInstance(
     pid,
     name: createInstanceName(),
     host,
-    port: actualPort,
+    port,
     flavor,
     cmd,
     version

--- a/src/packages/cli/src/detach.ts
+++ b/src/packages/cli/src/detach.ts
@@ -32,7 +32,7 @@ function getInstanceFilePath(instanceName: string): string {
  * Notify that the detached instance has started and is ready to receive requests.
  */
 export function notifyDetachedInstanceReady(port: number) {
-  // in "detach" mode, the parent will wait until the "ready" message is
+  // in "detach" mode, the parent will wait until the port is
   // received before disconnecting from the child process.
   process.send(port);
 }
@@ -112,11 +112,10 @@ export async function startDetachedInstance(
   // event is emitted) will be streamed to stderr on the parent.
   child.stderr.pipe(process.stderr);
 
-  // Wait for the child process to send the "ready" message, which indicates
-  // that the Ganache server has started and is ready to receive RPC requests.
-  // It signals by sending the port number to which it was bound back to us;
-  // this is needed because Ganache may bind to a random port if the user
-  // specified port 0.
+  // Wait for the child process to send its port, which indicates that the
+  // Ganache server has started and is ready to receive RPC requests. It signals
+  // by sending the port number to which it was bound back to us; this is needed
+  // because Ganache may bind to a random port if the user specified port 0.
   const port = await new Promise<number>((resolve, reject) => {
     child.on("message", port => {
       resolve(port as number);

--- a/src/packages/core/package-lock.json
+++ b/src/packages/core/package-lock.json
@@ -452,9 +452,9 @@
 			}
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.10.0-unofficial.1",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.1.tgz",
-			"integrity": "sha512-35K4XHmqWHLD9k0UsveCJG3NJ0zqdYG3cfRE8Z0984aNwNN+uf5nSNLcrUSs5szJExbknmSwJyHPOLtD+AiEeg==",
+			"version": "20.10.0-unofficial.2",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.2.tgz",
+			"integrity": "sha512-oQQlnS3oNeGsgS4K3KCSSavJgSb0W9D5ktZs4FacX9VbM7b+NlhjH96d6/G4fMrz+bc5MXRyco419on0X0dvRA==",
 			"requires": {
 				"bufferutil": "4.0.5",
 				"utf-8-validate": "5.0.7",
@@ -1514,9 +1514,9 @@
 			"dev": true
 		},
 		"node-gyp-build": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-			"integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+			"integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
 			"optional": true
 		},
 		"node-preload": {

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -53,7 +53,7 @@
     "@ganache/options": "0.7.0",
     "@ganache/tezos": "0.7.0",
     "@ganache/utils": "0.7.0",
-    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.1",
+    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.2",
     "aggregate-error": "3.1.0",
     "emittery": "0.10.0"
   },

--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -33,8 +33,13 @@ import ConnectorLoader from "./connector-loader";
 import WebsocketServer, { WebSocketCapableFlavor } from "./servers/ws-server";
 import HttpServer from "./servers/http-server";
 import Emittery from "emittery";
-import { createServer } from "http";
-import { isIPv4 } from "net";
+
+// not using the "net" node package in order to avoid having to polyfill this
+// for the browser build.
+// isIPv4 taken from https://github.com/nodejs/node/blob/01323d50c4b24cf730a651d06ba20633905ecbed/lib/internal/net.js#L31
+const v4Seg = "(?:[0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])";
+const IPv4Reg = new RegExp(`^(${v4Seg}[.]){3}${v4Seg}$`);
+const isIPv4 = (s: string) => IPv4Reg.test(s);
 
 export type Provider = Connector["provider"];
 

--- a/src/packages/core/src/server.ts
+++ b/src/packages/core/src/server.ts
@@ -290,7 +290,7 @@ export class Server<
   }
 
   public address() {
-    if (this.#status === ServerStatus.open) {
+    if (this.#listenSocket) {
       const address = this.#host;
       return {
         address,

--- a/src/packages/core/tests/server.test.ts
+++ b/src/packages/core/tests/server.test.ts
@@ -353,7 +353,7 @@ describe("server", () => {
           assert.strictEqual(
             address!.port,
             +specificPort,
-            "server.address().port should be non-zero after server.listen(0)"
+            "server.address().port should be equal to the specified port after server.listen(nonZeroPort)"
           );
           const req = request.post(`http://localhost:${+specificPort}`);
           await req.send(jsonRpcJson);

--- a/src/packages/core/tests/server.test.ts
+++ b/src/packages/core/tests/server.test.ts
@@ -336,15 +336,71 @@ describe("server", () => {
 
       for (const specificPort of validPorts) {
         s = Ganache.server(defaultOptions);
+        assert.strictEqual(
+          s.address(),
+          null,
+          "server.address() should be null before `server.listen(...)` is called"
+        );
         await s.listen(<any>specificPort);
 
         try {
+          const address = s.address();
+          assert.notEqual(
+            address,
+            null,
+            "server.address() should not be null after listening"
+          );
+          assert.strictEqual(
+            address!.port,
+            +specificPort,
+            "server.address().port should be non-zero after server.listen(0)"
+          );
           const req = request.post(`http://localhost:${+specificPort}`);
           await req.send(jsonRpcJson);
         } finally {
           await teardown();
         }
+        assert.strictEqual(
+          s.address(),
+          null,
+          "server.address() should be null after server is stopped"
+        );
       }
+    });
+
+    it("finds a port to listen on when port is 0", async () => {
+      const zeroPort = 0;
+      s = Ganache.server(defaultOptions);
+      assert.strictEqual(
+        s.address(),
+        null,
+        "server.address() should be null before `server.listen(...)` is called"
+      );
+      await s.listen(zeroPort);
+
+      try {
+        const address = s.address();
+        assert.notEqual(
+          address,
+          null,
+          "server.address() should not be null after listening"
+        );
+        const specificPort = address!.port;
+        assert.notStrictEqual(
+          specificPort,
+          zeroPort,
+          "server.address().port should be non-zero after server.listen(0)"
+        );
+        const req = request.post(`http://localhost:${+specificPort}`);
+        await req.send(jsonRpcJson);
+      } finally {
+        await teardown();
+      }
+      assert.strictEqual(
+        s.address(),
+        null,
+        "server.address() should be null after server is stopped"
+      );
     });
 
     it("fails with invalid ports", async () => {
@@ -369,8 +425,7 @@ describe("server", () => {
         "-0o1",
         "-0b1",
         "0o",
-        "0b",
-        0
+        "0b"
       ];
 
       for (const specificPort of invalidPorts) {

--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -165,7 +165,7 @@ const ganache = require("ganache");
 
 const options = {};
 const server = ganache.server(options);
-const PORT = 0; // 0 means any port
+const PORT = 0; // 0 means any available port
 server.listen(PORT, async err => {
   if (err) throw err;
 

--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -165,11 +165,11 @@ const ganache = require("ganache");
 
 const options = {};
 const server = ganache.server(options);
-const PORT = 8545;
+const PORT = 0; // 0 means any port
 server.listen(PORT, async err => {
   if (err) throw err;
 
-  console.log(`ganache listening on port ${PORT}...`);
+  console.log(`ganache listening on port ${server.address().port}...`);
   const provider = server.provider;
   const accounts = await provider.request({
     method: "eth_accounts",

--- a/src/packages/utils/package-lock.json
+++ b/src/packages/utils/package-lock.json
@@ -88,9 +88,9 @@
 			}
 		},
 		"@trufflesuite/uws-js-unofficial": {
-			"version": "20.10.0-unofficial.1",
-			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.1.tgz",
-			"integrity": "sha512-35K4XHmqWHLD9k0UsveCJG3NJ0zqdYG3cfRE8Z0984aNwNN+uf5nSNLcrUSs5szJExbknmSwJyHPOLtD+AiEeg==",
+			"version": "20.10.0-unofficial.2",
+			"resolved": "https://registry.npmjs.org/@trufflesuite/uws-js-unofficial/-/uws-js-unofficial-20.10.0-unofficial.2.tgz",
+			"integrity": "sha512-oQQlnS3oNeGsgS4K3KCSSavJgSb0W9D5ktZs4FacX9VbM7b+NlhjH96d6/G4fMrz+bc5MXRyco419on0X0dvRA==",
 			"dev": true,
 			"requires": {
 				"bufferutil": "4.0.5",
@@ -240,15 +240,6 @@
 			"optional": true,
 			"requires": {
 				"node-gyp-build": "^4.3.0"
-			},
-			"dependencies": {
-				"node-gyp-build": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-					"integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
-					"dev": true,
-					"optional": true
-				}
 			}
 		},
 		"camelcase": {
@@ -956,15 +947,6 @@
 			"optional": true,
 			"requires": {
 				"node-gyp-build": "^4.3.0"
-			},
-			"dependencies": {
-				"node-gyp-build": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-					"integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
-					"dev": true,
-					"optional": true
-				}
 			}
 		},
 		"util-deprecate": {

--- a/src/packages/utils/package.json
+++ b/src/packages/utils/package.json
@@ -53,7 +53,7 @@
     "seedrandom": "3.0.5"
   },
   "devDependencies": {
-    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.1",
+    "@trufflesuite/uws-js-unofficial": "20.10.0-unofficial.2",
     "@types/mocha": "9.0.0",
     "@types/seedrandom": "3.0.1",
     "cross-env": "7.0.3",


### PR DESCRIPTION
Specifying a port of `0` is a way to tell a server that you want the Operating System to let you bind to any open port. Ganache claimed to support binding to port 0, but would rudely yell at you if you tried: `Port should be >= 0 and < 65536. Received 0` :facepalm:! This PR rights our wrongs.

Using port `0` is useful when you don't care which port you bind to, you just want an open port.

You can use port `0` in a few ways:

### On the cli:

```console
$ ganache --port 0
…
RPC Listening on 127.0.0.1:35006
```

### In detach mode:

$$\color{#8b949e}\textsf{note: port 0 binding in detach mode doesn't yet provide a scripting friendly way of returning the port}$$
```console
$ ganache --detach --port 0
frozen_caramel_doughnut

$ ganache instances list
┌───────┬─────────────────────────┬──────────┬─────────┬─────────────────┬────────┐
│   PID │ Name                    │ Flavor   │ Version │ Host            │ Uptime │
├───────┼─────────────────────────┼──────────┼─────────┼─────────────────┼────────┤
│ 58078 │ frozen_caramel_doughnut │ ethereum │ 7.7.3   │ 127.0.0.1:35006 │    14s │
└───────┴─────────────────────────┴──────────┴─────────┴─────────────────┴────────┘
```

### and programmatically:

```javascript
import ganache from "ganache";

const server = ganache.server();
await server.listen(0);
console.log("Listening on port: ", server.address().port);
```

Fixes #2643 and #3805