### PR TITLE
fix: `evm_revert` fails in some cases

### DIFF
--- a/src/chains/ethereum/ethereum/src/forking/trie.ts
+++ b/src/chains/ethereum/ethereum/src/forking/trie.ts
@@ -89,14 +89,14 @@ export class ForkTrie extends GanacheTrie {
     endBlockNumber: Quantity
   ) {
     const db = this.metadataDB;
-    const stream = db.createReadStream({
+    const stream = db.createKeyStream({
       gte: lexico.encode([startBlockNumber.toBuffer()]),
       lt: lexico.encode([
         Quantity.from(endBlockNumber.toBigInt() + 1n).toBuffer()
       ])
     });
     const batch = db.batch();
-    for await (const [key] of stream) {
+    for await (const key of stream) {
       batch.del(key);
     }
     await batch.write();

--- a/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
@@ -888,7 +888,7 @@ describe("forking", function () {
         // make sure deleted state was properly reverted
         await testPermutations(
           localProvider,
-          localInitialValue,
+          expectedValueAfterRevert,
           snapshotValues
         );
 
@@ -917,7 +917,7 @@ describe("forking", function () {
       for (const remoteInitialValue of initialValues) {
         for (const initialValue of initialValues) {
           for (const permutation of permutations) {
-            it(`should revert to previous value after snapshot/{change}/revert, fork value: ${remoteInitialValue}, initialValue, ${initialValue}, permutations: ${JSON.stringify(
+            it(`should revert to previous value after snapshot/{change}/revert, fork value: ${remoteInitialValue}, initialValue, ${initialValue}, permutation: ${JSON.stringify(
               permutation
             )}`, async () => {
               const subId = await remoteProvider.send("eth_subscribe", [

--- a/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
@@ -805,31 +805,6 @@ describe("forking", function () {
     });
 
     describe("snapshot/revert", () => {
-      it.skip("should revert a value deletion", async () => {
-        const { localProvider } = await startLocalChain(PORT, {
-          disableCache: true
-        });
-        const initialBlockNumber = +(await localProvider.send(
-          "eth_blockNumber"
-        ));
-
-        const initialValue = await get(
-          localProvider,
-          "value0",
-          initialBlockNumber
-        );
-
-        const snapId = await localProvider.send("evm_snapshot");
-        await set(localProvider, 0, 0);
-        await localProvider.send("evm_mine");
-        await localProvider.send("evm_revert", [snapId]);
-        const finalBlockNumber = +(await localProvider.send("eth_blockNumber"));
-
-        const finalValue = await get(localProvider, "value0", finalBlockNumber);
-
-        assert.strictEqual(finalValue, initialValue);
-      });
-
       async function testPermutations(
         localProvider: EthereumProvider,
         initialValue: number,

--- a/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
@@ -826,15 +826,15 @@ describe("forking", function () {
         }
       }
 
-      /*
-        
-        - initialises localProvider as a fork of remoteProvider
-        - sets `value1` to `initialValue` (if it is not null)
-        - create snapshot
-        - iterate `snapshotValues`, setting `value1` to each value
-        - revert
-        - ensure that `value1` has reverted to either `initialValue`, or `initialRemoteValue` if not provided
-      */
+      /**
+       *  - Initializes `localProvider` as a fork of `remoteProvider`.
+       *  - Sets `value1` to `localInitialValue` (if it is not null).
+       *  - Creates a snapshot .
+       *  - Iterates `snapshotValues`, setting `value1` to each of those values.
+       *  - Reverts.
+       *  - Ensures that `value1` has reverted to either `localInitialValue` or
+       *    `remoteInitialValue` (if the `localInitialValue` was not provided).
+       */
       async function initializeSnapshotSetRevertThenTest(
         remoteInitialValue: number,
         localInitialValue: number | null,
@@ -849,7 +849,7 @@ describe("forking", function () {
         const subId = await localProvider.send("eth_subscribe", ["newHeads"]);
 
         if (localInitialValue !== null) {
-          // set value1 to {initialValue} (delete it, if the value is 0)
+          // set value1 to {initialValue} (note: if the value is `0` it actually deletes it from the state)
           await set(localProvider, 1, localInitialValue);
           await localProvider.once("message");
 
@@ -942,7 +942,7 @@ describe("forking", function () {
               const startValue = await get(
                 remoteProvider,
                 "value1",
-                +blockNumber
+                blockNumber
               );
 
               await initializeSnapshotSetRevertThenTest(


### PR DESCRIPTION
Resolves an issue where `evm_revert` would fail with error `.for is not iterable`. This happened when a user would attempt to revert a change that deletes a key that exists in an upstream network.

fixes: #4093 