### PR TITLE
docs: update contributing guide for linux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,8 @@ If installation fails due to a `node-gyp` issue you may need to perform some add
 ### on Linux (Ubuntu-based)
 
 - Make sure `npm` commands are not run as `root`.
-- Determine if you have Python 2.7 installed
-  - example: `which python2.7`
-- If you do not have Python 2.7 installed, you need to install it
-  - example: `sudo apt update && sudo apt install python2.7`
-- Run `npm config set python python2.7`
+- If you get an error that `make` isn't installed you might need to also install the `build-essential` package
+ - example `sudo apt update && sudo apt install build-essential`
 
 ### on Windows
 


### PR DESCRIPTION
Python 2.7 is no longer a requirement to build ganache, but `make` is.