### PR TITLE
fix: store transactions with the correct `effectiveGasPrice` 

### DIFF
--- a/src/chains/ethereum/block/src/block.ts
+++ b/src/chains/ethereum/block/src/block.ts
@@ -93,7 +93,7 @@ export class Block {
       // get the maxFeePerGas and maxPriorityFeePerGas, use those to calculate
       // the effectiveGasPrice and add it to `extra` above, or we can just
       // leave it out of extra and update the effectiveGasPrice after like this
-      tx.updateEffectiveGasPrice(header.baseFeePerGas.toBigInt());
+      tx.updateEffectiveGasPrice(header.baseFeePerGas?.toBigInt());
       return txFn(tx);
     }) as IncludeTransactions extends true ? TypedTransactionJSON[] : Data[];
 

--- a/src/chains/ethereum/block/src/block.ts
+++ b/src/chains/ethereum/block/src/block.ts
@@ -93,7 +93,7 @@ export class Block {
       // get the maxFeePerGas and maxPriorityFeePerGas, use those to calculate
       // the effectiveGasPrice and add it to `extra` above, or we can just
       // leave it out of extra and update the effectiveGasPrice after like this
-      tx.updateEffectiveGasPrice(header.baseFeePerGas);
+      tx.updateEffectiveGasPrice(header.baseFeePerGas.toBigInt());
       return txFn(tx);
     }) as IncludeTransactions extends true ? TypedTransactionJSON[] : Data[];
 

--- a/src/chains/ethereum/ethereum/src/api.ts
+++ b/src/chains/ethereum/ethereum/src/api.ts
@@ -1885,16 +1885,12 @@ export default class EthereumApi implements Api {
 
     const transactionPromise = transactions.get(txHash);
     const receiptPromise = transactionReceipts.get(txHash);
-    const blockPromise = transactionPromise.then(t =>
-      t ? blocks.get(t.blockNumber.toBuffer()) : null
-    );
-    const [transaction, receipt, block] = await Promise.all([
+    const [transaction, receipt] = await Promise.all([
       transactionPromise,
-      receiptPromise,
-      blockPromise
+      receiptPromise
     ]);
     if (transaction) {
-      return receipt.toJSON(block, transaction, common);
+      return receipt.toJSON(transaction, common);
     }
 
     // if we are performing "strict" instamining, then check to see if the

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -429,6 +429,9 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
         const hash = tx.hash.toBuffer();
         const index = Quantity.from(i);
 
+        // update the effective gas price of the transaction based off of the
+        // baseFeePerGas of the block that the transaction is actually on
+        tx.updateEffectiveGasPrice(block.header.baseFeePerGas);
         // save transaction to the database
         const serialized = tx.serializeForDb(blockHash, blockNumberQ, index);
         this.transactions.set(hash, serialized);

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -429,9 +429,6 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
         const hash = tx.hash.toBuffer();
         const index = Quantity.from(i);
 
-        // update the effective gas price of the transaction based off of the
-        // baseFeePerGas of the block that the transaction is actually on
-        tx.updateEffectiveGasPrice(block.header.baseFeePerGas);
         // save transaction to the database
         const serialized = tx.serializeForDb(blockHash, blockNumberQ, index);
         this.transactions.set(hash, serialized);

--- a/src/chains/ethereum/ethereum/src/miner/miner.ts
+++ b/src/chains/ethereum/ethereum/src/miner/miner.ts
@@ -93,7 +93,7 @@ export default class Miner extends Emittery<{
   #isBusy: boolean = false;
   #paused: boolean = false;
   #resumer: Promise<void>;
-  #currentBlockBaseFeePerGas: Quantity;
+  #currentBlockBaseFeePerGas: bigint;
   #resolver: (value: void) => void;
 
   /**
@@ -424,7 +424,7 @@ export default class Miner extends Emittery<{
           // if baseFeePerGas is undefined, we are pre london hard fork.
           // no need to refresh the order of the heap because all Txs only have gasPrice.
           if (this.#currentBlockBaseFeePerGas !== undefined) {
-            priced.refresh(this.#currentBlockBaseFeePerGas.toBigInt());
+            priced.refresh(this.#currentBlockBaseFeePerGas);
           }
         } else {
           // reset the miner
@@ -533,9 +533,7 @@ export default class Miner extends Emittery<{
       if (next && !next.locked) {
         const origin = next.from.toString();
         origins.add(origin);
-        next.updateEffectiveGasPrice(
-          this.#currentBlockBaseFeePerGas.toBigInt()
-        );
+        next.updateEffectiveGasPrice(this.#currentBlockBaseFeePerGas);
         priced.push(next);
         next.locked = true;
       }
@@ -573,9 +571,7 @@ export default class Miner extends Emittery<{
           continue;
         }
         origins.add(origin);
-        next.updateEffectiveGasPrice(
-          this.#currentBlockBaseFeePerGas.toBigInt()
-        );
+        next.updateEffectiveGasPrice(this.#currentBlockBaseFeePerGas);
         priced.push(next);
         next.locked = true;
       }
@@ -594,6 +590,6 @@ export default class Miner extends Emittery<{
     const baseFeePerGas = block.header.baseFeePerGas;
     // before london hard fork, there will be no baseFeePerGas on the block
     this.#currentBlockBaseFeePerGas =
-      baseFeePerGas === undefined ? undefined : Quantity.from(baseFeePerGas);
+      baseFeePerGas === undefined ? undefined : baseFeePerGas;
   };
 }

--- a/src/chains/ethereum/ethereum/src/miner/miner.ts
+++ b/src/chains/ethereum/ethereum/src/miner/miner.ts
@@ -146,7 +146,7 @@ export default class Miner extends Emittery<{
     this.#executables = executables;
     this.#createBlock = (previousBlock: Block) => {
       const newBlock = createBlock(previousBlock);
-      this.#setCurrentBlockBaseFeePerGas(newBlock);
+      this.#currentBlockBaseFeePerGas = newBlock.header.baseFeePerGas;
       return newBlock;
     };
 
@@ -179,7 +179,7 @@ export default class Miner extends Emittery<{
       this.#updatePricedHeap();
       return;
     } else {
-      this.#setCurrentBlockBaseFeePerGas(block);
+      this.#currentBlockBaseFeePerGas = block.header.baseFeePerGas;
       this.#setPricedHeap();
       const result = await this.#mine(block, maxTransactions, onlyOneBlock);
       this.emit("idle");
@@ -581,15 +581,4 @@ export default class Miner extends Emittery<{
   public toggleStepEvent(enable: boolean) {
     this.#emitStepEvent = enable;
   }
-
-  /**
-   * Sets the #currentBlockBaseFeePerGas property if the current block
-   * has a baseFeePerGas property
-   */
-  #setCurrentBlockBaseFeePerGas = (block: RuntimeBlock) => {
-    const baseFeePerGas = block.header.baseFeePerGas;
-    // before london hard fork, there will be no baseFeePerGas on the block
-    this.#currentBlockBaseFeePerGas =
-      baseFeePerGas === undefined ? undefined : baseFeePerGas;
-  };
 }

--- a/src/chains/ethereum/ethereum/src/miner/miner.ts
+++ b/src/chains/ethereum/ethereum/src/miner/miner.ts
@@ -71,7 +71,7 @@ const updateBloom = (blockBloom: Buffer, bloom: Buffer) => {
 const sortByPrice = (values: TypedTransaction[], a: number, b: number) =>
   values[a].effectiveGasPrice > values[b].effectiveGasPrice;
 
-const refresher = (item: TypedTransaction, context: Quantity) =>
+const refresher = (item: TypedTransaction, context: bigint) =>
   item.updateEffectiveGasPrice(context);
 
 export default class Miner extends Emittery<{
@@ -127,10 +127,7 @@ export default class Miner extends Emittery<{
   }
 
   // create a Heap that sorts by gasPrice
-  readonly #priced = new Heap<TypedTransaction, Quantity>(
-    sortByPrice,
-    refresher
-  );
+  readonly #priced = new Heap<TypedTransaction, bigint>(sortByPrice, refresher);
   /*
    * @param executables - A live Map of pending transactions from the transaction
    * pool. The miner will update this Map by removing the best transactions
@@ -427,7 +424,7 @@ export default class Miner extends Emittery<{
           // if baseFeePerGas is undefined, we are pre london hard fork.
           // no need to refresh the order of the heap because all Txs only have gasPrice.
           if (this.#currentBlockBaseFeePerGas !== undefined) {
-            priced.refresh(this.#currentBlockBaseFeePerGas);
+            priced.refresh(this.#currentBlockBaseFeePerGas.toBigInt());
           }
         } else {
           // reset the miner
@@ -536,7 +533,9 @@ export default class Miner extends Emittery<{
       if (next && !next.locked) {
         const origin = next.from.toString();
         origins.add(origin);
-        next.updateEffectiveGasPrice(this.#currentBlockBaseFeePerGas);
+        next.updateEffectiveGasPrice(
+          this.#currentBlockBaseFeePerGas.toBigInt()
+        );
         priced.push(next);
         next.locked = true;
       }
@@ -574,7 +573,9 @@ export default class Miner extends Emittery<{
           continue;
         }
         origins.add(origin);
-        next.updateEffectiveGasPrice(this.#currentBlockBaseFeePerGas);
+        next.updateEffectiveGasPrice(
+          this.#currentBlockBaseFeePerGas.toBigInt()
+        );
         priced.push(next);
         next.locked = true;
       }

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -189,9 +189,10 @@ export default class TransactionPool extends Emittery<{ drain: undefined }> {
       !transaction.effectiveGasPrice &&
       this.#blockchain.common.isActivatedEIP(1559)
     ) {
-      const baseFeePerGas = Quantity.from(
-        Block.calcNextBaseFee(this.#blockchain.blocks.latest)
+      const baseFeePerGas = Block.calcNextBaseFee(
+        this.#blockchain.blocks.latest
       );
+
       transaction.updateEffectiveGasPrice(baseFeePerGas);
     }
 

--- a/src/chains/ethereum/ethereum/src/transaction-pool.ts
+++ b/src/chains/ethereum/ethereum/src/transaction-pool.ts
@@ -14,6 +14,7 @@ import {
 import { EthereumInternalOptions } from "@ganache/ethereum-options";
 import { Executables } from "./miner/executables";
 import { TypedTransaction } from "@ganache/ethereum-transaction";
+import { Block } from "@ganache/ethereum-block";
 
 /**
  * Checks if the `replacer` is eligible to replace the `replacee` transaction
@@ -188,7 +189,9 @@ export default class TransactionPool extends Emittery<{ drain: undefined }> {
       !transaction.effectiveGasPrice &&
       this.#blockchain.common.isActivatedEIP(1559)
     ) {
-      const baseFeePerGas = this.#blockchain.blocks.latest.header.baseFeePerGas;
+      const baseFeePerGas = Quantity.from(
+        Block.calcNextBaseFee(this.#blockchain.blocks.latest)
+      );
       transaction.updateEffectiveGasPrice(baseFeePerGas);
     }
 

--- a/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
@@ -586,8 +586,8 @@ describe("api", () => {
         } as any;
         // we previously had a bug where the `gasPrice` field returned from
         // `eth_getTransactionByHash` was incorrect when multiple transactions
-        // were sent, because we weren't saving the updated `effectiveGasPrice`.
-        // this tests against that. see:
+        // were sent, because we weren't assigning the correct `effectiveGasPrice`
+        // when adding the transaction to the pool. see:
         // https://github.com/trufflesuite/ganache/issues/4094
         const hashes = await Promise.all([
           provider.send("eth_sendTransaction", [txJson]),

--- a/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
+++ b/src/chains/ethereum/ethereum/tests/api/eth/eth.test.ts
@@ -543,34 +543,67 @@ describe("api", () => {
       assert(receipt.transactionIndex, "0x0");
     });
 
-    it("eth_getTransactionByHash", async () => {
-      await provider.send("eth_subscribe", ["newHeads"]);
-      const txJson = {
-        type: "0x2",
-        chainId: "0x539",
-        nonce: "0x0",
-        from: accounts[0],
-        to: accounts[1],
-        value: "0x1",
-        maxPriorityFeePerGas: "0xf",
-        maxFeePerGas: "0xfffffffff",
-        gas: "0x15f90",
-        input: "0x01",
-        accessList: []
-      } as any;
-      const hash = await provider.send("eth_sendTransaction", [txJson]);
-      const _message = await provider.once("message");
-      // we want these values set for when we check against the return data,
-      // but they shouldn't be used in eth_sendTransaction, so we'll set them now
-      txJson.transactionIndex = "0x0";
-      txJson.gasPrice = "0x342770cf";
+    describe("eth_getTransactionByHash", () => {
+      it("returns a transaction matching the sent transaction", async () => {
+        await provider.send("eth_subscribe", ["newHeads"]);
+        const txJson = {
+          type: "0x2",
+          chainId: "0x539",
+          nonce: "0x0",
+          from: accounts[0],
+          to: accounts[1],
+          value: "0x1",
+          maxPriorityFeePerGas: "0xf",
+          maxFeePerGas: "0xfffffffff",
+          gas: "0x15f90",
+          input: "0x01",
+          accessList: []
+        } as any;
+        const hash = await provider.send("eth_sendTransaction", [txJson]);
+        const _message = await provider.once("message");
+        // we want these values set for when we check against the return data,
+        // but they shouldn't be used in eth_sendTransaction, so we'll set them now
+        txJson.transactionIndex = "0x0";
+        txJson.gasPrice = "0x342770cf";
 
-      const tx = await provider.send("eth_getTransactionByHash", [hash]);
+        const tx = await provider.send("eth_getTransactionByHash", [hash]);
 
-      // loop over all of the data we set to verify it matches
-      for (const [key, value] of Object.entries(txJson)) {
-        assert.deepStrictEqual(value, tx[key]);
-      }
+        // loop over all of the data we set to verify it matches
+        for (const [key, value] of Object.entries(txJson)) {
+          assert.deepStrictEqual(value, tx[key]);
+        }
+      });
+
+      it("has a `gasPrice` that matches the corresponding receipt's `effectiveGasPrice` after the transaction is mined", async () => {
+        await provider.send("eth_subscribe", ["newHeads"]);
+        await provider.send("miner_stop", []);
+        const txJson = {
+          type: "0x2",
+          from: accounts[0],
+          to: accounts[1],
+          maxPriorityFeePerGas: "0x77359400",
+          maxFeePerGas: "0x6FC23AC00"
+        } as any;
+        // we previously had a bug where the `gasPrice` field returned from
+        // `eth_getTransactionByHash` was incorrect when multiple transactions
+        // were sent, because we weren't saving the updated `effectiveGasPrice`.
+        // this tests against that. see:
+        // https://github.com/trufflesuite/ganache/issues/4094
+        const hashes = await Promise.all([
+          provider.send("eth_sendTransaction", [txJson]),
+          provider.send("eth_sendTransaction", [txJson])
+        ]);
+        await provider.send("miner_start", []);
+        const _message = await provider.once("message");
+        for (const hash of hashes) {
+          const tx = await provider.send("eth_getTransactionByHash", [hash]);
+          const receipt = await provider.send("eth_getTransactionReceipt", [
+            hash
+          ]);
+          assert.deepStrictEqual(tx.gasPrice, receipt.effectiveGasPrice);
+          assert.deepStrictEqual(tx.gasPrice.toString(), "0xab5d04c0");
+        }
+      });
     });
   });
 });

--- a/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
+++ b/src/chains/ethereum/ethereum/tests/transaction-pool.test.ts
@@ -92,7 +92,13 @@ describe("transaction pool", async () => {
       },
       common,
       blocks: {
-        latest: { header: { baseFeePerGas: Quantity.from(875000000) } }
+        latest: {
+          header: {
+            baseFeePerGas: Quantity.from(875000000),
+            gasLimit: Quantity.from(30000000),
+            gasUsed: Quantity.from(0)
+          }
+        }
       }
     };
   });
@@ -147,9 +153,7 @@ describe("transaction pool", async () => {
         }
       },
       common,
-      blocks: {
-        latest: { header: { baseFeePerGas: Quantity.from(875000000) } }
-      }
+      blocks: blockchain.blocks
     } as any;
     const txPool = new TransactionPool(options.miner, fakeNonceChain, origins);
     const executableTx = TransactionFactory.fromRpc(executableRpc, common);

--- a/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
@@ -254,11 +254,10 @@ export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
   }
 
   public updateEffectiveGasPrice(baseFeePerGas: bigint) {
-    const baseFeePerGasBigInt = baseFeePerGas;
     const maxFeePerGas = this.maxFeePerGas.toBigInt();
     const maxPriorityFeePerGas = this.maxPriorityFeePerGas.toBigInt();
-    const a = maxFeePerGas - baseFeePerGasBigInt;
+    const a = maxFeePerGas - baseFeePerGas;
     const tip = a < maxPriorityFeePerGas ? a : maxPriorityFeePerGas;
-    this.effectiveGasPrice = Quantity.from(baseFeePerGasBigInt + tip);
+    this.effectiveGasPrice = Quantity.from(baseFeePerGas + tip);
   }
 }

--- a/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
+++ b/src/chains/ethereum/transaction/src/eip1559-fee-market-transaction.ts
@@ -253,8 +253,8 @@ export class EIP1559FeeMarketTransaction extends RuntimeTransaction {
     return computeIntrinsicsFeeMarketTx(v, <EIP1559FeeMarketDatabaseTx>raw);
   }
 
-  public updateEffectiveGasPrice(baseFeePerGas: Quantity) {
-    const baseFeePerGasBigInt = baseFeePerGas.toBigInt();
+  public updateEffectiveGasPrice(baseFeePerGas: bigint) {
+    const baseFeePerGasBigInt = baseFeePerGas;
     const maxFeePerGas = this.maxFeePerGas.toBigInt();
     const maxPriorityFeePerGas = this.maxPriorityFeePerGas.toBigInt();
     const a = maxFeePerGas - baseFeePerGasBigInt;

--- a/src/chains/ethereum/transaction/src/runtime-transaction.ts
+++ b/src/chains/ethereum/transaction/src/runtime-transaction.ts
@@ -256,5 +256,5 @@ export abstract class RuntimeTransaction extends BaseTransaction {
   );
 
   protected abstract toVmTransaction();
-  protected abstract updateEffectiveGasPrice(baseFeePerGas?: bigint);
+  protected abstract updateEffectiveGasPrice(baseFeePerGas: bigint);
 }

--- a/src/chains/ethereum/transaction/src/runtime-transaction.ts
+++ b/src/chains/ethereum/transaction/src/runtime-transaction.ts
@@ -256,5 +256,5 @@ export abstract class RuntimeTransaction extends BaseTransaction {
   );
 
   protected abstract toVmTransaction();
-  protected abstract updateEffectiveGasPrice(baseFeePerGas?: Quantity);
+  protected abstract updateEffectiveGasPrice(baseFeePerGas?: bigint);
 }

--- a/src/chains/ethereum/transaction/src/transaction-receipt.ts
+++ b/src/chains/ethereum/transaction/src/transaction-receipt.ts
@@ -154,9 +154,6 @@ export class InternalTransactionReceipt {
     blockLog.blockNumber = blockNumber;
     raw[3].forEach(l => blockLog.append(transactionIndex, transactionHash, l));
     const logs = [...blockLog.toJSON()];
-    if (block.header.baseFeePerGas) {
-      transaction.updateEffectiveGasPrice(block.header.baseFeePerGas);
-    }
     const json: TransactionReceipt = {
       transactionHash,
       transactionIndex,

--- a/src/chains/ethereum/transaction/src/transaction-receipt.ts
+++ b/src/chains/ethereum/transaction/src/transaction-receipt.ts
@@ -133,21 +133,13 @@ export class InternalTransactionReceipt {
     }
   }
 
-  public toJSON(
-    block: {
-      hash(): Data;
-      header: { number: Quantity };
-    },
-    transaction: TypedTransaction,
-    common: Common
-  ) {
+  public toJSON(transaction: TypedTransaction, common: Common) {
     const raw = this.raw;
     const contractAddress =
       this.contractAddress.length === 0
         ? null
         : Data.from(this.contractAddress);
-    const blockHash = block.hash();
-    const blockNumber = block.header.number;
+    const { blockHash, blockNumber } = transaction;
     const blockLog = BlockLogs.create(blockHash);
     const transactionHash = transaction.hash;
     const transactionIndex = transaction.index;

--- a/src/chains/ethereum/transaction/src/transaction-receipt.ts
+++ b/src/chains/ethereum/transaction/src/transaction-receipt.ts
@@ -136,7 +136,7 @@ export class InternalTransactionReceipt {
   public toJSON(
     block: {
       hash(): Data;
-      header: { number: Quantity; baseFeePerGas?: Quantity };
+      header: { number: Quantity };
     },
     transaction: TypedTransaction,
     common: Common


### PR DESCRIPTION
Previously we were returning the wrong `gasPrice` when a transaction was fetched via `eth_getTransactionByHash`. This was happening because when we saved the transaction to the chain, we didn't update the transaction's `effectiveGasPrice` field based off of the `baseFeePerGas` of the block that the transaction was mined onto in some cases. 

However, the `effectiveGasPrice` returned on a receipt was correct because when the receipt was fetched, we would calculate the `effectiveGasPrice` on the fly just to correct what we return to the user, rather than directly using what the database returned.

This change removes the on-the-fly calculation of the `effectiveGasPrice` on the receipt, and presets the transaction's `effectiveGasPrice` based off of the _next_ block's `baseFeePerGas` when the transaction is added to the pool. As block's are mined, the miner updates all pending transaction's `effectiveGasPrice` based off of the next block's `baseFeePerGas`.

Fixes #4094.