### PR TITLE
test: ensure tests that are skipped in development are run in CI

### DIFF
--- a/src/chains/ethereum/ethereum/tests/forking/account.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/account.test.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 import getProvider from "../helpers/getProvider";
 import { EthereumProvider } from "../../src/provider";
 import request from "superagent";
+import skipIfNoInfuraKey from "../helpers/skipIfNoInfuraKey";
 
 describe("forking", function () {
   this.timeout(10000);
@@ -12,10 +13,10 @@ describe("forking", function () {
     const blockNumberHex = `0x${blockNumber.toString(16)}`;
     const URL = "https://mainnet.infura.io/v3/" + process.env.INFURA_KEY;
     let provider: EthereumProvider;
-    before(async function () {
-      if (!process.env.INFURA_KEY) {
-        this.skip();
-      }
+
+    skipIfNoInfuraKey();
+
+    before(async () => {
       provider = await getProvider({
         fork: {
           url: URL,

--- a/src/chains/ethereum/ethereum/tests/forking/block.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/block.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import getProvider from "../helpers/getProvider";
+import skipIfNoInfuraKey from "../helpers/skipIfNoInfuraKey";
 import { EthereumProvider } from "../../src/provider";
 import request from "superagent";
 
@@ -11,10 +12,10 @@ describe("forking", function () {
     const blockNumHex = `0x${blockNumber.toString(16)}`;
     const URL = "https://mainnet.infura.io/v3/" + process.env.INFURA_KEY;
     let provider: EthereumProvider;
-    before(async function () {
-      if (!process.env.INFURA_KEY) {
-        this.skip();
-      }
+
+    skipIfNoInfuraKey();
+
+    before(async () => {
       provider = await getProvider({
         fork: {
           url: URL,
@@ -52,7 +53,10 @@ describe("forking", function () {
         "earliest",
         true
       ]);
-      assert.deepStrictEqual(parseInt(block.number), parseInt(remoteBlock.number));
+      assert.deepStrictEqual(
+        parseInt(block.number),
+        parseInt(remoteBlock.number)
+      );
       assert.deepStrictEqual(block.hash, remoteBlock.hash);
     });
 
@@ -86,10 +90,18 @@ describe("forking", function () {
     });
 
     it("should get transaction count by hash from the original chain", async () => {
-      const block = await provider.send("eth_getBlockByNumber", ["0xB443", true]);
-      const blockTransactionCountByHash = await provider.send("eth_getBlockTransactionCountByHash", [block.hash]);
-      assert.deepStrictEqual(block.transactions.length, parseInt(blockTransactionCountByHash));
+      const block = await provider.send("eth_getBlockByNumber", [
+        "0xB443",
+        true
+      ]);
+      const blockTransactionCountByHash = await provider.send(
+        "eth_getBlockTransactionCountByHash",
+        [block.hash]
+      );
+      assert.deepStrictEqual(
+        block.transactions.length,
+        parseInt(blockTransactionCountByHash)
+      );
     });
-
   });
 });

--- a/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/forking.test.ts
@@ -1,5 +1,6 @@
 import { KNOWN_NETWORKS } from "@ganache/ethereum-options";
 import getProvider from "../helpers/getProvider";
+import skipIfNoInfuraKey from "../helpers/skipIfNoInfuraKey";
 import http from "http";
 import ganache from "../../../../../packages/core";
 import assert from "assert";
@@ -1047,9 +1048,7 @@ describe("forking", () => {
       let remoteProvider: EthereumProvider;
       let remoteAccounts: string[];
 
-      before("skip if we don't have the INFURA_KEY", function () {
-        if (!process.env.INFURA_KEY) this.skip();
-      });
+      skipIfNoInfuraKey();
 
       before("configure mainnet", async function () {
         // we fork from mainnet, but configure our fork such that it looks like
@@ -1171,9 +1170,7 @@ describe("forking", () => {
       let provider: EthereumProvider;
       const URL = "https://mainnet.infura.io/v3/" + process.env.INFURA_KEY;
 
-      before("skip if we don't have the INFURA_KEY", function () {
-        if (!process.env.INFURA_KEY) this.skip();
-      });
+      skipIfNoInfuraKey();
 
       before("configure provider", async () => {
         provider = await getProvider({
@@ -1247,11 +1244,8 @@ describe("forking", function () {
       }
     };
     let localProvider: EthereumProvider;
-    before("check conditions", function () {
-      if (!process.env.INFURA_KEY) {
-        this.skip();
-      }
-    });
+
+    skipIfNoInfuraKey();
 
     KNOWN_NETWORKS.forEach(network => {
       describe(network, () => {
@@ -1383,12 +1377,12 @@ describe("forking", function () {
         validatorIndex: "0x3a995"
       }
     ];
-    before("skip if we don't have the INFURA_KEY", function () {
-      // this test uses the `network: "goerli"` option, which requires an
-      // infura key; when run our tests it must be provided as an environment
-      // variable.
-      if (!process.env.INFURA_KEY) this.skip();
-    });
+
+    // this test uses the `network: "goerli"` option, which requires an
+    // infura key; when run our tests it must be provided as an environment
+    // variable.
+    skipIfNoInfuraKey();
+
     describe("shanghai", () => {
       let provider: EthereumProvider;
       const blockNumber = 8765432;

--- a/src/chains/ethereum/ethereum/tests/forking/transaction.test.ts
+++ b/src/chains/ethereum/ethereum/tests/forking/transaction.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import getProvider from "../helpers/getProvider";
+import skipIfNoInfuraKey from "../helpers/skipIfNoInfuraKey";
 import { EthereumProvider } from "../../src/provider";
 import request from "superagent";
 
@@ -10,10 +11,10 @@ describe("forking", () => {
     const blockNumber = 0xcb6169;
     const URL = "https://mainnet.infura.io/v3/" + process.env.INFURA_KEY;
     let provider: EthereumProvider;
-    before(async function () {
-      if (!process.env.INFURA_KEY) {
-        this.skip();
-      }
+
+    skipIfNoInfuraKey();
+
+    before(async () => {
       provider = await getProvider({
         fork: {
           url: URL,

--- a/src/chains/ethereum/ethereum/tests/helpers/skipIfNoInfuraKey.ts
+++ b/src/chains/ethereum/ethereum/tests/helpers/skipIfNoInfuraKey.ts
@@ -1,5 +1,5 @@
 function skipIfNoInfuraKey() {
-  before("gotta have an infura key", function () {
+  before("skip if no INFURA_KEY (unless in CI)", function () {
     // If there is no INFURA_KEY provided, the test should be skipped. Unless running
     // in CI, where there should _always_ be a key provided.
     if (!process.env.INFURA_KEY) {

--- a/src/chains/ethereum/ethereum/tests/helpers/skipIfNoInfuraKey.ts
+++ b/src/chains/ethereum/ethereum/tests/helpers/skipIfNoInfuraKey.ts
@@ -1,0 +1,17 @@
+function skipIfNoInfuraKey() {
+  before("gotta have an infura key", function () {
+    // If there is no INFURA_KEY provided, the test should be skipped. Unless running
+    // in CI, where there should _always_ be a key provided.
+    if (!process.env.INFURA_KEY) {
+      if (process.env.CI === "true") {
+        throw new Error(
+          "No INFURA_KEY was provided. When CI is true, an INFURA_KEY must be provided."
+        );
+      } else {
+        this.skip();
+      }
+    }
+  });
+}
+
+export default skipIfNoInfuraKey;

--- a/src/chains/ethereum/ethereum/tests/helpers/skipIfNoInfuraKey.ts
+++ b/src/chains/ethereum/ethereum/tests/helpers/skipIfNoInfuraKey.ts
@@ -5,7 +5,7 @@ function skipIfNoInfuraKey() {
     if (!process.env.INFURA_KEY) {
       if (process.env.CI === "true") {
         throw new Error(
-          "No INFURA_KEY was provided. When CI is true, an INFURA_KEY must be provided."
+          `No INFURA_KEY environment variable was provided. When process.env.CI is "true", an INFURA_KEY must be provided.`
         );
       } else {
         this.skip();

--- a/src/packages/core/tests/server.test.ts
+++ b/src/packages/core/tests/server.test.ts
@@ -116,11 +116,7 @@ describe("server", () => {
     return deferred;
   }
 
-  // skip this test unless in GitHub Actions, as this test iterates over
-  // all available network interfaces and network interfaces on user
-  // machines are unpredictible and may behave in ways that we don't care
-  // about.
-  (process.env.GITHUB_ACTION ? describe : describe.skip)("listen", function () {
+  describe("listen", function () {
     function isIPv6(
       info: NetworkInterfaceInfo
     ): info is NetworkInterfaceInfoIPv6 {
@@ -132,7 +128,7 @@ describe("server", () => {
     function getHost(info: NetworkInterfaceInfo, interfaceName: string) {
       // a link-local ipv6 address starts with fe80:: and _must_ include a "zone_id"
       if (isIPv6(info) && info.address.startsWith("fe80::")) {
-        if (process.platform == "win32") {
+        if (IS_WINDOWS) {
           // on windows the zone_id is the scopeid
           return `${info.address}%${info.scopeid}`;
         } else {
@@ -159,7 +155,13 @@ describe("server", () => {
       return validInterfaces;
     }
 
-    it("listens on all interfaces by default", async () => {
+    it("listens on all interfaces by default", async function () {
+      // This test iterates over all available network interfaces. This can be problematic on user
+      // machines (which may be configured in unsupported ways), so we skip it in this case.
+      if (process.env.CI !== "true") {
+        this.skip();
+      }
+
       await setup();
       try {
         const interfaces = getNetworkInterfaces();
@@ -190,10 +192,10 @@ describe("server", () => {
     });
 
     it("listens on given interface only", async function () {
-      // skip this test unless in CI, as this test iterates over all available network interfaces
-      // and network interfaces on user machines are unpredictible and may behave in ways that
-      // we don't care about.
-      if (process.env.CI !== "true") {
+      // This test iterates over all available network interfaces. This can be problematic on user
+      // machines (which may be configured in unsupported ways), and also in macOS (which exposes
+      // unsupported interfaces). In these cases, we skip this test.
+      if (process.env.CI !== "true" || process.platform === "darwin") {
         this.skip();
       }
 

--- a/src/packages/core/tests/server.test.ts
+++ b/src/packages/core/tests/server.test.ts
@@ -193,7 +193,9 @@ describe("server", () => {
       // skip this test unless in CI, as this test iterates over all available network interfaces
       // and network interfaces on user machines are unpredictible and may behave in ways that
       // we don't care about.
-      if (process.env.CI) this.skip();
+      if (process.env.CI !== "true") {
+        this.skip();
+      }
 
       const interfaces = networkInterfaces();
       assert(Object.keys(interfaces).length > 0);


### PR DESCRIPTION
Previously, tests that depend on an INFURA_KEY would be skipped if it were not provided. After this change these tests will fail in CI if no INFURA_KEY is provided.

Additionally, a test which was previously skipped is now run on Windows and Linux agents in Github Actions only. (` > server > listens on given interface only`)