### PR TITLE
Allow transaction simulation to read blocks after the fork point

### DIFF
--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -1376,10 +1376,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
           if (beforeEncoded === undefined) {
             // we haven't changed this account in a previous simulation, need to get the original account
             addressBuf = Buffer.from(addressStr, "hex");
-            beforeEncoded = await this.accounts.getRaw(
-              Address.from(addressBuf),
-              parentBlock.header.number.toBuffer()
-            );
+            beforeEncoded = await beforeStateManager._trie.get(addressBuf);
           }
           const afterEncoded = i[1].val;
           if (!beforeEncoded.equals(afterEncoded)) {

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -1458,13 +1458,23 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
           const generateVM = async () => {
             // note(hack): blockchain.vm.copy() doesn't work so we just do it this way
             // /shrug
+            const trie = this.trie.copy(false);
+            trie.setContext(
+              parentBlock.header.stateRoot.toBuffer(),
+              null,
+              parentBlock.header.number
+            );
 
             const vm = await this.createVmFromStateTrie(
-              this.trie.copy(false),
+              trie,
               options.chain.allowUnlimitedContractSize,
               options.chain.allowUnlimitedInitCodeSize,
-              false
+              false,
+              common
             );
+            await vm.eei.checkpoint();
+            //@ts-ignore
+            vm.eei.commit = () => {};
             return vm;
           };
 

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -1125,6 +1125,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
   }
 
   public async simulateTransactions(
+    common,
     transactions: SimulationTransaction[],
     runtimeBlock: RuntimeBlock,
     parentBlock: Block,
@@ -1132,16 +1133,6 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
     includeTrace: boolean,
     includeGasEstimate: boolean
   ) {
-    //todo: getCommonForBlockNumber doesn't presently respect shanghai, so we just assume it's the same common as the fork
-    // this won't work as expected if simulating on blocks before shanghai.
-    const common = this.fallback
-      ? this.fallback.getCommonForBlockNumber(
-          this.common,
-          BigInt(runtimeBlock.header.number.toString())
-        )
-      : this.common;
-    common.setHardfork("shanghai");
-
     const stateTrie = this.trie.copy(false);
     stateTrie.setContext(
       parentBlock.header.stateRoot.toBuffer(),
@@ -1517,6 +1508,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
                 0n, // no baseFeePerGas for estimates
                 KECCAK256_RLP
               );
+
               const runArgs = {
                 tx: tx.toVmTransaction(),
                 block,

--- a/src/chains/ethereum/ethereum/src/blockchain.ts
+++ b/src/chains/ethereum/ethereum/src/blockchain.ts
@@ -1368,7 +1368,7 @@ export default class Blockchain extends Emittery<BlockchainTypedEvents> {
           value: transaction.value == null ? 0n : transaction.value.toBigInt(),
           block: runtimeBlock as any
         };
-        const result = await vm.evm.runCall(runCallArgs as any);
+        const result = await vm.evm.runCall(runCallArgs);
 
         // todo: this is always going to pull the "before" from before _all_ simulations
         // in order for this to be correct, we need to check all previously simulated transactions

--- a/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
+++ b/src/chains/ethereum/ethereum/src/data-managers/block-manager.ts
@@ -1,6 +1,6 @@
 import Manager from "./manager";
 import { Tag, QUANTITY } from "@ganache/ethereum-utils";
-import { Quantity, Data, BUFFER_ZERO } from "@ganache/utils";
+import { Quantity, Data, BUFFER_ZERO, unref } from "@ganache/utils";
 import type { Common } from "@ethereumjs/common";
 import Blockchain from "../blockchain";
 import {
@@ -57,6 +57,33 @@ export default class BlockManager extends Manager<Block> {
   ) {
     const bm = new BlockManager(blockchain, common, blockIndexes, base);
     await bm.updateTaggedBlocks();
+    if (blockchain.fallback) {
+      // a hack to ensure `latest` is kept up to date.
+      // this just polls for `latest` every 7 seconds
+      unref(
+        setInterval(async () => {
+          const json = await blockchain.fallback.request<any>(
+            "eth_getBlockByNumber",
+            ["latest", true],
+            { disableCache: true }
+          );
+          if (json == null) {
+            return null;
+          } else {
+            const common = blockchain.fallback.getCommonForBlockNumber(
+              bm.#common,
+              BigInt(json.number)
+            );
+            console.log("latest is now", json.number);
+
+            bm.latest = new Block(
+              BlockManager.rawFromJSON(json, common),
+              common
+            );
+          }
+        }, 7000)
+      );
+    }
     return bm;
   }
 

--- a/src/chains/ethereum/ethereum/src/forking/fork.ts
+++ b/src/chains/ethereum/ethereum/src/forking/fork.ts
@@ -262,7 +262,10 @@ export class Fork {
   }
 
   public isValidForkBlockNumber(blockNumber: Quantity) {
-    return blockNumber.toBigInt() <= this.blockNumber.toBigInt();
+    // TODO: this is a temporary fix for using ganache for remote transaction
+    // simulations. it breaks lots of things for normal ganache usage.
+    return true;
+    // return blockNumber.toBigInt() <= this.blockNumber.toBigInt();
   }
 
   public selectValidForkBlockNumber(blockNumber: Quantity) {
@@ -281,8 +284,14 @@ export class Fork {
    * @param common -
    * @param blockNumber -
    */
-  public getCommonForBlockNumber(common: Common, blockNumber: BigInt) {
-    if (blockNumber <= this.blockNumber.toBigInt()) {
+  public getCommonForBlockNumber(
+    common: Common,
+    blockNumber: BigInt,
+    allowFuture = false
+  ) {
+    // if we are allowed to get a future hardfork block, then we should try to
+    // get a common for hardforks that will be activate at those block numbers
+    if (blockNumber <= this.blockNumber.toBigInt() || allowFuture) {
       // we are at or before our fork block
 
       let forkCommon: Common;
@@ -310,6 +319,7 @@ export class Fork {
           { baseChain: 1 }
         );
       }
+      (forkCommon as any).on = () => {};
       return forkCommon;
     } else {
       return common;

--- a/src/chains/ethereum/ethereum/src/forking/handlers/base-handler.ts
+++ b/src/chains/ethereum/ethereum/src/forking/handlers/base-handler.ts
@@ -196,7 +196,8 @@ export class BaseHandler {
 
         if (hasOwn(response, "result")) {
           // cache non-error responses only
-          this.valueCache.set(key, raw);
+          // don't set the cache when "latest" is requested.
+          if (!key.includes("latest")) this.valueCache.set(key, raw);
           if (!options.disableCache && this.persistentCache) {
             // swallow errors for the persistentCache, since it's not vital that
             // it always works

--- a/src/chains/ethereum/ethereum/src/helpers/gas-estimator.ts
+++ b/src/chains/ethereum/ethereum/src/helpers/gas-estimator.ts
@@ -296,13 +296,14 @@ const exactimate = async (
   };
   await vm.stateManager.checkpoint();
   const result = await vm
-    .runTx(runArgs as unknown as RunTxOpts)
+    .runTx({ ...runArgs, skipNonce: true } as unknown as RunTxOpts)
     .catch(vmerr => ({ vmerr }));
   await vm.stateManager.revert();
   if ("vmerr" in result) {
     const vmerr = result.vmerr;
     return callback(vmerr);
   } else if (result.execResult.exceptionError) {
+    console.error(result.execResult.exceptionError);
     const error = new RuntimeError(
       // erroneous gas estimations don't have meaningful hashes
       Quantity.Empty,

--- a/src/chains/ethereum/ethereum/src/helpers/gas-estimator.ts
+++ b/src/chains/ethereum/ethereum/src/helpers/gas-estimator.ts
@@ -1,3 +1,4 @@
+import { Interpreter, RunState } from "@ethereumjs/evm/dist/interpreter";
 import BN from "bn.js";
 import { RuntimeError, RETURN_TYPES } from "@ganache/ethereum-utils";
 import { Quantity } from "@ganache/utils";
@@ -24,28 +25,33 @@ const bigIntToBN = (val: bigint) => {
 };
 const MULTIPLE = 64 / 63;
 
-const check = (set: Set<string>) => (opname: string) => set.has(opname);
-const isCall = check(
-  new Set(["CALL", "DELEGATECALL", "STATICCALL", "CALLCODE"])
-);
-const isCallOrCallcode = check(new Set(["CALL", "CALLCODE"]));
-const isCreate = check(new Set(["CREATE", "CREATE2"]));
+const check = (set: Set<number>) => (opname: number) => set.has(opname);
+const isCall = check(new Set([0xf1, 0xf4, 0xfa, 0xf2]));
+const isCallOrCallcode = check(new Set([0xf1, 0xf2]));
+const isCreate = check(new Set([0xf0, 0xf5]));
 const isTerminator = check(
-  new Set(["STOP", "RETURN", "REVERT", "INVALID", "SELFDESTRUCT"])
+  // TODO: figure out INVALID efficiently
+  new Set([0x00, 0xf3, 0xfd, /*"INVALID",*/ 0xff])
 );
 type SystemOptions = {
   index: number;
   depth: number;
-  name: string;
+  name: number;
+};
+type I = {
+  depth: number;
+  opcode: number;
+  stack: any[];
+  gasLeft: bigint;
 };
 const stepTracker = () => {
   const sysOps: SystemOptions[] = [];
-  const allOps: InterpreterStep[] = [];
+  const allOps: I[] = [];
   const preCompile: Set<number> = new Set();
   let preCompileCheck = false;
   let precompileCallDepth = 0;
   return {
-    collect: (info: InterpreterStep) => {
+    collect: (info: I) => {
       if (preCompileCheck) {
         if (info.depth === precompileCallDepth) {
           // If the current depth is unchanged.
@@ -55,20 +61,20 @@ const stepTracker = () => {
         // Reset the flag immediately here
         preCompileCheck = false;
       }
-      if (isCall(info.opcode.name)) {
+      if (isCall(info.opcode)) {
         info.stack = [...info.stack];
         preCompileCheck = true;
         precompileCallDepth = info.depth;
         sysOps.push({
           index: allOps.length,
           depth: info.depth,
-          name: info.opcode.name
+          name: info.opcode
         });
-      } else if (isCreate(info.opcode.name) || isTerminator(info.opcode.name)) {
+      } else if (isCreate(info.opcode) || isTerminator(info.opcode)) {
         sysOps.push({
           index: allOps.length,
           depth: info.depth,
-          name: info.opcode.name
+          name: info.opcode
         });
       }
       // This goes last so we can use the length for the index ^
@@ -78,7 +84,7 @@ const stepTracker = () => {
     done: () =>
       !allOps.length ||
       sysOps.length < 2 ||
-      !isTerminator(allOps[allOps.length - 1].opcode.name),
+      !isTerminator(allOps[allOps.length - 1].opcode),
     ops: allOps,
     systemOps: sysOps
   };
@@ -155,7 +161,15 @@ const exactimate = async (
   callback: (err: Error, result?: EstimateGasResult) => void
 ) => {
   const steps = stepTracker();
-  vm.evm.events.on("step", steps.collect);
+  (vm.evm as any).handleRunStep = (interpreter: Interpreter) => {
+    const runState = (interpreter as any)._runState as RunState;
+    steps.collect({
+      opcode: runState.opCode,
+      stack: runState.stack._store,
+      depth: interpreter._env.depth,
+      gasLeft: runState.gasLeft
+    } as any);
+  };
 
   type ContextType = ReturnType<typeof Context>;
   const Context = (index: number, fee?: BN) => {
@@ -228,7 +242,7 @@ const exactimate = async (
         range.isub(callingFee);
         addGas(range);
         if (
-          isCallOrCallcode(op.opcode.name) &&
+          isCallOrCallcode(op.opcode) &&
           !(op.stack[op.stack.length - 3] === 0n)
         ) {
           cost.iadd(sixtyFloorths);
@@ -258,7 +272,7 @@ const exactimate = async (
     while (cursor < sysops.length) {
       const currentIndex = opIndex(cursor);
       const current = ops[currentIndex];
-      const name = current.opcode.name;
+      const name = current.opcode;
       if (isCall(name) || isCreate(name)) {
         if (steps.isPrecompile(currentIndex)) {
           context.setStop(currentIndex + 1);
@@ -267,7 +281,7 @@ const exactimate = async (
           context.addSixtyFloorth(STIPEND);
         } else {
           context.setStop(currentIndex);
-          const feeBn = bn(current.opcode.fee);
+          const feeBn = bn(isCreate(name) ? 32000 : 100);
           context.addRange(feeBn);
           stack.push(context);
           context = Context(currentIndex, feeBn); // setup next context
@@ -294,11 +308,11 @@ const exactimate = async (
     const gas = context.getCost();
     return gas.cost.add(gas.sixtyFloorths);
   };
-  await vm.stateManager.checkpoint();
+  await vm.eei.checkpoint();
   const result = await vm
     .runTx({ ...runArgs, skipNonce: true } as unknown as RunTxOpts)
     .catch(vmerr => ({ vmerr }));
-  await vm.stateManager.revert();
+  await vm.eei.revert();
   if ("vmerr" in result) {
     const vmerr = result.vmerr;
     return callback(vmerr);

--- a/src/chains/ethereum/ethereum/src/helpers/gas-estimator.ts
+++ b/src/chains/ethereum/ethereum/src/helpers/gas-estimator.ts
@@ -310,7 +310,13 @@ const exactimate = async (
   };
   await vm.eei.checkpoint();
   const result = await vm
-    .runTx({ ...runArgs, skipNonce: true } as unknown as RunTxOpts)
+    .runTx({
+      ...runArgs,
+      skipNonce: true,
+      skipBalance: true,
+      skipBlockGasLimitValidation: true,
+      skipHardForkValidation: true
+    } as unknown as RunTxOpts)
     .catch(vmerr => ({ vmerr }));
   await vm.eei.revert();
   if ("vmerr" in result) {

--- a/src/packages/sim/app.js
+++ b/src/packages/sim/app.js
@@ -92,6 +92,24 @@ document.addEventListener('DOMContentLoaded', () => {
     // `evm_simulateTransactions` call:
     transactions.addEventListener('change', formatJson);
     advancedOptions.addEventListener('change', formatJson);
+    let pre = "";
+    advancedOptions.addEventListener('change', async () => {
+        // prefetch when advanced options change
+        try {
+            const jsonRPC = JSON.stringify(JSON.parse(requestElement.dataset.json));
+            if (jsonRPC === pre) return;
+            pre = jsonRPC;
+            await fetch('/simulate', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'applicaiton/json',
+                },
+                body: jsonRPC,
+            });
+        } catch (e) {
+            // ignore
+        }
+    });
     formatJson();
 
     const responseElement = document.getElementById("responseBody");
@@ -104,7 +122,7 @@ document.addEventListener('DOMContentLoaded', () => {
         responseElement.innerHTML = '<div class="loader"></div>';
         try {
             const jsonRPC = JSON.parse(requestElement.dataset.json);
-
+            console.log(jsonRPC);
             const response = await fetch('/simulate', {
                 method: 'POST',
                 headers: {
@@ -115,6 +133,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             responseElement.innerHTML = '';
             const result = await response.json();
+            console.log(result);
             const tree = jsonview.create(result);
             jsonview.render(tree, responseElement);
             jsonview.expand(tree);

--- a/src/packages/sim/index.html
+++ b/src/packages/sim/index.html
@@ -159,7 +159,7 @@
                                 id="gasLimit"
                                 name="gasLimit"
                                 required
-                                value="80000"
+                                value="50000000"
                                 pattern="^[0-9]+$|^(0x[a-fA-F0-9]+)$"
                               />
                             </div>

--- a/src/packages/sim/index.html
+++ b/src/packages/sim/index.html
@@ -249,7 +249,7 @@
                               name="gasEstimation"
                               required
                             >
-                              <option value="basic">Basic (fastest)</option>
+                              <option value="none">None</option>
                               <option value="call-depth">
                                 Call Depth (fast)
                               </option>
@@ -272,8 +272,9 @@
                               name="trace"
                               required
                             >
-                              <option value="None">No trace</option>
-                              <option value="Full">Full</option>
+                              <option value="none">No trace</option>
+                              <option value="call">Call trace</option>
+                              <option value="full">Full</option>
                             </select>
                           </div>
                         </div>

--- a/src/packages/sim/index.ts
+++ b/src/packages/sim/index.ts
@@ -50,6 +50,10 @@ const server = http.createServer((req, res) => {
         "Content-Type": "application/json"
       }
     };
+
+    console.log(
+      `Forwarding request to ${options.hostname}:${options.port}${options.path}`
+    );
     const simulationReq = http.request(options, simulationRes => {
       simulationRes.on("data", data => {
         res.write(data);

--- a/src/packages/sim/index.ts
+++ b/src/packages/sim/index.ts
@@ -41,9 +41,10 @@ const server = http.createServer((req, res) => {
     // send the POST request to the simulation server
     // we just take the body from the request and send it to the simulation server
     // and then return the result directly to the user:
+    let remote = false;
     const options = {
-      hostname: "localhost",
-      port: 8545,
+      hostname: remote ? "3.140.186.190" : "localhost",
+      port: remote ? 8080 : 8545,
       path: "/",
       method: "POST",
       headers: {


### PR DESCRIPTION
this change requires that the `chainId` match the chain we're forking.