### PR TITLE
fix: show a helpful message when `ganache instances` is executed without a subcommand

### DIFF
--- a/src/packages/cli/src/args.ts
+++ b/src/packages/cli/src/args.ts
@@ -285,7 +285,7 @@ export default function (
       function () {
         // this handler executes when `ganache instances` is called without a subcommand
         const command = chalk`{hex("${TruffleColors.porsche}") ganache instances}`;
-        console.log(`${command} requires a subcommand:`);
+        console.log(`${command} requires a subcommand.`);
         console.log();
         yargs.showHelp();
         yargs.exit(1, new Error("No subcommand provided"));

--- a/src/packages/cli/src/args.ts
+++ b/src/packages/cli/src/args.ts
@@ -285,7 +285,7 @@ export default function (
       function () {
         // this handler executes when `ganache instances` is called without a subcommand
         const command = chalk`{hex("${TruffleColors.porsche}") ganache instances}`;
-        console.log(`${command} requires a subcommand.`);
+        console.log(`Missing subcommand for ${command}.`);
         console.log();
         yargs.showHelp();
         yargs.exit(1, new Error("No subcommand provided"));

--- a/src/packages/cli/src/args.ts
+++ b/src/packages/cli/src/args.ts
@@ -281,9 +281,17 @@ export default function (
             }
           )
           .version(false);
+      },
+      function () {
+        // this handler executes when `ganache instances` is called without a subcommand
+        const command = chalk`{hex("${TruffleColors.porsche}") ganache instances}`;
+        console.log(`${command} requires a subcommand:`);
+        console.log();
+        yargs.showHelp();
+        yargs.exit(1, new Error("No subcommand provided"));
       }
     )
-    .showHelpOnFail(false, "Specify -? or --help for available options")
+    .showHelpOnFail(false)
     .alias("help", "?")
     .wrap(wrapWidth)
     .version(version);


### PR DESCRIPTION
When `ganache instances` is executed, a subcommand must be provided.

Previously an unhelpful error was thrown, with this fix we output a simple error message, followed by the the help text for `ganache instances`.

```terminal
$ ganache instances
ganache instances requires a subcommand:

ganache instances

Manage instances of Ganache running in detached mode.
(Ganache can be run in detached mode by providing the --detach flag)

Commands:
  ganache instances list         List instances running in detached mode
  ganache instances stop <name>  Stop the instance specified by <name>

Options:
  -?, --help  Show help                                                                           [boolean]
```

fixes: #4360