### PR TITLE
fix: remove setting of private property

### DIFF
--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -710,8 +710,6 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
         await mclInitPromise; // ensure that mcl is initialized!
       }
     }
-    // skip `vm.init`, since we don't use any of it
-    (vm as any)._isInitialized = true;
     return vm;
   };
 


### PR DESCRIPTION
Before the latest upgrade of etheremjs-vm, we would manually set the `_isInitialized` property of the `VM` to avoid some extra computation that came along with initialization that we didn't need. After the ethereumjs-vm upgrde, creating the `VM` also initializes it, so this manual setting of the private property is unnecessary, but we didn't remove it. This change removes the manual setting of `vm._isInitialized`.