### PR TITLE
ci: update setup-python action to v4.4.0

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -66,7 +66,7 @@ jobs:
         # resources it downloads no longer exist, and windows-build-tools@5
         # fails to install Python (it will wait on the python installer forever)
         if: startsWith(matrix.os, 'windows-')
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9 #v4.3.1
         with:
           python-version: "2.7"
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -66,7 +66,7 @@ jobs:
         # resources it downloads no longer exist, and windows-build-tools@5
         # fails to install Python (it will wait on the python installer forever)
         if: startsWith(matrix.os, 'windows-')
-        uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9 #v4.3.1
+        uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912 #v4.4.0
         with:
           python-version: "2.7"
 


### PR DESCRIPTION
The GitHub Actions runner was warning about deprecated API use by the setup-python package, so this PR updates it to the latest tagged version.