### PR TITLE
fix: `node-gyp-build: Permission denied` error

### DIFF
--- a/src/packages/ganache/Dockerfile
+++ b/src/packages/ganache/Dockerfile
@@ -1,9 +1,40 @@
+ARG UID=2000
+ARG GID=2000
+
+ARG INFURA_KEY=00000000000000000000000000000000
+
+# Stage: Prepare build layer ---------------------------------------------------
+
 # use full node to install dependencies
-FROM node:14.17.4@sha256:cd98882c1093f758d09cf6821dc8f96b241073b38e8ed294ca1f9e484743858f AS builder
+FROM node:14.21.3-buster AS base-build
+
+ARG UID
+ARG GID
+
+RUN addgroup --gid ${GID} ganache; \
+    adduser --uid ${UID} --gid ${GID} ganache --disabled-password
+
+# Stage: Prepare runtime layer -------------------------------------------------
+
+FROM node:14.21.3-slim AS base-runtime
+
+ARG UID
+ARG GID
+
+RUN addgroup --gid ${GID} ganache; \
+    adduser --uid ${UID} --gid ${GID} ganache --disabled-password
+
+# Stage: Build -----------------------------------------------------------------
+
+FROM base-build as builder
+
+ARG UID
+ARG GID
+USER ${UID}
 
 WORKDIR /app
 
-COPY . .
+COPY --chown=${UID}:${GID} . .
 
 # clean and install dependencies
 RUN npm run clean
@@ -18,16 +49,21 @@ RUN npm run build
 # prune development dependencies
 RUN npx lerna exec --scope ganache -- npm prune --production
 
-# we use node "slim" instead of "alpine" until we create a uwebsockets build for alpine.
-FROM node:14.17.4-slim@sha256:766e2dcf4461582f7f750656807edbc28019753cecae92b1f2b25d13d3401ef3
+# Stage: Run -------------------------------------------------------------------
+
+FROM base-runtime as runtime
+
+ARG UID
+ARG GID
+USER ${UID}
 
 WORKDIR /app
 
 # copy from build image
-COPY --from=builder /app/src/packages/ganache/node_modules node_modules
+COPY --from=builder --chown=${UID}:${GID} /app/src/packages/ganache/node_modules node_modules
 # TODO(perf): we don't need everything in here. Maybe either create a separate
 # build for docker or cherry-pick the files we actually need.
-COPY --from=builder /app/src/packages/ganache/dist/node dist/node
+COPY --from=builder --chown=${UID}:${GID} /app/src/packages/ganache/dist/node dist/node
 
 ENV DOCKER true
 ENV NODE_ENV production

--- a/src/packages/ganache/README.md
+++ b/src/packages/ganache/README.md
@@ -628,7 +628,11 @@ $ git clone https://github.com/trufflesuite/ganache.git && cd ganache
 then:
 
 ```console
-$ docker build --tag trufflesuite/ganache --file ./src/packages/ganache/Dockerfile .
+$ docker build \
+        --build-arg INFURA_KEY=<32-chars-hexadecimal> \
+        --tag trufflesuite/ganache \
+        --file ./src/packages/ganache/Dockerfile \
+    .
 $ docker run --publish 8545:8545 trufflesuite/ganache
 ```
 


### PR DESCRIPTION
- Use non-root user to build/run ganache.
- Use newer base image so that python3 is 3.6+.
- Pin base images to tags (not SHA's) since we build cross-platform.